### PR TITLE
fix(tracing): amqp: read incoming headers case insensitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-.npmrc
 npm-debug*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Read X-INSTANA-... headers case-insensitive in amqp instrumentation.
+
 ## 1.67.1
 - Fix: Handle koa routes defined by regular expressions.
 

--- a/packages/collector/.gitignore
+++ b/packages/collector/.gitignore
@@ -1,3 +1,0 @@
-node_modules
-.npmrc
-npm-debug*

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,3 +1,0 @@
-node_modules
-.npmrc
-npm-debug*

--- a/packages/core/src/tracing/instrumentation/protocols/grpc.js
+++ b/packages/core/src/tracing/instrumentation/protocols/grpc.js
@@ -350,6 +350,8 @@ function modifyArgs(originalArgs, span, responseStream) {
 }
 
 function readMetadata(metadata, key) {
+  // The grpc library normalizes keys internally to lower-case, so we do not need to take care of reading
+  // them case-insensitive ourselves.
   var values = metadata.get(key);
   if (values && values.length > 0) {
     return values[0];

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -90,3 +90,17 @@ exports.shortenDatabaseStatement = function shortenDatabaseStatement(stmt) {
 
   return stmt.substring(0, 4000);
 };
+
+exports.readAttribCaseInsensitive = function readAttribCaseInsensitive(object, key) {
+  if (!object || typeof object !== 'object' || typeof key !== 'string') {
+    return null;
+  }
+  var keyUpper = key.toUpperCase();
+  var allKeys = Object.keys(object);
+  for (var i = 0; i < allKeys.length; i++) {
+    if (typeof allKeys[i] === 'string' && allKeys[i].toUpperCase() === keyUpper) {
+      return object[allKeys[i]];
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
Tracers should always send the X-INSTANA-... headers in an all-uppercase
fashion, and read them case-insensitive.