### PR TITLE
fix(tracing): do not send batch size 0 (redis multi)

### DIFF
--- a/src/tracing/instrumentation/redis.js
+++ b/src/tracing/instrumentation/redis.js
@@ -150,11 +150,13 @@ function instrumentMultiExec(isAtomic, original) {
       subCommands[i] = subCommand.command;
       subCommand.callback = buildSubCommandCallback(span, subCommand.callback);
     }
-    span.b = {
-      s: subCommands.length,
-      u: false
-    };
-
+    // must not send batch size 0
+    if (subCommands.length > 0) {
+      span.b = {
+        s: subCommands.length,
+        u: false
+      };
+    }
     span.ec = 0;
     span.error = false;
 


### PR DESCRIPTION
Avoid sending a batch size of null, if there are no subCommands, do not mark the span as a batch at all.

Disclaimer: I didn't look deeper into this to find out in which cases the multi queue could be empty, this simply avoids sending malformed batch data.