### PR TITLE
only instrument bluebird if it is actually available

### DIFF
--- a/src/tracing/instrumentation/bluebird.js
+++ b/src/tracing/instrumentation/bluebird.js
@@ -13,8 +13,20 @@ exports.deactivate = function() {
 
 exports.init = function() {
   try {
-    require('cls-bluebird')(cls.ns);
-  } catch (e) {
-    logger.warn('Failed to instrument bluebird', e);
+    if (require.resolve('bluebird')) {
+      try {
+        require('cls-bluebird')(cls.ns);
+      } catch (e) {
+        logger.warn('Failed to instrument bluebird', e);
+      }
+    } else {
+      // This should actually not happen as require.resolve should either return a resolved filename or throw an
+      // exception.
+      logger.debug('Won\'t instrument bluebird as it is not installed (require.resolve returned falsy value).');
+    }
+  } catch (notResolved) {
+    // This happens if bluebird is not available, in which case we do not need
+    // to instrument anything, so we can safely ignore the error.
+    logger.debug('Won\'t instrument bluebird as it is not installed.');
   }
 };


### PR DESCRIPTION
Until now we tried to instrument bluebird unconditionally. If `bluebird` is not at all installed in `node_modules` of the instrumented application, this will lead to an error in `cls-bluebird` (see below). This can be reproduced by creating a new Node.js project and only install `instana-nodejs-sensor` into it and starting a file with the following contest:

```
require('instana-nodejs-sensor')();
```

Error:
```
{"name":"instana-nodejs-sensor","hostname":"Bastians-MacBook-Pro.local","pid":44034,"module":"tracing/bluebird","level":40,"msg":"Failed to instrument bluebird Error: Could not require Bluebird\n    at patchBluebird (/Users/bastian/instana/code/node-bluebird-experiment/node_modules/cls-bluebird/lib/index.js:46:23)\n    at Object.exports.init (/Users/bastian/instana/code/node-bluebird-experiment/node_modules/instana-nodejs-sensor/src/tracing/instrumentation/bluebird.js:16:28)\n    at Object.exports.init (/Users/bastian/instana/code/node-bluebird-experiment/node_modules/instana-nodejs-sensor/src/tracing/index.js:24:45)\n    at start (/Users/bastian/instana/code/node-bluebird-experiment/node_modules/instana-nodejs-sensor/src/index.js:17:24)\n    at Object.<anonymous> (/Users/bastian/instana/code/node-bluebird-experiment/index.js:1:95)\n    at Module._compile (module.js:652:30)\n    at Object.Module._extensions..js (module.js:663:10)\n    at Module.load (module.js:565:32)\n    at tryModuleLoad (module.js:505:12)\n    at Function.Module._load (module.js:497:3)","time":"2018-07-04T07:03:12.186Z","v":0}
```

My guess: The only reason this has not been seen in the wild earlier/more often is that Bluebird is so pervasive that nearly every non-trivial app has it in it node_modules somewhere, at least as a transitive dependency.