### PR TITLE
process cmdline can be changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  - Node.js <=4.5.0 can have `Buffer.from`, but it does not accept a string.
+ - Support announce to agent even when the Node.js process is renamed.
 
 ## 1.28.0
  - Support automatic Node.js 8 tracing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+ - Node.js <=4.5.0 can have `Buffer.from`, but it does not accept a string.
+
 ## 1.28.0
  - Support automatic Node.js 8 tracing.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ app.get('/', (req, res) => {
   res.send('OK');
 });
 
-app.listen(300, function() {
+app.listen(3000, function() {
   log('Listening on port 3000');
 });
 ```

--- a/src/agentConnection.js
+++ b/src/agentConnection.js
@@ -8,6 +8,7 @@ var atMostOnce = require('./util/atMostOnce');
 var agentOpts = require('./agent/opts');
 var buffer = require('./util/buffer');
 var pidStore = require('./pidStore');
+var cmdline = require('./cmdline');
 var http = require('./http');
 
 // How many extra characters are to be reserved for the inode and
@@ -15,7 +16,6 @@ var http = require('./http');
 var paddingForInodeAndFileDescriptor = 200;
 
 exports.announceNodeSensor = function announceNodeSensor(cb) {
-  var cmdline = require('./cmdline');
   cb = atMostOnce('callback for announceNodeSensor', cb);
 
   var payload = {
@@ -33,6 +33,7 @@ exports.announceNodeSensor = function announceNodeSensor(cb) {
     spacer: ''
   };
 
+  cmdline.fetch();
   if (cmdline.name && cmdline.args) {
     payload.name = cmdline.name;
     payload.args = cmdline.args;

--- a/src/agentConnection.js
+++ b/src/agentConnection.js
@@ -8,7 +8,6 @@ var atMostOnce = require('./util/atMostOnce');
 var agentOpts = require('./agent/opts');
 var buffer = require('./util/buffer');
 var pidStore = require('./pidStore');
-var cmdline = require('./cmdline');
 var http = require('./http');
 
 // How many extra characters are to be reserved for the inode and
@@ -16,6 +15,7 @@ var http = require('./http');
 var paddingForInodeAndFileDescriptor = 200;
 
 exports.announceNodeSensor = function announceNodeSensor(cb) {
+  var cmdline = require('./cmdline');
   cb = atMostOnce('callback for announceNodeSensor', cb);
 
   var payload = {

--- a/src/agentConnection.js
+++ b/src/agentConnection.js
@@ -33,10 +33,10 @@ exports.announceNodeSensor = function announceNodeSensor(cb) {
     spacer: ''
   };
 
-  cmdline.fetch();
-  if (cmdline.name && cmdline.args) {
-    payload.name = cmdline.name;
-    payload.args = cmdline.args;
+  var processCmdline = cmdline.getCmdline();
+  if (processCmdline.name && processCmdline.args) {
+    payload.name = processCmdline.name;
+    payload.args = processCmdline.args;
   }
 
   var payloadStr = JSON.stringify(payload);

--- a/src/cmdline.js
+++ b/src/cmdline.js
@@ -4,31 +4,36 @@ var fs = require('fs');
 
 var logger = require('./logger').getLogger('cmdline');
 
-exports.name = undefined;
-exports.args = undefined;
+exports.getCmdline = function getCmdline() {
+  var name;
+  var args;
 
-exports.fetch = function fetch() {
   try {
     var cmdline = fs.readFileSync(
       '/proc/' + process.pid + '/cmdline',
       {encoding: 'utf8'}
     );
+
     cmdline = cmdline.split('\u0000');
     if (cmdline.length > 0) {
-      exports.name = cmdline[0];
+      name = cmdline[0];
     }
     // There will be one extra (empty) argument in the end due to the
     // trailing \u0000. We are not interested in this one.
     // This behavior is document in `man proc`.
     if (cmdline.length > 2) {
-      exports.args = cmdline.slice(1, cmdline.length - 1);
+      args = cmdline.slice(1, cmdline.length - 1);
     } else {
-      exports.args = [];
+      args = [];
     }
   } catch (err) {
     if (err.code !== 'ENOENT') {
       logger.warn('cmdline could not be retrieved via proc file. Reason: %s', err.message);
     }
   }
+
+  return {
+    name: name,
+    args: args
+  };
 };
-exports.fetch();

--- a/src/cmdline.js
+++ b/src/cmdline.js
@@ -7,25 +7,28 @@ var logger = require('./logger').getLogger('cmdline');
 exports.name = undefined;
 exports.args = undefined;
 
-try {
-  var cmdline = fs.readFileSync(
-    '/proc/' + process.pid + '/cmdline',
-    {encoding: 'utf8'}
-  );
-  cmdline = cmdline.split('\u0000');
-  if (cmdline.length > 0) {
-    exports.name = cmdline[0];
+exports.fetch = function fetch() {
+  try {
+    var cmdline = fs.readFileSync(
+      '/proc/' + process.pid + '/cmdline',
+      {encoding: 'utf8'}
+    );
+    cmdline = cmdline.split('\u0000');
+    if (cmdline.length > 0) {
+      exports.name = cmdline[0];
+    }
+    // There will be one extra (empty) argument in the end due to the
+    // trailing \u0000. We are not interested in this one.
+    // This behavior is document in `man proc`.
+    if (cmdline.length > 2) {
+      exports.args = cmdline.slice(1, cmdline.length - 1);
+    } else {
+      exports.args = [];
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      logger.warn('cmdline could not be retrieved via proc file. Reason: %s', err.message);
+    }
   }
-  // There will be one extra (empty) argument in the end due to the
-  // trailing \u0000. We are not interested in this one.
-  // This behavior is document in `man proc`.
-  if (cmdline.length > 2) {
-    exports.args = cmdline.slice(1, cmdline.length - 1);
-  } else {
-    exports.args = [];
-  }
-} catch (err) {
-  if (err.code !== 'ENOENT') {
-    logger.warn('cmdline could not be retrieved via proc file. Reason: %s', err.message);
-  }
-}
+};
+exports.fetch();

--- a/src/cmdline_test.js
+++ b/src/cmdline_test.js
@@ -8,53 +8,53 @@ var proxyquire = require('proxyquire');
 
 describe('cmdline', function() {
   var fs;
-  var mod;
+  var result;
 
   beforeEach(function() {
     fs = {
       readFileSync: sinon.stub()
     };
-    mod = null;
+    result = null;
   });
 
   it('should not define name and args when procfile cannot be read', function() {
     fs.readFileSync.throws({code: 'ENOENT'});
     req();
-    expect(mod.name).to.equal(undefined);
-    expect(mod.args).to.equal(undefined);
+    expect(result.name).to.equal(undefined);
+    expect(result.args).to.equal(undefined);
   });
 
   it('should split the command line', function() {
     fs.readFileSync.returns('node\u0000foo\u0000my app\u0000');
     req();
-    expect(mod.name).to.equal('node');
-    expect(mod.args).to.deep.equal(['foo', 'my app']);
+    expect(result.name).to.equal('node');
+    expect(result.args).to.deep.equal(['foo', 'my app']);
   });
 
   it('should define args an empty array when there are no args', function() {
     fs.readFileSync.returns('node\u0000');
     req();
-    expect(mod.name).to.equal('node');
-    expect(mod.args).to.deep.equal([]);
+    expect(result.name).to.equal('node');
+    expect(result.args).to.deep.equal([]);
   });
 
   it('should not fail when the file is empty', function() {
     fs.readFileSync.returns('');
     req();
-    expect(mod.name).to.equal('');
-    expect(mod.args).to.deep.equal([]);
+    expect(result.name).to.equal('');
+    expect(result.args).to.deep.equal([]);
   });
 
   it('should work with only one commandline argument', function() {
     fs.readFileSync.returns('node\u0000my app\u0000');
     req();
-    expect(mod.name).to.equal('node');
-    expect(mod.args).to.deep.equal(['my app']);
+    expect(result.name).to.equal('node');
+    expect(result.args).to.deep.equal(['my app']);
   });
 
   function req() {
-    mod = proxyquire('./cmdline', {
+    result = proxyquire('./cmdline', {
       fs: fs
-    });
+    }).getCmdline();
   }
 });

--- a/src/util/buffer.js
+++ b/src/util/buffer.js
@@ -1,9 +1,14 @@
 'use strict';
 
-// Node.js 0.12 is lacking support for Buffer.from
+var semver = require('semver');
+
+// Node.js 0.12 is lacking support for Buffer.from,
+// and < 4.5.0 version Buffer.from doesn't support string as parameter
+var suppotsBufferFrom = Buffer.from && semver.satisfies(process.versions.node, '>=4.5.0');
+
 exports.fromString = function fromString(str, encoding) {
   encoding = encoding || 'utf8';
-  if (Buffer.from) {
+  if (suppotsBufferFrom) {
     return Buffer.from(str, encoding);
   }
   return new Buffer(str, encoding);


### PR DESCRIPTION
Changing the `process.title` ([1]) results in failing agent announce because the process title is cached in [2]. We should read the file on every agent announce to support this.

[1] https://nodejs.org/api/process.html#process_process_title
[2] https://github.com/instana/nodejs-sensor/blob/master/src/cmdline.js