### PR TITLE
Include reporting PID in agent logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+ - Include reporting PID in agent logs.
+
 ## 1.38.3
  - Protect spans from accidental retransmission.
  - Abort HTTP requests to the agent on timeouts.

--- a/src/agent/bunyanToAgentStream.js
+++ b/src/agent/bunyanToAgentStream.js
@@ -2,10 +2,18 @@
 
 var log = require('./log');
 
+var pidStore = require('../pidStore/internalPidStore');
+
 module.exports = exports = {
   write: function write(record) {
     var logLevel = getAgentLogLevel(record.level);
-    var message = 'Node.js sensor (pid: ' + process.pid + '): ' + record.msg;
+    var message =
+      'Node.js sensor (pid: ' +
+      process.pid +
+      ', reporting pid: ' +
+      pidStore.pid +
+      '): ' +
+      record.msg;
     var stack = null;
 
     if (record.err) {
@@ -16,7 +24,6 @@ module.exports = exports = {
     log(logLevel, message, stack);
   }
 };
-
 
 function getAgentLogLevel(level) {
   if (level < 30) {

--- a/src/pidStore/index_test.js
+++ b/src/pidStore/index_test.js
@@ -28,9 +28,12 @@ describe('pidStore', function() {
 
 
   function doRequire() {
-    pidStore = proxyquire('./pidStore', {
+    pidStore = proxyquire('./index', {
       fs: {
         readFileSync: readFileSync
+      },
+      './internalPidStore': {
+        pid: process.pid
       }
     });
   }

--- a/src/pidStore/internalPidStore.js
+++ b/src/pidStore/internalPidStore.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// This file exists to avoid dependency cycles between:
+//   logger => agent/bunyanToAgentStream => pidStore/index => logger
+exports.pid = process.pid;


### PR DESCRIPTION
In order to analyse problems related to the announce cycle (especially
when running within containers), it is helpful to include the
reporting PID in the agent log. This way, it is easier to identify
broken announce cycles solely based on the agent log.