### PR TITLE
fix(tracing): Fix support for mysql2 versions prior to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+ - Fix support for mysql2 versions prior to 1.5.0
+
 ## 1.35.1
  - HTTPS exit spans can have the wrong protocol set.
 

--- a/src/tracing/instrumentation/mysql.js
+++ b/src/tracing/instrumentation/mysql.js
@@ -23,7 +23,9 @@ function instrumentMysql(mysql) {
 
 function instrumentMysql2(mysql) {
   instrumentConnection(mysql.Connection.prototype);
-  instrumentPool(Object.getPrototypeOf('mysql.Pool'));
+  if ( typeof mysql.Pool !== 'undefined' && mysql.Pool ) {
+    instrumentPool(mysql.Pool.prototype);
+  }
 }
 
 

--- a/src/tracing/instrumentation/mysql.js
+++ b/src/tracing/instrumentation/mysql.js
@@ -23,7 +23,7 @@ function instrumentMysql(mysql) {
 
 function instrumentMysql2(mysql) {
   instrumentConnection(mysql.Connection.prototype);
-  instrumentPool(mysql.Pool.prototype);
+  instrumentPool(Object.getPrototypeOf('mysql.Pool'));
 }
 
 

--- a/src/tracing/instrumentation/mysql.js
+++ b/src/tracing/instrumentation/mysql.js
@@ -23,9 +23,7 @@ function instrumentMysql(mysql) {
 
 function instrumentMysql2(mysql) {
   instrumentConnection(mysql.Connection.prototype);
-  if ( typeof mysql.Pool !== 'undefined' && mysql.Pool ) {
-    instrumentPool(mysql.Pool.prototype);
-  }
+  mysql.Pool && instrumentPool(mysql.Pool.prototype);
 }
 
 


### PR DESCRIPTION
This fixes `Cannot read property 'prototype' of undefined` when using mysql2 packages
earlier than version 1.5.0.