### PR TITLE
validate Buffer.from

### DIFF
--- a/src/util/buffer.js
+++ b/src/util/buffer.js
@@ -3,11 +3,11 @@
 var semver = require('semver');
 
 // Node.js 0.12 is lacking support for Buffer.from,
-// and < 4.5.0 version Buffer.from doesn't support string as parameter 
+// and < 4.5.0 version Buffer.from doesn't support string as parameter
 
-var isSupportedVersion = function(){
+var isSupportedVersion = function() {
   return semver.satisfies(process.versions.node, '>=4.5.0');
-}
+};
 
 exports.fromString = function fromString(str, encoding) {
   encoding = encoding || 'utf8';

--- a/src/util/buffer.js
+++ b/src/util/buffer.js
@@ -1,9 +1,17 @@
 'use strict';
 
-// Node.js 0.12 is lacking support for Buffer.from
+var semver = require('semver');
+
+// Node.js 0.12 is lacking support for Buffer.from,
+// and < 4.5.0 version Buffer.from doesn't support string as parameter 
+
+var isSupportedVersion = function(){
+  return semver.satisfies(process.versions.node, '>=4.5.0');
+}
+
 exports.fromString = function fromString(str, encoding) {
   encoding = encoding || 'utf8';
-  if (Buffer.from) {
+  if (Buffer.from && isSupportedVersion() === true) {
     return Buffer.from(str, encoding);
   }
   return new Buffer(str, encoding);


### PR DESCRIPTION
If the node version < 4.5.0, Buffer.from doesn't support string as parameter. Do a validation check.