### PR TITLE
fix(tracing): Do not break on fastify routes with beforeHandler array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Read X-INSTANA-... headers case-insensitive in amqp instrumentation.
+- Fix handling of Fastify routes with an beforeHandler array.
 
 ## 1.67.1
 - Fix: Handle koa routes defined by regular expressions.

--- a/packages/collector/test/tracing/frameworks/fastify/app.js
+++ b/packages/collector/test/tracing/frameworks/fastify/app.js
@@ -15,9 +15,39 @@ var fastify = require('fastify');
 var app = fastify();
 var logPrefix = 'Fastify (' + process.pid + '):\t';
 
-// Declare a route
 app.get('/', ok);
+
 app.get('/foo/:id', ok);
+
+app.get(
+  '/before-handler/:id',
+  {
+    beforeHandler: (request, reply, done) => {
+      // This tests that we record the path template even if a beforeHandler exits early
+      // (before the handler is executed).
+      reply.send({ before: 'handler' });
+    }
+  },
+  ok
+);
+
+app.get(
+  '/before-handler-array/:id',
+  {
+    beforeHandler: [
+      async () => {
+        // This tests that we record the path template even if a beforeHandler exits early
+        // (before the handler is executed).
+        throw new Error('Yikes');
+      },
+      (request, reply, done) => {
+        done();
+      }
+    ]
+  },
+  ok
+);
+
 app.register(subRouter, { prefix: '/sub' });
 
 async function ok() {

--- a/packages/collector/test/tracing/frameworks/fastify/test.js
+++ b/packages/collector/test/tracing/frameworks/fastify/test.js
@@ -25,24 +25,35 @@ describe('tracing/fastify', function() {
   controls.registerTestHooks();
 
   describe('path templates', function() {
-    check('/', '/');
-    check('/foo/42', '/foo/:id');
-    check('/sub', '/sub');
-    check('/sub/bar/42', '/sub/bar/:id');
+    check('/', 200, { hello: 'world' }, '/');
+    check('/foo/42', 200, { hello: 'world' }, '/foo/:id');
+    check('/before-handler/13', 200, { before: 'handler' }, '/before-handler/:id');
+    check(
+      '/before-handler-array/02',
+      500,
+      { statusCode: 500, error: 'Internal Server Error', message: 'Yikes' },
+      '/before-handler-array/:id'
+    );
+    check('/sub', 200, { hello: 'world' }, '/sub');
+    check('/sub/bar/42', 200, { hello: 'world' }, '/sub/bar/:id');
 
-    function check(actualPath, expectedTemplate) {
+    function check(actualPath, expectedStatusCode, expectedResponse, expectedTemplate) {
       it('must report path templates for actual path: ' + actualPath, function() {
         return controls
           .sendRequest({
             method: 'GET',
-            path: actualPath
+            path: actualPath,
+            simple: false,
+            resolveWithFullResponse: true
           })
-          .then(function() {
+          .then(function(response) {
+            expect(response.statusCode).to.equal(expectedStatusCode);
+            expect(response.body).to.deep.equal(expectedResponse);
             return utils.retry(function() {
               return agentControls.getSpans().then(function(spans) {
                 utils.expectOneMatching(spans, function(span) {
                   expect(span.data.http.path_tpl).to.equal(expectedTemplate);
-                  expect(span.data.http.status).to.equal(200);
+                  expect(span.data.http.status).to.equal(expectedStatusCode);
                   expect(span.data.http.url).to.equal(actualPath);
                   expect(span.k).to.equal(constants.ENTRY);
                 });


### PR DESCRIPTION
opts.beforeHandler can be a function or an array. We did not handle the
array case correctly. Furthermore, handling opts.beforeHandler is
redundant anyway since opts.handler will always be there and it is
sufficient to hook in opts.handler. Consequently, the handling of
opts.beforeHandler has been removed entirely.