### PR TITLE
fix(deps): use newer netlinkwrapper /w support for musl libc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Warn about missing dependency netlinkwrapper at startup when reporting of uncaught exceptions is enabled.
+- Fix: Uncaught exception reporting can now be enabled on systems using musl libc instead of glibc (e.g. Alpine Linux)
 
 ## 1.48.1
 - Fix secret scrubbing for HTTP server instrumentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3580,9 +3580,9 @@
       }
     },
     "netlinkwrapper": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/netlinkwrapper/-/netlinkwrapper-1.1.0.tgz",
-      "integrity": "sha512-36htkuyBlBxDVGB4pU01X3kv/AL0SbbEzKL4Ra6FgaSk9MUo94yRyAmaWJ4xxYq0fxSRyfOO9kiqverRKfZxYw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/netlinkwrapper/-/netlinkwrapper-1.1.1.tgz",
+      "integrity": "sha512-upMFuUEwE7XFrHALa3F75O140mN2aYeZCr5erR5saz35hQ0q+SQWOQlk/0aQW/qRSLt3cb4GDk4FiesFYcyNTA==",
       "optional": true,
       "requires": {
         "bindings": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@risingstack/v8-profiler": "5.7.11",
     "event-loop-stats": "1.0.0",
     "gcstats.js": "1.0.0",
-    "netlinkwrapper": "1.1.0"
+    "netlinkwrapper": "1.1.1"
   },
   "devDependencies": {
     "admin": "^1.4.0",


### PR DESCRIPTION
See https://github.com/JacobFischer/netlinkwrapper/pull/6 and
https://github.com/JacobFischer/netlinkwrapper/pull/6/commits/813742a7791e8f6d008960a0ac297204e9bc60a9

This fix enables the installation of the optional dependency
netlinkwrapper (necessary for reporting uncaught exceptions)
on systems that use [musl libc](https://www.musl-libc.org/)
instead of glibc. Musl libc is used in the Linux Alpine distro and
since the [official Node.js Docker repo](https://hub.docker.com/_/node/)
advertises its Alpine based images as "highly recommended
when final image size being as small as possible is desired", it turns
out that quite a few people run Node.js on Alpine via these images.

This change should not have any impact on systems that use the more
widespread glibc, as the updated imports in netlinkwrapper should be
available in all libc variants.