### PR TITLE
Add support for non-bunyan loggers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -93,9 +93,11 @@ This sensor is using the [bunyan](https://www.npmjs.com/package/bunyan) logging 
 
 ```javascript
 require('instana-nodejs-sensor')({
-  logger: A_BUNYAN_LOGGER
+  logger: A_LOGGER
 });
 ```
+
+Other logging modules are supported if they provide functions for the log levels `debug`, `info`, `warn` and `error`.
 
 ### Log Level Configuration
 The Node.js sensor will now create children of this logger with the same log level and target streams. If you only want to change the default log level, you can configure it via:

--- a/src/logger.js
+++ b/src/logger.js
@@ -9,6 +9,9 @@ var parentLogger;
 exports.init = function(config) {
   if (config.logger) {
     parentLogger = config.logger.child({module: 'instana-nodejs-logger-parent'});
+  } else if (config.nonBunyanLogger) {
+    parentLogger = config.nonBunyanLogger;
+    return;
   } else {
     parentLogger = bunyan.createLogger({name: 'instana-nodejs-sensor'});
   }
@@ -27,6 +30,10 @@ exports.init = function(config) {
 exports.getLogger = function(moduleName) {
   if (!parentLogger) {
     exports.init({});
+  }
+
+  if (typeof parentLogger.child !== 'function') {
+    return parentLogger;
   }
 
   var logger = parentLogger.child({

--- a/src/logger.js
+++ b/src/logger.js
@@ -7,10 +7,10 @@ var bunyanToAgentStream = require('./agent/bunyanToAgentStream');
 var parentLogger;
 
 exports.init = function(config) {
-  if (config.logger) {
+  if (config.logger && typeof config.logger.child === 'function') {
     parentLogger = config.logger.child({module: 'instana-nodejs-logger-parent'});
-  } else if (config.nonBunyanLogger) {
-    parentLogger = config.nonBunyanLogger;
+  } else if (config.logger && hasLoggingFunctions(config.logger)) {
+    parentLogger = config.logger;
     return;
   } else {
     parentLogger = bunyan.createLogger({name: 'instana-nodejs-sensor'});
@@ -42,3 +42,10 @@ exports.getLogger = function(moduleName) {
 
   return logger;
 };
+
+function hasLoggingFunctions(logger) {
+  return typeof logger.debug === 'function' &&
+    typeof logger.info === 'function' &&
+    typeof logger.warn === 'function' &&
+    typeof logger.error === 'function';
+}

--- a/test/logger_test.js
+++ b/test/logger_test.js
@@ -53,4 +53,12 @@ describe('logger', function() {
 
     expect(logger.level()).to.equal(50);
   });
+
+  it('should accept non-bunyan loggers', function() {
+    var nonBunyanLogger = {};
+
+    log.init({ nonBunyanLogger: nonBunyanLogger });
+
+    expect(log.getLogger('childName')).to.equal(nonBunyanLogger);
+  });
 });

--- a/test/logger_test.js
+++ b/test/logger_test.js
@@ -54,11 +54,26 @@ describe('logger', function() {
     expect(logger.level()).to.equal(50);
   });
 
-  it('should accept non-bunyan loggers', function() {
+  it('should not accept non-bunyan loggers without necessary logging functions', function() {
     var nonBunyanLogger = {};
 
-    log.init({ nonBunyanLogger: nonBunyanLogger });
+    log.init({ logger: nonBunyanLogger });
 
-    expect(log.getLogger('childName')).to.equal(nonBunyanLogger);
+    var logger = log.getLogger('myLogger');
+    expect(logger).to.be.an.instanceOf(bunyan);
+  });
+
+  it('should accept non-bunyan loggers with necessary logging functions', function() {
+    var nonBunyanLogger = {
+      debug: function () {},
+      info: function () {},
+      warn: function () {},
+      error: function () {}
+    };
+
+    log.init({ logger: nonBunyanLogger });
+
+    var logger = log.getLogger('myLogger');
+    expect(logger).not.to.be.an.instanceOf(bunyan);
   });
 });


### PR DESCRIPTION
This adds support for non-bunyan loggers that do not have `logger.child()`, `logger.addStream()` or `logger.level()` like [winston](https://github.com/winstonjs/winston).