### PR TITLE
feat(config): accept stack trace length as string

### DIFF
--- a/src/tracing/tracingUtil.js
+++ b/src/tracing/tracingUtil.js
@@ -4,12 +4,58 @@ var stackTrace = require('../util/stackTrace');
 var agentOpts = require('../agent/opts');
 var pidStore = require('../pidStore');
 var leftPad = require('./leftPad');
+var logger;
+logger = require('../logger').getLogger('tracing/util', function(newLogger) {
+  logger = newLogger;
+});
 
+var defaultStackTraceLength = 10;
 var stackTraceLength = 0;
 
 exports.init = function(config) {
-  stackTraceLength = config.tracing.stackTraceLength != null ? config.tracing.stackTraceLength : 10;
+  if (config.tracing.stackTraceLength != null) {
+    if (typeof config.tracing.stackTraceLength === 'number') {
+      stackTraceLength = normalizeNumericalStackTraceLength(config.tracing.stackTraceLength);
+    } else if (typeof config.tracing.stackTraceLength === 'string') {
+      stackTraceLength = parseInt(config.tracing.stackTraceLength, 10);
+      if (!isNaN(stackTraceLength)) {
+        stackTraceLength = normalizeNumericalStackTraceLength(stackTraceLength);
+      } else {
+        logger.warn(
+          'The value of config.tracing.stackTraceLength ("%s") has type string and cannot be parsed to a numerical ' +
+          'value. Assuming the default stack trace length %s.',
+          config.tracing.stackTraceLength,
+          defaultStackTraceLength
+        );
+        stackTraceLength = defaultStackTraceLength;
+      }
+    } else {
+      logger.warn(
+        'The value of config.tracing.stackTraceLength has the non-supported type %s (the value is "%s"). Assuming ' +
+        'the default stack trace length %s.',
+        (typeof config.tracing.stackTraceLength),
+        config.tracing.stackTraceLength,
+        defaultStackTraceLength
+      );
+      stackTraceLength = defaultStackTraceLength;
+    }
+  } else {
+    stackTraceLength = defaultStackTraceLength;
+  }
 };
+
+function normalizeNumericalStackTraceLength(numericalLength) {
+  // just in case folks provide non-integral numbers or negative numbers
+  var normalized = Math.abs(Math.round(numericalLength));
+  if (normalized !== numericalLength) {
+    logger.warn(
+      'Normalized the provided value of config.tracing.stackTraceLength ("%s") to %s.',
+      numericalLength,
+      normalized
+    );
+  }
+  return normalized;
+}
 
 exports.getFrom = function getFrom() {
   return {

--- a/test/apps/expressProxy.js
+++ b/test/apps/expressProxy.js
@@ -10,7 +10,7 @@ require('../../')({
   tracing: {
     enabled: true,
     forceTransmissionStartingAt: 1,
-    stackTraceLength: process.env.STACK_TRACE_LENGTH != null ? parseInt(process.env.STACK_TRACE_LENGTH, 10) : 10
+    stackTraceLength: process.env.STACK_TRACE_LENGTH != null ? process.env.STACK_TRACE_LENGTH : 10
   }
 });
 


### PR DESCRIPTION
This makes it more convenient to provide the config value as a
environment variable.