### PR TITLE
refactor(tracing): introduce mandatory argument kind for cls.startSpan

### DIFF
--- a/src/tracing/cls_test.js
+++ b/src/tracing/cls_test.js
@@ -19,11 +19,13 @@ describe('tracing/cls', function() {
 
   it('must initialize a new valid span', function() {
     cls.ns.run(function() {
-      var newSpan = cls.startSpan('cls-test-run');
+      var newSpan = cls.startSpan('cls-test-run', cls.EXIT);
       expect(newSpan).to.be.a('Object');
       expect(newSpan).to.have.property('t');
       expect(newSpan).to.have.property('s');
       expect(newSpan).to.have.property('f');
+      expect(newSpan).to.have.property('k');
+      expect(newSpan.k).to.equal(cls.EXIT);
       expect(newSpan).to.have.property('async');
       expect(newSpan.async).to.equal(false);
       expect(newSpan).to.have.property('error');
@@ -45,8 +47,8 @@ describe('tracing/cls', function() {
     var newSpan;
 
     cls.ns.run(function() {
-      parentSpan = cls.startSpan('Mr-Brady');
-      newSpan = cls.startSpan('Peter-Brady');
+      parentSpan = cls.startSpan('Mr-Brady', cls.ENTRY);
+      newSpan = cls.startSpan('Peter-Brady', cls.EXIT);
     });
     expect(newSpan.t).to.equal(parentSpan.t);
     expect(newSpan.p).to.equal(parentSpan.s);
@@ -56,40 +58,40 @@ describe('tracing/cls', function() {
     cls.ns.run(function() {
       cls.setTracingLevel('0');
       expect(cls.tracingSuppressed()).to.equal(true);
-      cls.startSpan('Antonio-Andolini');
+      cls.startSpan('Antonio-Andolini', cls.ENTRY);
       expect(cls.tracingSuppressed()).to.equal(true);
-      cls.startSpan('Vito-Corleone');
+      cls.startSpan('Vito-Corleone', cls.EXIT);
       expect(cls.tracingSuppressed()).to.equal(true);
-      cls.startSpan('Michael-Corleone');
+      cls.startSpan('Michael-Corleone', cls.EXIT);
       expect(cls.tracingSuppressed()).to.equal(true);
 
       cls.ns.run(function() {
         cls.setTracingLevel('1');
         expect(cls.tracingSuppressed()).to.equal(false);
-        cls.startSpan('Antonio-Andolini');
+        cls.startSpan('Antonio-Andolini', cls.EXIT);
         expect(cls.tracingSuppressed()).to.equal(false);
-        cls.startSpan('Vito-Corleone');
+        cls.startSpan('Vito-Corleone', cls.EXIT);
         expect(cls.tracingSuppressed()).to.equal(false);
-        cls.startSpan('Michael-Corleone');
+        cls.startSpan('Michael-Corleone', cls.EXIT);
         expect(cls.tracingSuppressed()).to.equal(false);
 
         cls.ns.run(function() {
           cls.setTracingLevel('0');
           expect(cls.tracingSuppressed()).to.equal(true);
-          cls.startSpan('Antonio-Andolini');
+          cls.startSpan('Antonio-Andolini', cls.EXIT);
           expect(cls.tracingSuppressed()).to.equal(true);
-          cls.startSpan('Vito-Corleone');
+          cls.startSpan('Vito-Corleone', cls.EXIT);
           expect(cls.tracingSuppressed()).to.equal(true);
-          cls.startSpan('Michael-Corleone');
+          cls.startSpan('Michael-Corleone', cls.EXIT);
           expect(cls.tracingSuppressed()).to.equal(true);
 
           cls.ns.run(function() {
             expect(cls.tracingSuppressed()).to.equal(true);
-            cls.startSpan('Antonio-Andolini');
+            cls.startSpan('Antonio-Andolini', cls.EXIT);
             expect(cls.tracingSuppressed()).to.equal(true);
-            cls.startSpan('Vito-Corleone');
+            cls.startSpan('Vito-Corleone', cls.EXIT);
             expect(cls.tracingSuppressed()).to.equal(true);
-            cls.startSpan('Michael-Corleone');
+            cls.startSpan('Michael-Corleone', cls.EXIT);
             expect(cls.tracingSuppressed()).to.equal(true);
           });
         });
@@ -103,22 +105,22 @@ describe('tracing/cls', function() {
     var localSpan;
 
     cls.ns.run(function() {
-      entrySpan = cls.startSpan('node.http.server');
-      exitSpan = cls.startSpan('mongo');
-      localSpan = cls.startSpan('myCustom');
+      entrySpan = cls.startSpan('node.http.server', cls.ENTRY);
+      exitSpan = cls.startSpan('mongo', cls.EXIT);
+      localSpan = cls.startSpan('myCustom', cls.INTERMEDIATE);
     });
 
-    expect(entrySpan.k).to.equal(1);
+    expect(entrySpan.k).to.equal(cls.ENTRY);
     expect(cls.isEntrySpan(entrySpan)).to.equal(true);
     expect(cls.isExitSpan(entrySpan)).to.equal(false);
     expect(cls.isLocalSpan(entrySpan)).to.equal(false);
 
-    expect(exitSpan.k).to.equal(2);
+    expect(exitSpan.k).to.equal(cls.EXIT);
     expect(cls.isEntrySpan(exitSpan)).to.equal(false);
     expect(cls.isExitSpan(exitSpan)).to.equal(true);
     expect(cls.isLocalSpan(exitSpan)).to.equal(false);
 
-    expect(localSpan.k).to.equal(3);
+    expect(localSpan.k).to.equal(cls.INTERMEDIATE);
     expect(cls.isEntrySpan(localSpan)).to.equal(false);
     expect(cls.isExitSpan(localSpan)).to.equal(false);
     expect(cls.isLocalSpan(localSpan)).to.equal(true);
@@ -129,7 +131,7 @@ describe('tracing/cls', function() {
       expect(context[cls.currentRootSpanKey]).to.equal(undefined);
       expect(context[cls.currentSpanKey]).to.equal(undefined);
 
-      var span = cls.startSpan('node.http.server');
+      var span = cls.startSpan('node.http.server', cls.ENTRY);
       expect(context[cls.currentRootSpanKey]).to.equal(span);
       expect(context[cls.currentSpanKey]).to.equal(span);
 

--- a/src/tracing/instrumentation/elasticsearch.js
+++ b/src/tracing/instrumentation/elasticsearch.js
@@ -46,7 +46,7 @@ function instrumentApi(client, action, info) {
       return original.apply(client, arguments);
     }
 
-    var span = cls.startSpan('elasticsearch');
+    var span = cls.startSpan('elasticsearch', cls.EXIT);
     span.stack = tracingUtil.getStackTrace(instrumentedAction);
     span.data = {
         elasticsearch: {

--- a/src/tracing/instrumentation/httpClient.js
+++ b/src/tracing/instrumentation/httpClient.js
@@ -93,7 +93,7 @@ function instrument(coreModule) {
     }
 
     cls.ns.run(function() {
-      var span = cls.startSpan('node.http.client');
+      var span = cls.startSpan('node.http.client', cls.EXIT);
 
       var completeCallUrl;
       if (urlArg && typeof urlArg === 'string') {

--- a/src/tracing/instrumentation/httpServer.js
+++ b/src/tracing/instrumentation/httpServer.js
@@ -36,7 +36,7 @@ function shimEmit(realEmit) {
 
       var incomingTraceId = getExistingTraceId(req);
       var incomingSpanId = getExistingSpanId(req);
-      var span = cls.startSpan(exports.spanName, incomingTraceId, incomingSpanId);
+      var span = cls.startSpan(exports.spanName, cls.ENTRY, incomingTraceId, incomingSpanId);
 
       // Grab the URL before application code gets access to the incoming message.
       // We are doing this because libs like express are manipulating req.url when

--- a/src/tracing/instrumentation/ioredis.js
+++ b/src/tracing/instrumentation/ioredis.js
@@ -59,7 +59,7 @@ function instrumentSendCommand(original) {
 
     var argsForOriginal = arguments;
     return cls.ns.runAndReturn(function() {
-      var span = cls.startSpan('redis');
+      var span = cls.startSpan('redis', cls.EXIT);
       span.stack = tracingUtil.getStackTrace(wrappedInternalSendCommand);
       span.data = {
         redis: {
@@ -122,7 +122,7 @@ function instrumentMultiOrPipelineCommand(commandName, original) {
     // create a new cls context parent to track the multi/pipeline child calls
     var clsContextForMultiOrPipeline = cls.ns.createContext();
     cls.ns.enter(clsContextForMultiOrPipeline);
-    var span = cls.startSpan('redis');
+    var span = cls.startSpan('redis', cls.EXIT);
     span.stack = tracingUtil.getStackTrace(wrappedInternalMultiOrPipelineCommand);
     span.data = {
       redis: {

--- a/src/tracing/instrumentation/kafka.js
+++ b/src/tracing/instrumentation/kafka.js
@@ -45,7 +45,7 @@ function instrumentedSend(ctx, originalSend, produceRequests, cb) {
 
   var produceRequest = produceRequests[0];
 
-  var span = cls.startSpan('kafka');
+  var span = cls.startSpan('kafka', cls.EXIT);
   span.b = { s: produceRequests.length };
   span.stack = tracingUtil.getStackTrace(instrumentedSend);
   span.data = {
@@ -83,7 +83,7 @@ function shimEmit(original) {
     var originalArgs = arguments;
 
     cls.ns.runAndReturn(function() {
-      var span = cls.startSpan('kafka');
+      var span = cls.startSpan('kafka', cls.ENTRY);
       span.stack = [];
       span.data = {
           kafka: {

--- a/src/tracing/instrumentation/mongodb.js
+++ b/src/tracing/instrumentation/mongodb.js
@@ -96,7 +96,7 @@ function onStarted(event) {
     return;
   }
 
-  var span = cls.startSpan('mongo', traceId, parentSpanId, false);
+  var span = cls.startSpan('mongo', cls.EXIT, traceId, parentSpanId, false);
 
   var peer = null;
   var service = null;

--- a/src/tracing/instrumentation/mssql.js
+++ b/src/tracing/instrumentation/mssql.js
@@ -79,7 +79,7 @@ function instrumentedMethod(ctx, originalFunction, originalArgs, stackTraceRef, 
   var connectionParameters = findConnectionParameters(ctx);
   var command = commandProvider(originalArgs);
   return cls.ns.runAndReturn(function() {
-    var span = cls.startSpan('mssql');
+    var span = cls.startSpan('mssql', cls.EXIT);
     span.stack = tracingUtil.getStackTrace(stackTraceRef);
     span.data = {
       mssql: {

--- a/src/tracing/instrumentation/mysql.js
+++ b/src/tracing/instrumentation/mysql.js
@@ -103,7 +103,7 @@ function instrumentedQuery(ctx, originalQuery, statementOrOpts, valuesOrCallback
   }
 
   return cls.ns.runAndReturn(function() {
-    var span = cls.startSpan('mysql');
+    var span = cls.startSpan('mysql', cls.EXIT);
     span.b = {s: 1};
     span.stack = tracingUtil.getStackTrace(instrumentedQuery);
     span.data = {

--- a/src/tracing/instrumentation/pg.js
+++ b/src/tracing/instrumentation/pg.js
@@ -49,7 +49,7 @@ function instrumentedQuery(ctx, originalQuery, argsForOriginalQuery) {
   var config = argsForOriginalQuery[0];
 
   return cls.ns.runAndReturn(function() {
-    var span = cls.startSpan('postgres');
+    var span = cls.startSpan('postgres', cls.EXIT);
     span.stack = tracingUtil.getStackTrace(instrumentedQuery);
     span.data = {
       pg: {

--- a/src/tracing/instrumentation/redis.js
+++ b/src/tracing/instrumentation/redis.js
@@ -59,7 +59,7 @@ function instrumentCommand(command, original) {
       return original.apply(this, arguments);
     }
 
-    var span = cls.startSpan('redis');
+    var span = cls.startSpan('redis', cls.EXIT);
     // do not set the redis span as the current span
     cls.setCurrentSpan(parentSpan);
     span.stack = tracingUtil.getStackTrace(wrappedCommand);
@@ -118,7 +118,7 @@ function instrumentMultiExec(isAtomic, original) {
       return original.apply(this, arguments);
     }
 
-    var span = cls.startSpan('redis');
+    var span = cls.startSpan('redis', cls.EXIT);
     // do not set the redis span as the current span
     cls.setCurrentSpan(parentSpan);
     span.stack = tracingUtil.getStackTrace(instrumentedMultiExec);


### PR DESCRIPTION
Previously we relied on a central list of span names to distinguish between entry, exit and intermediate spans. This proved to be error prone because it is easy to forget to update this list when adding new instrumentations. Now the `cls.startSpan` method has a new, mandatory argument `kind` to indicate the call direction.