### PR TITLE
Set logger later (after initialization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unpublished
+- Provide API to set a logger after initialization to resolve init/logger cycle.
+
 ## 1.56.0
 - Record [koa-router](https://github.com/alexmingoia/koa-router) routes as path templates when tracing HTTP entries.
 - Improve announce payload.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ To make a release, you first need to ensure that the released version will eithe
  - Push the commit and the tag created by `npm version` to GitHub, e.g. `git push --tags origin master`.
 
 ### Pushing Artifacts to NPM
-Once the released is properly commited and tagged, you can release the artifact to NPM in the following way:
+Once the release is properly committed and tagged, you can release the artifact to NPM in the following way:
 
 ```
 # you will be prompted for a 2FA code/OTP (one time password).

--- a/src/actions/profiling/cpu.js
+++ b/src/actions/profiling/cpu.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var logger = require('../../logger').getLogger('actions/profiling/cpu');
+var logger;
+logger = require('../../logger').getLogger('actions/profiling/cpu', function(newLogger) {
+  logger = newLogger;
+});
 
 var profiler;
 var samplingIntervalMicros = 1000; /* v8 profiler default */

--- a/src/actions/source.js
+++ b/src/actions/source.js
@@ -2,7 +2,10 @@
 
 var fs = require('fs');
 
-var logger = require('../logger').getLogger('actions/profiling/cpu');
+var logger;
+logger = require('../logger').getLogger('actions/source', function(newLogger) {
+  logger = newLogger;
+});
 
 var validFileRequests = /\.(js|ts|jsx)$|(^|\/)package\.json$/i;
 

--- a/src/agent/requestHandler.js
+++ b/src/agent/requestHandler.js
@@ -2,7 +2,11 @@
 
 var semver = require('semver');
 
-var logger = require('../logger').getLogger('agent/requestHandler');
+var logger;
+logger = require('../logger').getLogger('agent/requestHandler', function(newLogger) {
+  logger = newLogger;
+});
+
 var agentConnection = require('../agentConnection');
 
 var actionMapping = {

--- a/src/agentConnection.js
+++ b/src/agentConnection.js
@@ -3,7 +3,11 @@
 var pathUtil = require('path');
 var fs = require('fs');
 
-var logger = require('./logger').getLogger('agentConnection');
+var logger;
+logger = require('./logger').getLogger('agentConnection', function(newLogger) {
+  logger = newLogger;
+});
+
 var atMostOnce = require('./util/atMostOnce');
 var agentOpts = require('./agent/opts');
 var buffer = require('./util/buffer');

--- a/src/cmdline.js
+++ b/src/cmdline.js
@@ -2,7 +2,10 @@
 
 var fs = require('fs');
 
-var logger = require('./logger').getLogger('cmdline');
+var logger;
+logger = require('./logger').getLogger('cmdline', function(newLogger) {
+  logger = newLogger;
+});
 
 exports.getCmdline = function getCmdline() {
   var name;

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,10 @@ var fs = require('fs');
 
 var spanHandle = require('./tracing/spanHandle');
 var clsHolder = {};
+var config;
 
-module.exports = exports = function start(config) {
-  config = config || {};
+module.exports = exports = function start(_config) {
+  config = _config || {};
 
   log.init(config);
   require('./util/requireHook').init(config);
@@ -21,7 +22,11 @@ module.exports = exports = function start(config) {
   require('./util/uncaughtExceptionHandler').init(config);
   require('./states/agentready').init(config);
 
-  var logger = log.getLogger('index');
+  var logger;
+  logger = log.getLogger('index', function(newLogger) {
+    logger = newLogger;
+  });
+
   logger.info('instana-nodejs-sensor module version:', require(path.join(__dirname, '..', 'package.json')).version);
 
   var currentState = null;
@@ -58,4 +63,9 @@ exports.opentracing = require('./tracing/opentracing');
 
 exports.currentSpan = function getHandleForCurrentSpan() {
   return spanHandle.getHandleForCurrentSpan(clsHolder.cls);
+};
+
+exports.setLogger = function(logger) {
+  config.logger = logger;
+  log.init(config);
 };

--- a/src/logger.js
+++ b/src/logger.js
@@ -6,46 +6,66 @@ var bunyanToAgentStream = require('./agent/bunyanToAgentStream');
 
 var parentLogger;
 
+var registry = {};
+
 exports.init = function(config) {
+  var isBunyanLogger = false;
   if (config.logger && typeof config.logger.child === 'function') {
+    // a custom bunyan logger has been provided via config
     parentLogger = config.logger.child({
       module: 'instana-nodejs-logger-parent',
       __in: 1
     });
+    isBunyanLogger = true;
   } else if (config.logger && hasLoggingFunctions(config.logger)) {
+    // a custom non-bunyan logger has been provided via config
     parentLogger = config.logger;
-    return;
+    isBunyanLogger = false;
   } else {
+    // no custom logger has been provided via config
     parentLogger = bunyan.createLogger({
       name: 'instana-nodejs-sensor',
       __in: 1
     });
+    isBunyanLogger = true;
   }
 
-  parentLogger.addStream({
-    type: 'raw',
-    stream: bunyanToAgentStream,
-    level: 'info'
+  if (isBunyanLogger) {
+    parentLogger.addStream({
+      type: 'raw',
+      stream: bunyanToAgentStream,
+      level: 'info'
+    });
+    if (config.level) {
+      parentLogger.level(config.level);
+    }
+  }
+
+  Object.keys(registry).forEach(function(loggerName) {
+    var reInit = registry[loggerName];
+    reInit(exports.getLogger(loggerName));
   });
-
-  if (config.level) {
-    parentLogger.level(config.level);
-  }
 };
 
-exports.getLogger = function(moduleName) {
+exports.getLogger = function(loggerName, reInit) {
   if (!parentLogger) {
     exports.init({});
   }
 
+  var logger;
+
   if (typeof parentLogger.child !== 'function') {
-    return parentLogger;
+    // non-bunyan logger
+    logger = parentLogger;
+  } else {
+    logger = parentLogger.child({
+      module: loggerName
+    });
   }
 
-  var logger = parentLogger.child({
-    module: moduleName
-  });
-
+  if (reInit) {
+    registry[loggerName] = reInit;
+  }
   return logger;
 };
 

--- a/src/metrics/dependencies.js
+++ b/src/metrics/dependencies.js
@@ -4,7 +4,10 @@ var path = require('path');
 var fs = require('fs');
 
 var applicationUnderMonitoring = require('../applicationUnderMonitoring');
-var logger = require('../logger').getLogger('dependencies');
+var logger;
+logger = require('../logger').getLogger('metrics/dependencies', function(newLogger) {
+  logger = newLogger;
+});
 
 exports.payloadPrefix = 'dependencies';
 exports.currentPayload = {};

--- a/src/metrics/description.js
+++ b/src/metrics/description.js
@@ -1,7 +1,10 @@
 'use strict';
 
 var applicationUnderMonitoring = require('../applicationUnderMonitoring');
-var logger = require('../logger').getLogger('description');
+var logger;
+logger = require('../logger').getLogger('metrics/description', function(newLogger) {
+  logger = newLogger;
+});
 
 exports.payloadPrefix = 'description';
 exports.currentPayload = undefined;

--- a/src/metrics/directDependencies.js
+++ b/src/metrics/directDependencies.js
@@ -3,7 +3,10 @@
 var fs = require('fs');
 
 var applicationUnderMonitoring = require('../applicationUnderMonitoring');
-var logger = require('../logger').getLogger('dependencies');
+var logger;
+logger = require('../logger').getLogger('metrics/directDependencies', function(newLogger) {
+  logger = newLogger;
+});
 
 exports.payloadPrefix = 'directDependencies';
 exports.currentPayload = {

--- a/src/metrics/gc.js
+++ b/src/metrics/gc.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var logger = require('../logger').getLogger('metrics-gc');
+var logger;
+logger = require('../logger').getLogger('metrics/gc', function(newLogger) {
+  logger = newLogger;
+});
+
 var slidingWindow = require('../slidingWindow');
 
 var windowOpts = { duration: 1000 };

--- a/src/metrics/healthchecks.js
+++ b/src/metrics/healthchecks.js
@@ -1,7 +1,10 @@
 'use strict';
 
 var requireHook = require('../util/requireHook');
-var logger = require('../logger').getLogger('metrics/healthchecks');
+var logger;
+logger = require('../logger').getLogger('metrics/healthchecks', function(newLogger) {
+  logger = newLogger;
+});
 
 var timeBetweenHealthcheckCalls;
 var healthy = 1;

--- a/src/metrics/keywords.js
+++ b/src/metrics/keywords.js
@@ -1,7 +1,10 @@
 'use strict';
 
 var applicationUnderMonitoring = require('../applicationUnderMonitoring');
-var logger = require('../logger').getLogger('keywords');
+var logger;
+logger = require('../logger').getLogger('metrics/keywords', function(newLogger) {
+  logger = newLogger;
+});
 
 exports.payloadPrefix = 'keywords';
 exports.currentPayload = [];

--- a/src/metrics/libuv.js
+++ b/src/metrics/libuv.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var logger = require('../logger').getLogger('libuv');
+var logger;
+logger = require('../logger').getLogger('metrics/libuv', function(newLogger) {
+  logger = newLogger;
+});
 
 var eventLoopStats;
 try {

--- a/src/metrics/name.js
+++ b/src/metrics/name.js
@@ -1,7 +1,10 @@
 'use strict';
 
 var applicationUnderMonitoring = require('../applicationUnderMonitoring');
-var logger = require('../logger').getLogger('name');
+var logger;
+logger = require('../logger').getLogger('metrics/name', function(newLogger) {
+  logger = newLogger;
+});
 
 exports.payloadPrefix = 'name';
 exports.currentPayload = undefined;

--- a/src/metrics/version.js
+++ b/src/metrics/version.js
@@ -1,7 +1,10 @@
 'use strict';
 
 var applicationUnderMonitoring = require('../applicationUnderMonitoring');
-var logger = require('../logger').getLogger('version');
+var logger;
+logger = require('../logger').getLogger('metrics/version', function(newLogger) {
+  logger = newLogger;
+});
 
 exports.payloadPrefix = 'version';
 exports.currentPayload = undefined;

--- a/src/pidStore/index.js
+++ b/src/pidStore/index.js
@@ -3,7 +3,10 @@
 var fs = require('fs');
 var EventEmitter = require('events').EventEmitter;
 
-var logger = require('../logger').getLogger('pidStore');
+var logger;
+logger = require('../logger').getLogger('pidStore', function(newLogger) {
+  logger = newLogger;
+});
 var internalPidStore = require('./internalPidStore');
 
 var eventName = 'pidChanged';

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var logger = require('./logger').getLogger('agentConnection');
+var logger;
+logger = require('./logger').getLogger('secrets', function(newLogger) {
+  logger = newLogger;
+});
+
 var defaultMatcherMode = 'contains-ignore-case';
 var defaultSecrets = ['key', 'pass', 'secret'];
 

--- a/src/states/agentHostLookup.js
+++ b/src/states/agentHostLookup.js
@@ -5,7 +5,10 @@ var http = require('../http');
 var agentOpts = require('../agent/opts');
 var exec = require('child_process').exec;
 var atMostOnce = require('../util/atMostOnce');
-var logger = require('../logger').getLogger('agentHostLookup');
+var logger;
+logger = require('../logger').getLogger('states/agentHostLookup', function(newLogger) {
+  logger = newLogger;
+});
 
 // Depending on the environment in which the agent and node sensor are running,
 // the agent may be available under different hosts. For instance,

--- a/src/states/agentready.js
+++ b/src/states/agentready.js
@@ -4,7 +4,10 @@ var path = require('path');
 var fs = require('fs');
 
 var uncaughtExceptionHandler = require('../util/uncaughtExceptionHandler');
-var logger = require('../logger').getLogger('agentready');
+var logger;
+logger = require('../logger').getLogger('states/agentready', function(newLogger) {
+  logger = newLogger;
+});
 var requestHandler = require('../agent/requestHandler');
 var agentConnection = require('../agentConnection');
 var compression = require('../compression');

--- a/src/states/announced.js
+++ b/src/states/announced.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var logger = require('../logger').getLogger('announced');
+var logger;
+logger = require('../logger').getLogger('states/announced', function(newLogger) {
+  logger = newLogger;
+});
+
 var agentConnection = require('../agentConnection');
 
 module.exports = {

--- a/src/states/unannounced.js
+++ b/src/states/unannounced.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var logger = require('../logger').getLogger('unannounced');
+var logger;
+logger = require('../logger').getLogger('states/unannounced', function(newLogger) {
+  logger = newLogger;
+});
 var agentConnection = require('../agentConnection');
 var agentOpts = require('../agent/opts');
 var pidStore = require('../pidStore');

--- a/src/tracing/cls.js
+++ b/src/tracing/cls.js
@@ -3,7 +3,10 @@
 var transmission = require('./transmission');
 var tracingUtil = require('./tracingUtil');
 var hooked = require('./clsHooked');
-var logger = require('../logger').getLogger('cls');
+var logger;
+logger = require('../logger').getLogger('tracing/cls', function(newLogger) {
+  logger = newLogger;
+});
 
 var currentRootSpanKey = (exports.currentRootSpanKey = 'com.instana.rootSpan');
 var currentSpanKey = (exports.currentSpanKey = 'com.instana.span');

--- a/src/tracing/index.js
+++ b/src/tracing/index.js
@@ -2,7 +2,10 @@
 
 var semver = require('semver');
 
-var logger = require('../logger').getLogger('tracing');
+var logger;
+logger = require('../logger').getLogger('tracing', function(newLogger) {
+  logger = newLogger;
+});
 
 var tracingEnabled = false;
 var automaticTracingEnabled = false;

--- a/src/tracing/index.js
+++ b/src/tracing/index.js
@@ -93,7 +93,7 @@ function shouldEnableAutomaticTracing() {
 }
 
 exports.supportedVersion = function supportedVersion(version) {
-  return semver.satisfies(version, '^4.5 || ^5.10 || ^6 || ^7 || ^8.2.1 || ^9.1.0 || ^10.0.0');
+  return semver.satisfies(version, '^4.5 || ^5.10 || ^6 || ^7 || ^8.2.1 || ^9.1.0 || ^10.4.0');
 };
 
 exports.activate = function() {

--- a/src/tracing/instrumentation/control_flow/bluebird.js
+++ b/src/tracing/instrumentation/control_flow/bluebird.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var logger = require('../../../logger').getLogger('tracing/bluebird');
+var logger;
+logger = require('../../../logger').getLogger('tracing/bluebird', function(newLogger) {
+  logger = newLogger;
+});
+
 var cls = require('../../cls');
 
 exports.activate = function() {

--- a/src/tracing/instrumentation/database/mongodb.js
+++ b/src/tracing/instrumentation/database/mongodb.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var logger = require('../../../logger').getLogger('tracing/mongodb');
+var logger;
+logger = require('../../../logger').getLogger('tracing/mongodb', function(newLogger) {
+  logger = newLogger;
+});
+
 var requireHook = require('../../../util/requireHook');
 var tracingUtil = require('../../tracingUtil');
 var cls = require('../../cls');

--- a/src/tracing/transmission.js
+++ b/src/tracing/transmission.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var logger = require('../logger').getLogger('tracing/transmission');
+var logger;
+logger = require('../logger').getLogger('tracing/transmission', function(newLogger) {
+  logger = newLogger;
+});
+
 var agentConnection = require('../agentConnection');
 
 var maxBufferedSpans;

--- a/src/util/atMostOnce.js
+++ b/src/util/atMostOnce.js
@@ -2,7 +2,10 @@
 
 'use strict';
 
-var logger = require('../logger').getLogger('atMostOnce');
+var logger;
+logger = require('../logger').getLogger('util/atMostOnce', function(newLogger) {
+  logger = newLogger;
+});
 
 /**
  * Make sure that a function is only ever called once. This is useful to maintain

--- a/src/util/uncaughtExceptionHandler.js
+++ b/src/util/uncaughtExceptionHandler.js
@@ -2,7 +2,11 @@
 
 var serializeError = require('serialize-error');
 
-var logger = require('../logger').getLogger('uncaughtExceptionHandler');
+var logger;
+logger = require('../logger').getLogger('util/uncaughtExceptionHandler', function(newLogger) {
+  logger = newLogger;
+});
+
 var transmission = require('../tracing/transmission');
 var agentConnection = require('../agentConnection');
 var stackTraceUtil = require('./stackTrace');

--- a/test/apps/expressControls.js
+++ b/test/apps/expressControls.js
@@ -105,6 +105,14 @@ exports.setUnhealthy = function(useHttps) {
   });
 };
 
+exports.setLogger = function(useHttps, logFilePath) {
+  return request({
+    method: 'POST',
+    url: getBaseUrl(useHttps) + '/set-logger?logFilePath=' + encodeURIComponent(logFilePath),
+    strictSSL: false
+  });
+};
+
 function getBaseUrl(useHttps) {
   return 'http' + (useHttps ? 's' : '') + '://127.0.0.1:' + appPort;
 }

--- a/test/logger_test.js
+++ b/test/logger_test.js
@@ -10,11 +10,13 @@ var log = require('../src/logger');
 
 describe('logger', function() {
   it('should return the default parent logger if no config is available', function() {
+    log.init({});
     var logger = log.getLogger('myLogger');
     expect(logger).to.be.an.instanceOf(bunyan);
   });
 
-  it('should return a child logger if wanted', function() {
+  it('should return a child logger if requested', function() {
+    log.init({});
     var logger = log.getLogger('childName');
     expect(logger).to.be.an.instanceOf(bunyan);
     expect(logger.fields).to.have.property('module');
@@ -74,5 +76,40 @@ describe('logger', function() {
 
     var logger = log.getLogger('myLogger');
     expect(logger).not.to.be.an.instanceOf(bunyan);
+  });
+
+  it('should reset loggers when the logger is set after initialization', function() {
+    log.init({});
+    var reInitCalled = false;
+    var logger;
+    logger = log.getLogger('myLogger', function(newLogger) {
+      reInitCalled = true;
+      logger = newLogger;
+    });
+
+    // first getLogger call should yield the default bunyan logger
+    expect(logger).to.be.an.instanceOf(bunyan);
+    expect(logger.fields.name).to.equal('instana-nodejs-sensor');
+    var originalLogger = logger;
+
+    var logger2 = bunyan.createLogger({ name: 'new-logger' });
+    log.init({ logger: logger2 });
+
+    expect(reInitCalled).to.be.true;
+    expect(logger).to.be.an.instanceOf(bunyan);
+    expect(logger === originalLogger).to.not.be.true;
+    expect(logger.fields.name).to.equal('new-logger');
+  });
+
+  it('should not choke on re-initialization when there is no reInit callback', function() {
+    log.init({});
+    var logger = log.getLogger('myLogger');
+
+    // first getLogger call should yield the default bunyan logger
+    expect(logger).to.be.an.instanceOf(bunyan);
+    expect(logger.fields.name).to.equal('instana-nodejs-sensor');
+
+    var logger2 = bunyan.createLogger({ name: 'new-logger' });
+    log.init({ logger: logger2 });
   });
 });

--- a/test/setLogger_test.js
+++ b/test/setLogger_test.js
@@ -1,0 +1,48 @@
+/* global Promise */
+
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+var os = require('os');
+
+var supportedVersion = require('../src/tracing/index').supportedVersion;
+var config = require('./config');
+var utils = require('./utils');
+
+describe('setLogger', function() {
+  if (!supportedVersion(process.versions.node)) {
+    return;
+  }
+
+  var agentStubControls = require('./apps/agentStubControls');
+  var expressControls = require('./apps/expressControls');
+
+  this.timeout(config.getTestTimeout());
+
+  agentStubControls.registerTestHooks();
+  expressControls.registerTestHooks();
+
+  var dummyLogFile = path.join(os.tmpdir(), 'instana-nodejs-dummy-test.log');
+
+  afterEach(function() {
+    fs.unlinkSync(dummyLogFile);
+  });
+
+  it('must reinitialize all loggers on setLogger', function() {
+    expressControls.setLogger(false, dummyLogFile);
+    return utils.retry(function() {
+      return new Promise(function(resolve, reject) {
+        fs.readFile(dummyLogFile, 'utf-8', function(err, data) {
+          if (err) {
+            reject(err);
+          }
+          // wait (arbitrarily) for 100 characters to be written
+          if (data.length > 100) {
+            resolve(data);
+          }
+        });
+      });
+    });
+  });
+});

--- a/test/tracing/index_test.js
+++ b/test/tracing/index_test.js
@@ -23,7 +23,8 @@ describe('tracing', function() {
       expect(tracing.supportedVersion('8.3.0')).to.equal(true);
       expect(tracing.supportedVersion('8.9.1')).to.equal(true);
       expect(tracing.supportedVersion('9.2.0')).to.equal(true);
-      expect(tracing.supportedVersion('10.0.0')).to.equal(true);
+      expect(tracing.supportedVersion('10.4.0')).to.equal(true);
+      expect(tracing.supportedVersion('10.13.0')).to.equal(true);
     });
 
     it('must report various Node.js versions as not supported', function() {
@@ -36,6 +37,10 @@ describe('tracing', function() {
       expect(tracing.supportedVersion('8.0.0')).to.equal(false);
       expect(tracing.supportedVersion('8.1.4')).to.equal(false);
       expect(tracing.supportedVersion('9.0.0')).to.equal(false);
+      expect(tracing.supportedVersion('10.0.0')).to.equal(false);
+      expect(tracing.supportedVersion('10.1.0')).to.equal(false);
+      expect(tracing.supportedVersion('10.2.0')).to.equal(false);
+      expect(tracing.supportedVersion('10.3.0')).to.equal(false);
     });
   });
 });

--- a/test/tracing/logger/bunyan/app-instana-creates-bunyan-logger.js
+++ b/test/tracing/logger/bunyan/app-instana-creates-bunyan-logger.js
@@ -13,7 +13,10 @@ instana({
     forceTransmissionStartingAt: 1
   }
 });
-var instanaLogger = require('../../../../src/logger').getLogger('test-module-name');
+var instanaLogger;
+instanaLogger = require('../../../../src/logger').getLogger('test-module-name', function(newLogger) {
+  instanaLogger = newLogger;
+});
 
 var bodyParser = require('body-parser');
 var express = require('express');

--- a/test/tracing/logger/bunyan/app-instana-receives-bunyan-logger.js
+++ b/test/tracing/logger/bunyan/app-instana-receives-bunyan-logger.js
@@ -14,7 +14,10 @@ instana({
     forceTransmissionStartingAt: 1
   }
 });
-var instanaLogger = require('../../../../src/logger').getLogger('test-module-name');
+var instanaLogger;
+instanaLogger = require('../../../../src/logger').getLogger('test-module-name', function(newLogger) {
+  instanaLogger = newLogger;
+});
 
 var bodyParser = require('body-parser');
 var express = require('express');

--- a/test/tracing/logger/bunyan/app-instana-receives-non-bunyan-logger.js
+++ b/test/tracing/logger/bunyan/app-instana-receives-non-bunyan-logger.js
@@ -23,7 +23,10 @@ instana({
     forceTransmissionStartingAt: 1
   }
 });
-var instanaLogger = require('../../../../src/logger').getLogger('test-module-name');
+var instanaLogger;
+instanaLogger = require('../../../../src/logger').getLogger('test-module-name', function(newLogger) {
+  instanaLogger = newLogger;
+});
 
 var bodyParser = require('body-parser');
 var express = require('express');


### PR DESCRIPTION
This adds a new function to the exposed API, enabling client code to set a custom logger after the initialization has already happened. This is crucial if users want to set a custom logger but also want to have their logging library auto-instrumented (which requires Instana to be initialized before the logging module even has required, making it impossible to pass the logger instance to Instana at initialization time).