### PR TITLE
feat(tracing): enable tracing in Node.js ^9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+ - Enable tracing in Node.js `9.1.0`.
+
 ## 1.36.1
  - Reduce severity in log messages which describe dependency analysis failures.
  - Upgrade `event-loop-lag` to address [security vulnerability](https://nodesecurity.io/advisories/534) in `debug`.

--- a/src/tracing/index.js
+++ b/src/tracing/index.js
@@ -73,7 +73,7 @@ function shouldEnableAutomaticTracing() {
 
 
 exports.supportedVersion = function supportedVersion(version) {
-  return semver.satisfies(version, '^4.5 || ^5.10 || >=6 <8.0 || >=8.2.1 < 9');
+  return semver.satisfies(version, '^4.5 || ^5.10 || ^6 || ^7 || ^8.2.1 || ^9.1.0');
 };
 
 

--- a/src/tracing/index_test.js
+++ b/src/tracing/index_test.js
@@ -22,6 +22,7 @@ describe('tracing', function() {
       expect(tracing.supportedVersion('8.2.1')).to.equal(true);
       expect(tracing.supportedVersion('8.3.0')).to.equal(true);
       expect(tracing.supportedVersion('8.9.1')).to.equal(true);
+      expect(tracing.supportedVersion('9.2.0')).to.equal(true);
     });
 
     it('must report various Node.js versions as not supported', function() {


### PR DESCRIPTION
Once merged and release, the public docs will also need to be updated with the new supported version information:

https://docs.instana.io/ecosystem/node-js/#supported-versions