### PR TITLE
Update ES Database to include msearch, and mget calls as known DB type calls

### DIFF
--- a/src/tracing/instrumentation/database/elasticsearch.js
+++ b/src/tracing/instrumentation/database/elasticsearch.js
@@ -22,6 +22,8 @@ function instrument(es) {
     instrumentApi(client, 'search', info);
     instrumentApi(client, 'index', info);
     instrumentApi(client, 'get', info);
+    instrumentApi(client, 'msearch', info);
+    instrumentApi(client, 'mget', info);
 
     return client;
   };


### PR DESCRIPTION
Logging of query content wont work due to the unknown length and structure of the "multiple" actions