### PR TITLE
fix(tracing): Adapt Server-Timing format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+ - Update `Server-Timing` response header in HTTP instrumentation to format of latest spec version.
+
 ## 1.30.0
  - Use MIT license.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "instana-nodejs-sensor",
-  "version": "1.28.1",
+  "version": "1.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/apps/express.js
+++ b/test/apps/express.js
@@ -63,6 +63,12 @@ app.use(function(req, res) {
   if (req.query.cookie) {
     res.set('set-CooKie', req.query.cookie);
   }
+  if (req.query.serverTiming) {
+    res.set('sErver-tiMING', 'myServerTimingKey');
+  }
+  if (req.query.serverTimingArray) {
+    res.set('sErver-tiMING', ['key1', "key2;dur=42"]);
+  }
 
   setTimeout(function() {
     res.sendStatus(responseStatus);

--- a/test/apps/expressControls.js
+++ b/test/apps/expressControls.js
@@ -72,7 +72,9 @@ exports.sendRequest = function(opts) {
     qs: {
       responseStatus: opts.responseStatus,
       delay: opts.delay,
-      cookie: opts.cookie
+      cookie: opts.cookie,
+      serverTiming: opts.serverTiming,
+      serverTimingArray: opts.serverTimingArray
     },
     resolveWithFullResponse: opts.resolveWithFullResponse
   })

--- a/test/tracing_test.js
+++ b/test/tracing_test.js
@@ -40,14 +40,40 @@ describe('tracing', function() {
     });
   });
 
-  it('must expose trace id as Server-Timing header', function() {
-    return expressControls.sendRequest({
-      method: 'POST',
-      path: '/checkout',
-      resolveWithFullResponse: true
-    })
-    .then(function(res) {
-      expect(res.headers['server-timing']).to.match(/^ibs_[a-f0-9]+=1$/);
+  describe('serverTiming', function() {
+    it('must expose trace id as Server-Timing header', function() {
+      return expressControls.sendRequest({
+        method: 'POST',
+        path: '/checkout',
+        resolveWithFullResponse: true
+      })
+      .then(function(res) {
+        expect(res.headers['server-timing']).to.match(/^intid;desc=[a-f0-9]+$/);
+      });
+    });
+
+    it('must expose trace id as Server-Timing header: Custom server-timing arrayg', function() {
+      return expressControls.sendRequest({
+        method: 'POST',
+        path: '/checkout',
+        resolveWithFullResponse: true,
+        serverTiming: true
+      })
+      .then(function(res) {
+        expect(res.headers['server-timing']).to.match(/^myServerTimingKey, intid;desc=[a-f0-9]+$/);
+      });
+    });
+
+    it('must expose trace id as Server-Timing header: Custom server-timing array', function() {
+      return expressControls.sendRequest({
+        method: 'POST',
+        path: '/checkout',
+        resolveWithFullResponse: true,
+        serverTimingArray: true
+      })
+      .then(function(res) {
+        expect(res.headers['server-timing']).to.match(/^key1, key2;dur=42, intid;desc=[a-f0-9]+$/);
+      });
     });
   });
 


### PR DESCRIPTION
Update `Server-Timing` response header in HTTP instrumentation to format
of latest spec version. This was triggered by activity on the Chrome dev
mailing list and their intention to ship this API:

https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/ivub1L2UQzQ/discussion