### PR TITLE
fix(tracing): Spans may be accidentally retransmitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
  - Protect spans from accidental retransmission.
  - Abort HTTP requests to the agent on timeouts.
+ - HTTP client instrumentation does not correctly interpret HTTP client timeouts.
 
 ## 1.38.2
  - ioredis: Correctly manage tracing context in ioredis instrumentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+ - Protect spans from accidental retransmission.
+
 ## 1.38.2
  - ioredis: Correctly manage tracing context in ioredis instrumentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  - Protect spans from accidental retransmission.
+ - Abort HTTP requests to the agent on timeouts.
 
 ## 1.38.2
  - ioredis: Correctly manage tracing context in ioredis instrumentation

--- a/src/agentConnection.js
+++ b/src/agentConnection.js
@@ -71,6 +71,7 @@ exports.announceNodeSensor = function announceNodeSensor(cb) {
 
   req.setTimeout(agentOpts.requestTimeout, function onTimeout() {
     cb(new Error('Announce request to agent failed due to timeout'));
+    req.abort();
   });
 
   req.on('error', function(err) {
@@ -129,6 +130,7 @@ function checkWhetherResponseForPathIsOkay(path, cb) {
 
   req.setTimeout(agentOpts.requestTimeout, function onTimeout() {
     cb(false);
+    req.abort();
   });
 
   req.on('error', function() {
@@ -229,6 +231,7 @@ function sendData(path, data, cb, ignore404) {
 
   req.setTimeout(agentOpts.requestTimeout, function onTimeout() {
     cb(new Error('Timeout while trying to send data to agent via path: ' + path));
+    req.abort();
   });
 
   req.on('error', function(err) {

--- a/src/tracing/cls.js
+++ b/src/tracing/cls.js
@@ -180,6 +180,11 @@ function InstanaSpan(name) {
     writable: false,
     enumerable: false
   });
+  Object.defineProperty(this, 'transmitted', {
+    value: false,
+    writable: true,
+    enumerable: false
+  });
 }
 
 InstanaSpan.prototype.addCleanup = function addCleanup(fn) {
@@ -187,8 +192,11 @@ InstanaSpan.prototype.addCleanup = function addCleanup(fn) {
 };
 
 InstanaSpan.prototype.transmit = function transmit() {
-  transmission.addSpan(this);
-  this.cleanup();
+  if (!this.transmitted) {
+    transmission.addSpan(this);
+    this.cleanup();
+    this.transmitted = true;
+  }
 };
 
 InstanaSpan.prototype.cleanup = function cleanup() {

--- a/src/tracing/instrumentation/httpClient.js
+++ b/src/tracing/instrumentation/httpClient.js
@@ -76,26 +76,42 @@ exports.init = function() {
       clientRequest.setHeader(tracingConstants.traceIdHeaderName, span.t);
       clientRequest.setHeader(tracingConstants.traceLevelHeaderName, '1');
 
+      var isTimeout = false;
       clientRequest.on('timeout', function() {
-        span.data = {
-          http: {
-            method: clientRequest.method,
-            url: completeCallUrl,
-            error: 'Timeout exceeded'
-          }
-        };
-        span.d = Date.now() - span.ts;
-        span.error = true;
-        span.ec = 1;
-        span.transmit();
+        // From the Node.js HTTP client documentation:
+        //
+        //  > Emitted when the underlying socket times out from inactivity. This **only notifies** that the socket
+        //  > has been idle. **The request must be aborted manually.**
+        //
+        // This means that the timeout event is only an indication that something is wrong. After the timeout occurred,
+        // a well behaved client will do one of two things:
+        //
+        // 1) Abort the request via req.abort(). This will result in a "socket hang up" error event being emitted by
+        //    the request.
+        // 2) The request continues as normal and the timeout is ignored. In this case, we could end up either in a
+        //    success or in an error state. This is most likely unintentional HTTP client behavior.
+        //
+        // On top of this, commonly used HTTP client libraries add additional timeout capabilities based on wall clock
+        // time on top of Node.js' timeout capabilities (which typically end in an abort() call).
+        isTimeout = true;
       });
 
       clientRequest.on('error', function(err) {
+        var errorMessage = err.message;
+        if (isTimeout) {
+          errorMessage = 'Timeout exceeded';
+
+          if (clientRequest.aborted) {
+            errorMessage += ', request aborted';
+          }
+        } else if (clientRequest.aborted) {
+          errorMessage = 'Request aborted';
+        }
         span.data = {
           http: {
             method: clientRequest.method,
             url: completeCallUrl,
-            error: err.message
+            error: errorMessage
           }
         };
         span.d = Date.now() - span.ts;

--- a/test/tracing/AbstractControls.js
+++ b/test/tracing/AbstractControls.js
@@ -41,7 +41,16 @@ AbstractControls.prototype.registerTestHooks = function registerTestHooks() {
     }.bind(this));
   }
 
-  afterEach(function() {
+  afterEach(this.kill.bind(this));
+};
+
+
+AbstractControls.prototype.kill = function kill() {
+  if (this.process.killed) {
+    return Promise.resolve();
+  }
+  return new Promise(function(resolve) {
+    this.process.once('exit', resolve);
     this.process.kill();
   }.bind(this));
 };

--- a/test/tracing/httpClient/clientApp.js
+++ b/test/tracing/httpClient/clientApp.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+require('../../../')({
+  agentPort: process.env.AGENT_PORT,
+  level: 'info',
+  tracing: {
+    forceTransmissionStartingAt: 1
+  }
+});
+
+var bodyParser = require('body-parser');
+var rp = require('request-promise');
+var express = require('express');
+var morgan = require('morgan');
+var http = require('http');
+
+var app = express();
+var logPrefix = 'Express HTTP client: Client (' + process.pid + '):\t';
+
+if (process.env.WITH_STDOUT) {
+  app.use(morgan(logPrefix + ':method :url :status'));
+}
+
+app.use(bodyParser.json());
+
+app.get('/', function(req, res) {
+  res.sendStatus(200);
+});
+
+app.get('/timeout', function(req, res) {
+  rp({
+    method: 'GET',
+    url: 'http://127.0.0.1:' + process.env.SERVER_PORT + '/timeout',
+    timeout: 500
+  })
+    .then(function() {
+      res.sendStatus(200);
+    })
+    .catch(function() {
+      res.sendStatus(500);
+    });
+});
+
+app.get('/abort', function(req, res) {
+  var clientRequest = http.request({
+    method: 'GET',
+    hostname: '127.0.0.1',
+    port: process.env.SERVER_PORT,
+    path: '/timeout'
+  });
+
+  clientRequest.end();
+
+  setTimeout(function() {
+    clientRequest.abort();
+  }, 300);
+
+  res.sendStatus(200);
+});
+
+
+app.listen(process.env.APP_PORT, function() {
+  log('Listening on port: ' + process.env.APP_PORT);
+});
+
+function log() {
+  var args = Array.prototype.slice.call(arguments);
+  args[0] = logPrefix + args[0];
+  console.log.apply(console, args);
+}

--- a/test/tracing/httpClient/clientControls.js
+++ b/test/tracing/httpClient/clientControls.js
@@ -1,0 +1,15 @@
+/* eslint-env mocha */
+
+'use strict';
+
+var path = require('path');
+
+var AbstractControls = require('../AbstractControls');
+
+var Controls = module.exports = function Controls(opts) {
+  opts.appPath = path.join(__dirname, 'clientApp.js');
+  opts.port = 3216;
+  AbstractControls.call(this, opts);
+};
+
+Controls.prototype = Object.create(AbstractControls.prototype);

--- a/test/tracing/httpClient/serverApp.js
+++ b/test/tracing/httpClient/serverApp.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-console */
+
+'use strict';
+
+require('../../../')({
+  agentPort: process.env.AGENT_PORT,
+  level: 'info',
+  tracing: {
+    forceTransmissionStartingAt: 1
+  }
+});
+
+var bodyParser = require('body-parser');
+var express = require('express');
+var morgan = require('morgan');
+
+var app = express();
+var logPrefix = 'Express HTTP client: Server (' + process.pid + '):\t';
+
+if (process.env.WITH_STDOUT) {
+  app.use(morgan(logPrefix + ':method :url :status'));
+}
+
+app.use(bodyParser.json());
+
+app.get('/', function(req, res) {
+  res.sendStatus(200);
+});
+
+app.get('/timeout', function(req, res) {
+  setTimeout(function() {
+    res.sendStatus(200);
+  }, 1000);
+});
+
+app.listen(process.env.APP_PORT, function() {
+  log('Listening on port: ' + process.env.APP_PORT);
+});
+
+function log() {
+  var args = Array.prototype.slice.call(arguments);
+  args[0] = logPrefix + args[0];
+  console.log.apply(console, args);
+}

--- a/test/tracing/httpClient/serverControls.js
+++ b/test/tracing/httpClient/serverControls.js
@@ -1,0 +1,15 @@
+/* eslint-env mocha */
+
+'use strict';
+
+var path = require('path');
+
+var AbstractControls = require('../AbstractControls');
+
+var Controls = module.exports = function Controls(opts) {
+  opts.appPath = path.join(__dirname, 'serverApp.js');
+  opts.port = 3217;
+  AbstractControls.call(this, opts);
+};
+
+Controls.prototype = Object.create(AbstractControls.prototype);

--- a/test/tracing/httpClient/test.js
+++ b/test/tracing/httpClient/test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+var supportedVersion = require('../../../src/tracing/index').supportedVersion;
+var config = require('../../config');
+var utils = require('../../utils');
+
+describe('tracing/httpClient', function() {
+  if (!supportedVersion(process.versions.node)) {
+    return;
+  }
+
+  // controls require features that aren't available in early Node.js versions
+  var agentControls = require('../../apps/agentStubControls');
+  var ClientControls = require('./clientControls');
+  var ServerControls = require('./serverControls');
+
+  this.timeout(config.getTestTimeout());
+
+  agentControls.registerTestHooks();
+
+  var serverControls = new ServerControls({
+    agentControls: agentControls
+  });
+  serverControls.registerTestHooks();
+
+  var clientControls = new ClientControls({
+    agentControls: agentControls,
+    env: {
+      SERVER_PORT: serverControls.port
+    }
+  });
+  clientControls.registerTestHooks();
+
+  it('must trace calls that fail due to connection refusal', function() {
+    return serverControls.kill()
+      .then(function() {
+        return clientControls.sendRequest({
+          method: 'GET',
+          path: '/timeout',
+          simple: false
+        });
+      })
+      .then(function() {
+        return utils.retry(function() {
+          return agentControls.getSpans()
+          .then(function(spans) {
+            utils.expectOneMatching(spans, function(span) {
+              expect(span.n).to.equal('node.http.client');
+              expect(span.ec).to.equal(1);
+              expect(span.data.http.error).to.match(/ECONNREFUSED/);
+            });
+          });
+        });
+      });
+  });
+
+  it('must trace calls that fail due to timeouts', function() {
+    return clientControls.sendRequest({
+      method: 'GET',
+      path: '/timeout',
+      simple: false
+    })
+      .then(function() {
+        return utils.retry(function() {
+          return agentControls.getSpans()
+          .then(function(spans) {
+            utils.expectOneMatching(spans, function(span) {
+              expect(span.n).to.equal('node.http.client');
+              expect(span.ec).to.equal(1);
+              expect(span.data.http.error).to.match(/Timeout/);
+            });
+          });
+        });
+      });
+  });
+
+  it('must trace aborted calls', function() {
+    return clientControls.sendRequest({
+      method: 'GET',
+      path: '/abort',
+      simple: false
+    })
+      .then(function() {
+        return utils.retry(function() {
+          return agentControls.getSpans()
+          .then(function(spans) {
+            utils.expectOneMatching(spans, function(span) {
+              expect(span.n).to.equal('node.http.client');
+              expect(span.ec).to.equal(1);
+              expect(span.data.http.error).to.match(/aborted/);
+            });
+          });
+        });
+      });
+  });
+});


### PR DESCRIPTION
Turns out that we had some wrong assumptions around Node.js' HTTP client in the code, specifically around timeouts and errors. This PR corrects our usage of the HTTP client as well as the instrumentation.