### PR TITLE
MongoDB instrumentation tests fail intermittently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## Unreleased
+ - Fix: MongoDB instrumentation tests fail intermittently
+
 ## 1.28.1
- - Node.js <=4.5.0 can have `Buffer.from`, but it does not accept a string.
+ - Node.js <=4.5.0 can have `Buffer.from`, but it does not accept a string.  Thanks @libozh!
  - Support announce to agent even when the Node.js process is renamed.
  - Update supported versions; checks & tests
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "kafka-node": "^1.0.7",
     "lodash": "4.15.0",
     "mocha": "2.3.3",
-    "mongodb": "2.2.9",
+    "mongodb": "2.2.33",
     "morgan": "^1.8.1",
     "mysql": "^2.13.0",
     "proxyquire": "1.7.3",


### PR DESCRIPTION
A re-run of the test will usually fix but there is some inconsistency that exists after the recent CLS changes.

Need to investigate: https://travis-ci.org/instana/nodejs-sensor/jobs/303463058