### PR TITLE
fix: call unref() on all Timeout objects

### DIFF
--- a/src/actions/profiling/cpu.js
+++ b/src/actions/profiling/cpu.js
@@ -48,6 +48,7 @@ exports.startProfiling = function(request, multiCb) {
   profilingCallback = multiCb;
   var duration = request.args.duration ? Math.min(request.args.duration, maxProfilingDurationMillis) : 1000 * 60;
   profilingTimeoutHandle = setTimeout(onStopProfiling, duration);
+  profilingTimeoutHandle.unref();
   multiCb({
     data: 'Profiling successfully started for ' + duration + 'ms.'
   });

--- a/src/metrics/gc.js
+++ b/src/metrics/gc.js
@@ -72,6 +72,7 @@ exports.activate = function() {
     exports.currentPayload.weakCallbackProcessing = processWeakCallbacksWindow.sum();
     exports.currentPayload.gcPause = gcPauseWindow.sum();
   }, 1000);
+  reducingIntervalHandle.unref();
 };
 
 exports.deactivate = function() {

--- a/src/metrics/healthchecks.js
+++ b/src/metrics/healthchecks.js
@@ -51,11 +51,13 @@ function gatherHealthcheckResults() {
 
       exports.currentPayload = results;
       timeoutHandle = setTimeout(gatherHealthcheckResults, timeBetweenHealthcheckCalls);
+      timeoutHandle.unref();
     })
     .catch(function onHealthcheckResultFailure(err) {
       exports.currentPayload = {};
       logger.warn('Unexpected error while getting healthcheck results', err);
       timeoutHandle = setTimeout(gatherHealthcheckResults, timeBetweenHealthcheckCalls);
+      timeoutHandle.unref();
     });
 }
 

--- a/src/metrics/heapSpaces.js
+++ b/src/metrics/heapSpaces.js
@@ -18,6 +18,7 @@ exports.activate = function() {
   if (v8 && v8.getHeapSpaceStatistics) {
     gatherHeapSpaceStatistics();
     activeIntervalHandle = setInterval(gatherHeapSpaceStatistics, 1000);
+    activeIntervalHandle.unref();
   }
 };
 

--- a/src/metrics/memory.js
+++ b/src/metrics/memory.js
@@ -8,6 +8,7 @@ var activeIntervalHandle = null;
 exports.activate = function() {
   gatherMemoryUsageStatistics();
   activeIntervalHandle = setInterval(gatherMemoryUsageStatistics, 1000);
+  activeIntervalHandle.unref();
 };
 
 function gatherMemoryUsageStatistics() {

--- a/src/states/agentready.js
+++ b/src/states/agentready.js
@@ -67,7 +67,7 @@ module.exports = exports = {
           transmissionsSinceLastFullDataEmit++;
         }
         requestHandler.handleRequests(requests);
-        setTimeout(sendData, 1000);
+        setTimeout(sendData, 1000).unref();
       });
     }
   },

--- a/src/states/announced.js
+++ b/src/states/announced.js
@@ -27,7 +27,7 @@ function checkWhetherAgentIsReadyToAccept(totalNumberOfAttempts, ctx) {
       );
       ctx.transitionTo('unannounced');
     } else {
-      setTimeout(checkWhetherAgentIsReadyToAccept, 10000, totalNumberOfAttempts + 1, ctx);
+      setTimeout(checkWhetherAgentIsReadyToAccept, 10000, totalNumberOfAttempts + 1, ctx).unref();
     }
   });
 }

--- a/src/states/unannounced.js
+++ b/src/states/unannounced.js
@@ -23,7 +23,7 @@ function tryToAnnounce(ctx) {
   agentConnection.announceNodeSensor(function(err, rawResponse) {
     if (err) {
       logger.info('Announce attempt failed: %s. Will retry in %sms', err.message, retryDelay);
-      setTimeout(tryToAnnounce, retryDelay, ctx);
+      setTimeout(tryToAnnounce, retryDelay, ctx).unref();
       return;
     }
 
@@ -37,7 +37,7 @@ function tryToAnnounce(ctx) {
         retryDelay,
         e
       );
-      setTimeout(tryToAnnounce, retryDelay, ctx);
+      setTimeout(tryToAnnounce, retryDelay, ctx).unref();
       return;
     }
 

--- a/src/tracing/instrumentation/database/elasticsearch.js
+++ b/src/tracing/instrumentation/database/elasticsearch.js
@@ -38,7 +38,7 @@ function gatherClusterInfo(client, info) {
     function() {
       setTimeout(function() {
         gatherClusterInfo(client, info);
-      }, 30000);
+      }, 30000).unref();
     }
   );
 }

--- a/src/tracing/transmission.js
+++ b/src/tracing/transmission.js
@@ -24,6 +24,7 @@ exports.activate = function() {
   isActive = true;
   spans = [];
   transmissionTimeoutHandle = setTimeout(transmitSpans, 1000);
+  transmissionTimeoutHandle.unref();
 };
 
 exports.deactivate = function() {
@@ -53,6 +54,7 @@ function transmitSpans() {
 
   if (spans.length === 0) {
     transmissionTimeoutHandle = setTimeout(transmitSpans, 1000);
+    transmissionTimeoutHandle.unref();
     return;
   }
 
@@ -67,6 +69,7 @@ function transmitSpans() {
     }
 
     transmissionTimeoutHandle = setTimeout(transmitSpans, 1000);
+    transmissionTimeoutHandle.unref();
   });
 }
 


### PR DESCRIPTION
Timeouts created by the Node.js sensor should never be responsible for
keeping the event loop alive. If nothing from the monitored process
keeps the event loop alive, then we should not prevent Node.js from
terminating the process.