### PR TITLE
Upgrade event-loop-lag dependency due to security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/instana/nodejs-sensor#readme",
   "dependencies": {
     "bunyan": "^1.5.1",
-    "event-loop-lag": "1.1.0",
+    "event-loop-lag": "1.2.0",
     "semver": "5.3.0",
     "shimmer": "1.1.0",
     "opentracing": "^0.13.0"


### PR DESCRIPTION
Running the nsp tool over a codebase with this sensor provides the following security warning:

https://nodesecurity.io/advisories/46

I tracked it down to the `event-loop-lag` package (which had an older version of the `debug` package which depended on the offending `ms` package)