### PR TITLE
chore: apply some lebab transforms on test files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-
   extends: 'airbnb/legacy',
 
   env: {
@@ -7,22 +6,22 @@ module.exports = {
   },
 
   parserOptions: {
-    sourceType: 'strict',
+    ecmaVersion: 6,
+    sourceType: 'strict'
   },
 
-  plugins: [
-    'mocha'
-  ],
+  plugins: ['mocha'],
 
-  rules:  {
-    'arrow-parens': [2, 'always'],
+  rules: {
     'block-scoped-var': 0,
     'comma-dangle': 0,
     'consistent-return': 0,
     eqeqeq: [2, 'allow-null'],
     'func-names': 0,
+    'function-paren-newline': 0,
     'global-require': 0,
     'id-length': 0,
+    'implicit-arrow-linebreak': 0,
     indent: 0,
     'max-len': [2, 120, 2],
     'mocha/no-exclusive-tests': 2,
@@ -38,12 +37,12 @@ module.exports = {
     'no-restricted-globals': 0,
     'no-underscore-dangle': 0,
     'no-unused-expressions': 0,
-    'no-use-before-define':  [2, 'nofunc'],
+    'no-use-before-define': [2, 'nofunc'],
     'object-curly-spacing': 0,
     'operator-linebreak': 0,
     'prefer-arrow-callback': 0,
     'space-before-function-paren': 0,
-    'strict': [2, 'global'],
+    strict: [2, 'global'],
     'vars-on-top': 0,
     'wrap-iife': 0,
     yoda: 0

--- a/packages/collector/dummy-app/src/config.js
+++ b/packages/collector/dummy-app/src/config.js
@@ -14,9 +14,9 @@ function getInt(key) {
   if (process.env[key] == null) {
     return null;
   }
-  var val = parseInt(process.env[key], 10);
+  const val = parseInt(process.env[key], 10);
   if (isNaN(val)) {
-    console.log('Cannot parse ' + key + ' value: ' + process.env[key]);
+    console.log(`Cannot parse ${key} value: ${process.env[key]}`);
     return null;
   }
   return val;

--- a/packages/collector/dummy-app/src/index.js
+++ b/packages/collector/dummy-app/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var config = require('./config');
+const config = require('./config');
 
 if (config.collectorEnabled) {
   console.log('enabling @instana/collector');
@@ -15,16 +15,16 @@ if (config.collectorEnabled) {
   console.log('NOT enabling @instana/collector');
 }
 
-var express = require('express');
-var app = express();
+const express = require('express');
+const app = express();
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   if (config.logRequests) {
     console.log('received request');
   }
   res.send('OK');
 });
 
-app.listen(config.appPort, function() {
+app.listen(config.appPort, () => {
   console.log('Listening on port', config.appPort);
 });

--- a/packages/collector/test/actions/getModuleAnalysis_test.js
+++ b/packages/collector/test/actions/getModuleAnalysis_test.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var expect = require('chai').expect;
-var semver = require('semver');
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
+const expect = require('chai').expect;
+const semver = require('semver');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
 
-var config = require('../config');
-var utils = require('../utils');
+const config = require('../config');
+const utils = require('../utils');
 
 describe('actions/getModuleAnalysis', function() {
   if (semver.satisfies(process.versions.node, '<4')) {
     return;
   }
 
-  var expressControls = require('../apps/expressControls');
-  var agentStubControls = require('../apps/agentStubControls');
+  const expressControls = require('../apps/expressControls');
+  const agentStubControls = require('../apps/agentStubControls');
 
   this.timeout(config.getTestTimeout());
 
@@ -22,30 +22,28 @@ describe('actions/getModuleAnalysis', function() {
     enableTracing: supportedVersion(process.versions.node)
   });
 
-  beforeEach(function() {
-    return agentStubControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid());
-  });
+  beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid()));
 
-  it('must receive module analysis', function() {
-    var messageId = 'a';
+  it('must receive module analysis', () => {
+    const messageId = 'a';
     return agentStubControls
       .addRequestForPid(expressControls.getPid(), {
         action: 'node.getModuleAnalysis',
-        messageId: messageId,
+        messageId,
         args: {}
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentStubControls.getResponses().then(function(responses) {
-            utils.expectOneMatching(responses, function(response) {
+      .then(() =>
+        utils.retry(() =>
+          agentStubControls.getResponses().then(responses => {
+            utils.expectOneMatching(responses, response => {
               expect(response.messageId).to.equal(messageId);
               expect(response.data.data.cwd).to.be.a('string');
               expect(response.data.data['require.main.filename']).to.be.a('string');
               expect(response.data.data['require.main.paths']).to.be.an('array');
               expect(response.data.data['require.cache']).to.be.an('array');
             });
-          });
-        });
-      });
+          })
+        )
+      );
   });
 });

--- a/packages/collector/test/actions/profiling/cpu_test.js
+++ b/packages/collector/test/actions/profiling/cpu_test.js
@@ -1,42 +1,42 @@
 'use strict';
 
-var expect = require('chai').expect;
-var semver = require('semver');
-var path = require('path');
-var fs = require('fs');
+const expect = require('chai').expect;
+const semver = require('semver');
+const path = require('path');
+const fs = require('fs');
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var cpu = require('../../../src/actions/profiling/cpu');
-var config = require('../../config');
-var utils = require('../../utils');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const cpu = require('../../../src/actions/profiling/cpu');
+const config = require('../../config');
+const utils = require('../../utils');
 
-describe('actions/profiling/cpu', function() {
+describe('actions/profiling/cpu', () => {
   if (!semver.satisfies(process.versions.node, '>=4.0.0')) {
     return;
   }
 
-  var elasticSearchControls = require('../../tracing/database/elasticsearch/controls');
-  var agentStubControls = require('../../apps/agentStubControls');
+  const elasticSearchControls = require('../../tracing/database/elasticsearch/controls');
+  const agentStubControls = require('../../apps/agentStubControls');
 
-  describe('toTreeWithTiming', function() {
-    var rawCpuProfile;
+  describe('toTreeWithTiming', () => {
+    let rawCpuProfile;
 
-    beforeEach(function() {
+    beforeEach(() => {
       rawCpuProfile = JSON.parse(fs.readFileSync(path.join(__dirname, 'cpuProfile.json'), { encoding: 'utf8' }));
     });
 
-    it('must turn the raw CPU profile into a tree with timing information', function() {
-      var root = cpu.toTreeWithTiming(rawCpuProfile, 1000);
+    it('must turn the raw CPU profile into a tree with timing information', () => {
+      const root = cpu.toTreeWithTiming(rawCpuProfile, 1000);
       expect(root.f).to.equal('(root)');
 
-      var firstChild = root.c[0];
+      const firstChild = root.c[0];
       expect(firstChild.f).to.equal('');
       expect(firstChild.u).to.equal('node.js');
       expect(firstChild.l).to.equal(10);
     });
 
-    it('must calculate timing information based on sampling interval', function() {
-      var root = cpu.toTreeWithTiming(rawCpuProfile, 100);
+    it('must calculate timing information based on sampling interval', () => {
+      const root = cpu.toTreeWithTiming(rawCpuProfile, 100);
       expect(root.sh).to.equal(0);
       expect(root.th).to.equal(3799);
 
@@ -44,8 +44,8 @@ describe('actions/profiling/cpu', function() {
       expect(root.t).to.equal(3799000);
     });
 
-    it('must shorten bailout reasons', function() {
-      var firstChild = cpu.toTreeWithTiming(rawCpuProfile, 100).c[0];
+    it('must shorten bailout reasons', () => {
+      const firstChild = cpu.toTreeWithTiming(rawCpuProfile, 100).c[0];
       expect(firstChild.b).to.equal(undefined);
     });
   });
@@ -62,43 +62,41 @@ describe('actions/profiling/cpu', function() {
       enableTracing: supportedVersion(process.versions.node)
     });
 
-    beforeEach(function() {
-      return agentStubControls.waitUntilAppIsCompletelyInitialized(elasticSearchControls.getPid());
-    });
+    beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(elasticSearchControls.getPid()));
 
-    it('must inform about start of CPU profile', function() {
-      var messageId = 'a';
+    it('must inform about start of CPU profile', () => {
+      const messageId = 'a';
       return agentStubControls
         .addRequestForPid(elasticSearchControls.getPid(), {
           action: 'node.startCpuProfiling',
-          messageId: messageId,
+          messageId,
           args: {
             duration: 1000
           }
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentStubControls.getResponses().then(function(responses) {
-              utils.expectOneMatching(responses, function(response) {
+        .then(() =>
+          utils.retry(() =>
+            agentStubControls.getResponses().then(responses => {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(messageId);
                 expect(response.data.data).to.match(/Profiling successfully started/i);
               });
 
-              utils.expectOneMatching(responses, function(response) {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(messageId);
                 expect(response.data.data.f).to.equal('(root)');
                 expect(response.data.data.sh).to.equal(0);
                 expect(response.data.data.th).to.be.above(0);
                 expect(response.data.data.t).to.equal(response.data.data.th * 1000);
               });
-            });
-          });
-        });
+            })
+          )
+        );
     });
 
-    it('must stop running CPU profiles and provide the results', function() {
-      var startMessageId = 'start';
-      var stopMessageId = 'stop';
+    it('must stop running CPU profiles and provide the results', () => {
+      const startMessageId = 'start';
+      const stopMessageId = 'stop';
       return agentStubControls
         .addRequestForPid(elasticSearchControls.getPid(), {
           action: 'node.startCpuProfiling',
@@ -107,38 +105,38 @@ describe('actions/profiling/cpu', function() {
             duration: 6000000
           }
         })
-        .then(function() {
-          return agentStubControls.addRequestForPid(elasticSearchControls.getPid(), {
+        .then(() =>
+          agentStubControls.addRequestForPid(elasticSearchControls.getPid(), {
             action: 'node.stopCpuProfiling',
             messageId: stopMessageId,
             args: {}
-          });
-        })
-        .then(function() {
-          return utils.retry(function() {
-            return agentStubControls.getResponses().then(function(responses) {
-              utils.expectOneMatching(responses, function(response) {
+          })
+        )
+        .then(() =>
+          utils.retry(() =>
+            agentStubControls.getResponses().then(responses => {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(stopMessageId);
                 expect(response.data.data).to.match(/CPU profiling successfully stopped/i);
               });
 
-              utils.expectOneMatching(responses, function(response) {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(startMessageId);
                 expect(response.data.data).to.match(/Profiling successfully started/i);
               });
 
-              utils.expectOneMatching(responses, function(response) {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(startMessageId);
                 expect(response.data.data.f).to.equal('(root)');
               });
-            });
-          });
-        });
+            })
+          )
+        );
     });
 
-    it('must abort running CPU profiles', function() {
-      var startMessageId = 'start';
-      var stopMessageId = 'stop';
+    it('must abort running CPU profiles', () => {
+      const startMessageId = 'start';
+      const stopMessageId = 'stop';
       return agentStubControls
         .addRequestForPid(elasticSearchControls.getPid(), {
           action: 'node.startCpuProfiling',
@@ -147,34 +145,34 @@ describe('actions/profiling/cpu', function() {
             duration: 6000000
           }
         })
-        .then(function() {
-          return agentStubControls.addRequestForPid(elasticSearchControls.getPid(), {
+        .then(() =>
+          agentStubControls.addRequestForPid(elasticSearchControls.getPid(), {
             action: 'node.stopCpuProfiling',
             messageId: stopMessageId,
             args: {
               abort: true
             }
-          });
-        })
-        .then(function() {
-          return utils.retry(function() {
-            return agentStubControls.getResponses().then(function(responses) {
-              utils.expectOneMatching(responses, function(response) {
+          })
+        )
+        .then(() =>
+          utils.retry(() =>
+            agentStubControls.getResponses().then(responses => {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(stopMessageId);
                 expect(response.data.data).to.match(/CPU profiling successfully aborted/i);
               });
 
-              utils.expectOneMatching(responses, function(response) {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(startMessageId);
                 expect(response.data.data).to.match(/Profiling successfully started/i);
               });
-            });
-          });
-        });
+            })
+          )
+        );
     });
 
-    it('must do nothing when there is no active CPU profile', function() {
-      var stopMessageId = 'stop';
+    it('must do nothing when there is no active CPU profile', () => {
+      const stopMessageId = 'stop';
       return agentStubControls
         .addRequestForPid(elasticSearchControls.getPid(), {
           action: 'node.stopCpuProfiling',
@@ -183,16 +181,16 @@ describe('actions/profiling/cpu', function() {
             abort: true
           }
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentStubControls.getResponses().then(function(responses) {
-              utils.expectOneMatching(responses, function(response) {
+        .then(() =>
+          utils.retry(() =>
+            agentStubControls.getResponses().then(responses => {
+              utils.expectOneMatching(responses, response => {
                 expect(response.messageId).to.equal(stopMessageId);
                 expect(response.data.data).to.match(/No active CPU profiling session found/i);
               });
-            });
-          });
-        });
+            })
+          )
+        );
     });
   });
 });

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -2,23 +2,23 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
-var _ = require('lodash');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
+const _ = require('lodash');
 
-var utils = require('../utils');
-var config = require('../config');
+const utils = require('../utils');
+const config = require('../config');
 
-var agentPort = (exports.agentPort = 3210);
+const agentPort = (exports.agentPort = 3210);
 
-var agentStub;
+let agentStub;
 
-exports.registerTestHooks = function(opts) {
+exports.registerTestHooks = opts => {
   opts = opts || {};
 
-  beforeEach(function() {
-    var env = Object.create(process.env);
+  beforeEach(() => {
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.EXTRA_HEADERS = (opts.extraHeaders || []).join(',');
     env.SECRETS_MATCHER = opts.secretsMatcher || 'contains-ignore-case';
@@ -26,95 +26,80 @@ exports.registerTestHooks = function(opts) {
 
     agentStub = spawn('node', [path.join(__dirname, 'agentStub.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     agentStub.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + agentPort
-    });
-  });
+      url: `http://127.0.0.1:${agentPort}`
+    })
+  );
 }
 
-exports.getDiscoveries = function() {
-  return request({
+exports.getDiscoveries = () =>
+  request({
     method: 'GET',
-    url: 'http://127.0.0.1:' + agentPort + '/discoveries',
+    url: `http://127.0.0.1:${agentPort}/discoveries`,
     json: true
   });
-};
 
-exports.deleteDiscoveries = function() {
-  return request({
+exports.deleteDiscoveries = () =>
+  request({
     method: 'DELETE',
-    url: 'http://127.0.0.1:' + agentPort + '/discoveries',
+    url: `http://127.0.0.1:${agentPort}/discoveries`,
     json: true
   });
-};
 
-exports.getRetrievedData = function() {
-  return request({
+exports.getRetrievedData = () =>
+  request({
     method: 'GET',
-    url: 'http://127.0.0.1:' + agentPort + '/retrievedData',
+    url: `http://127.0.0.1:${agentPort}/retrievedData`,
     json: true
   });
-};
 
-exports.getEvents = function() {
-  return request({
+exports.getEvents = () =>
+  request({
     method: 'GET',
-    url: 'http://127.0.0.1:' + agentPort + '/retrievedEvents',
+    url: `http://127.0.0.1:${agentPort}/retrievedEvents`,
     json: true
   });
-};
 
-exports.clearRetrievedData = function() {
-  return request({
+exports.clearRetrievedData = () =>
+  request({
     method: 'DELETE',
-    url: 'http://127.0.0.1:' + agentPort + '/retrievedData',
+    url: `http://127.0.0.1:${agentPort}/retrievedData`,
     json: true
   });
-};
 
-exports.getSpans = function() {
-  return exports.getRetrievedData().then(function(data) {
-    return data.traces.reduce(function(result, traceMessage) {
-      return result.concat(traceMessage.data);
-    }, []);
-  });
-};
+exports.getSpans = () =>
+  exports
+    .getRetrievedData()
+    .then(data => data.traces.reduce((result, traceMessage) => result.concat(traceMessage.data), []));
 
-exports.getResponses = function() {
-  return exports.getRetrievedData().then(function(data) {
-    return data.responses;
-  });
-};
+exports.getResponses = () => exports.getRetrievedData().then(data => data.responses);
 
-exports.getLastMetricValue = function(pid, _path) {
-  return exports.getRetrievedData().then(function(data) {
-    return getLastMetricValue(pid, data, _path);
-  });
-};
+exports.getLastMetricValue = (pid, _path) =>
+  exports.getRetrievedData().then(data => getLastMetricValue(pid, data, _path));
 
 function getLastMetricValue(pid, data, _path) {
-  for (var i = data.runtime.length - 1; i >= 0; i--) {
-    var runtimeMessage = data.runtime[i];
+  for (let i = data.runtime.length - 1; i >= 0; i--) {
+    const runtimeMessage = data.runtime[i];
     if (runtimeMessage.pid !== pid) {
       // eslint-disable-next-line no-continue
       continue;
     }
 
-    var value = _.get(runtimeMessage.data, _path, undefined);
+    const value = _.get(runtimeMessage.data, _path, undefined);
     if (value !== undefined) {
       return value;
     }
@@ -123,58 +108,48 @@ function getLastMetricValue(pid, data, _path) {
   return undefined;
 }
 
-exports.getAllMetrics = function(pid) {
-  return exports.getRetrievedData().then(function(data) {
-    return getAllMetrics(pid, data);
-  });
-};
+exports.getAllMetrics = pid => exports.getRetrievedData().then(data => getAllMetrics(pid, data));
 
 function getAllMetrics(pid, data) {
-  return data.runtime.filter(function(runtimeMessage) {
-    return runtimeMessage.pid === pid;
-  });
+  return data.runtime.filter(runtimeMessage => runtimeMessage.pid === pid);
 }
 
-exports.waitUntilAppIsCompletelyInitialized = function(pid) {
-  return utils.retry(function() {
-    return exports.getRetrievedData().then(function(data) {
-      for (var i = 0, len = data.runtime.length; i < len; i++) {
-        var d = data.runtime[i];
+exports.waitUntilAppIsCompletelyInitialized = pid =>
+  utils.retry(() =>
+    exports.getRetrievedData().then(data => {
+      for (let i = 0, len = data.runtime.length; i < len; i++) {
+        const d = data.runtime[i];
         if (d.pid) {
           return true;
         }
       }
 
-      throw new Error('PID ' + pid + ' never sent any data to the agent.');
-    });
-  });
-};
+      throw new Error(`PID ${pid} never sent any data to the agent.`);
+    })
+  );
 
-exports.simulateDiscovery = function(pid) {
-  return request({
+exports.simulateDiscovery = pid =>
+  request({
     method: 'PUT',
-    url: 'http://127.0.0.1:' + agentPort + '/com.instana.plugin.nodejs.discovery',
+    url: `http://127.0.0.1:${agentPort}/com.instana.plugin.nodejs.discovery`,
     json: true,
     body: {
-      pid: pid
+      pid
     }
   });
-};
 
-exports.addEntityData = function(pid, data) {
-  return request({
+exports.addEntityData = (pid, data) =>
+  request({
     method: 'POST',
-    url: 'http://127.0.0.1:' + agentPort + '/com.instana.plugin.nodejs.' + pid,
+    url: `http://127.0.0.1:${agentPort}/com.instana.plugin.nodejs.${pid}`,
     json: true,
     body: data
   });
-};
 
-exports.addRequestForPid = function(pid, r) {
-  return request({
+exports.addRequestForPid = (pid, r) =>
+  request({
     method: 'POST',
-    url: 'http://127.0.0.1:' + agentPort + '/request/' + pid,
+    url: `http://127.0.0.1:${agentPort}/request/${pid}`,
     json: true,
     body: r
   });
-};

--- a/packages/collector/test/apps/agentStub_test.js
+++ b/packages/collector/test/apps/agentStub_test.js
@@ -2,50 +2,44 @@
 
 'use strict';
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../config');
-var expect = require('chai').expect;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../config');
+const expect = require('chai').expect;
 
 describe('agentStub', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentStubControls = require('./agentStubControls');
+  const agentStubControls = require('./agentStubControls');
 
   this.timeout(config.getTestTimeout());
 
   agentStubControls.registerTestHooks();
 
-  it('must respond without any discoveries upon start', function() {
-    return agentStubControls.getDiscoveries().then(function(discoveries) {
+  it('must respond without any discoveries upon start', () =>
+    agentStubControls.getDiscoveries().then(discoveries => {
       expect(discoveries).to.deep.equal({});
-    });
-  });
+    }));
 
-  it('must respond without any data upon start', function() {
-    return agentStubControls.getRetrievedData().then(function(data) {
+  it('must respond without any data upon start', () =>
+    agentStubControls.getRetrievedData().then(data => {
       expect(data).to.deep.equal({
         runtime: [],
         traces: [],
         responses: [],
         events: []
       });
-    });
-  });
+    }));
 
-  it('must return requests when retrieving entity data', function() {
-    var pid = 23;
-    var params = { foo: 'bar' };
+  it('must return requests when retrieving entity data', () => {
+    const pid = 23;
+    const params = { foo: 'bar' };
     return agentStubControls
       .simulateDiscovery(pid)
-      .then(function() {
-        return agentStubControls.addRequestForPid(pid, params);
-      })
-      .then(function() {
-        return agentStubControls.addEntityData(pid, {});
-      })
-      .then(function(requests) {
+      .then(() => agentStubControls.addRequestForPid(pid, params))
+      .then(() => agentStubControls.addEntityData(pid, {}))
+      .then(requests => {
         expect(requests).to.deep.equal([params]);
       });
   });

--- a/packages/collector/test/apps/expressProxy.js
+++ b/packages/collector/test/apps/expressProxy.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 
+'use strict';
+
 // This is a tiny express app which responds to all methods and has configurable
 // latency and response codes. This can be used a baselines for many tests, e.g.
 // to test distributed tracing.
@@ -14,24 +16,24 @@ require('../../')({
   }
 });
 
-var express = require('express');
-var request = require('request');
-var fetch = require('node-fetch');
-var app = express();
+const express = require('express');
+const request = require('request');
+const fetch = require('node-fetch');
+const app = express();
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.use(function(req, res) {
+app.use((req, res) => {
   log(req.method, req.url);
-  var delay = parseInt(req.query.delay || 0, 10);
-  setTimeout(function() {
-    var url;
+  const delay = parseInt(req.query.delay || 0, 10);
+  setTimeout(() => {
+    let url;
     if (req.query.url) {
       url = req.query.url;
     } else {
-      url = 'http://127.0.0.1:' + process.env.UPSTREAM_PORT + '/proxy-call' + req.url;
+      url = `http://127.0.0.1:${process.env.UPSTREAM_PORT}/proxy-call${req.url}`;
     }
 
     if (req.query.httpLib === 'node-fetch') {
@@ -40,10 +42,10 @@ app.use(function(req, res) {
         method: req.method,
         timeout: 500
       })
-        .then(function(response) {
+        .then(response => {
           res.sendStatus(response.status);
         })
-        .catch(function(err) {
+        .catch(err => {
           res.sendStatus(500);
           log('Unexpected error', err);
         });
@@ -52,11 +54,11 @@ app.use(function(req, res) {
       request(
         {
           method: req.method,
-          url: url,
+          url,
           qs: req.query,
           timeout: 500
         },
-        function(err, response) {
+        (err, response) => {
           if (err) {
             res.sendStatus(500);
             log('Unexpected error', err);
@@ -69,12 +71,12 @@ app.use(function(req, res) {
   }, delay * 0.25);
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
-  args[0] = 'Express Proxy (' + process.pid + '):\t' + args[0];
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `Express Proxy (${process.pid}):\t${args[0]}`;
   console.log.apply(console, args);
 }

--- a/packages/collector/test/apps/expressProxyControls.js
+++ b/packages/collector/test/apps/expressProxyControls.js
@@ -2,23 +2,23 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var errors = require('request-promise/errors');
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const errors = require('request-promise/errors');
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../utils');
-var config = require('../config');
-var agentPort = require('./agentStubControls').agentPort;
-var upstreamPort = require('./expressControls').appPort;
-var appPort = (exports.appPort = 3212);
+const utils = require('../utils');
+const config = require('../config');
+const agentPort = require('./agentStubControls').agentPort;
+const upstreamPort = require('./expressControls').appPort;
+const appPort = (exports.appPort = 3212);
 
-var expressProxyApp;
+let expressProxyApp;
 
-exports.registerTestHooks = function(opts) {
+exports.registerTestHooks = opts => {
   opts = opts || {};
-  beforeEach(function() {
-    var env = Object.create(process.env);
+  beforeEach(() => {
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.UPSTREAM_PORT = upstreamPort;
@@ -26,54 +26,54 @@ exports.registerTestHooks = function(opts) {
 
     expressProxyApp = spawn('node', [path.join(__dirname, 'expressProxy.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     expressProxyApp.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return expressProxyApp.pid;
-};
+exports.getPid = () => expressProxyApp.pid;
 
-exports.sendRequest = function(opts) {
+exports.sendRequest = opts => {
   opts.responseStatus = opts.responseStatus || 200;
   opts.delay = opts.delay || 0;
 
-  var headers = {};
+  const headers = {};
   if (opts.suppressTracing === true) {
     headers['X-INSTANA-L'] = '0';
   }
 
   return request({
     method: opts.method,
-    url: 'http://127.0.0.1:' + appPort + opts.path,
+    url: `http://127.0.0.1:${appPort}${opts.path}`,
     qs: {
       responseStatus: opts.responseStatus,
       delay: opts.delay,
       url: opts.target,
       httpLib: opts.httpLib
     },
-    headers: headers
-  }).catch(errors.StatusCodeError, function(reason) {
-    // treat all status code errors as likely // allowed
-    return reason;
-  });
+    headers
+  }).catch(
+    errors.StatusCodeError,
+    (
+      reason // treat all status code errors as likely // allowed
+    ) => reason
+  );
 };

--- a/packages/collector/test/cmdline_test.js
+++ b/packages/collector/test/cmdline_test.js
@@ -2,50 +2,50 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var sinon = require('sinon');
-var proxyquire = require('proxyquire');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
 
-describe('cmdline', function() {
-  var fs;
-  var result;
+describe('cmdline', () => {
+  let fs;
+  let result;
 
-  beforeEach(function() {
+  beforeEach(() => {
     fs = {
       readFileSync: sinon.stub()
     };
     result = null;
   });
 
-  it('should not define name and args when procfile cannot be read', function() {
+  it('should not define name and args when procfile cannot be read', () => {
     fs.readFileSync.throws({ code: 'ENOENT' });
     req();
     expect(result.name).to.equal(undefined);
     expect(result.args).to.equal(undefined);
   });
 
-  it('should split the command line', function() {
+  it('should split the command line', () => {
     fs.readFileSync.returns('node\u0000foo\u0000my app\u0000');
     req();
     expect(result.name).to.equal('node');
     expect(result.args).to.deep.equal(['foo', 'my app']);
   });
 
-  it('should define args an empty array when there are no args', function() {
+  it('should define args an empty array when there are no args', () => {
     fs.readFileSync.returns('node\u0000');
     req();
     expect(result.name).to.equal('node');
     expect(result.args).to.deep.equal([]);
   });
 
-  it('should not fail when the file is empty', function() {
+  it('should not fail when the file is empty', () => {
     fs.readFileSync.returns('');
     req();
     expect(result.name).to.equal('');
     expect(result.args).to.deep.equal([]);
   });
 
-  it('should work with only one commandline argument', function() {
+  it('should work with only one commandline argument', () => {
     fs.readFileSync.returns('node\u0000my app\u0000');
     req();
     expect(result.name).to.equal('node');
@@ -54,7 +54,7 @@ describe('cmdline', function() {
 
   function req() {
     result = proxyquire('../src/cmdline', {
-      fs: fs
+      fs
     }).getCmdline();
   }
 });

--- a/packages/collector/test/config.js
+++ b/packages/collector/test/config.js
@@ -1,13 +1,13 @@
 'use strict';
 
-exports.getAppStdio = function() {
+exports.getAppStdio = () => {
   if (process.env.WITH_STDOUT || process.env.CI) {
     return [process.stdin, process.stdout, process.stderr, 'ipc'];
   }
   return [process.stdin, 'ignore', process.stderr, 'ipc'];
 };
 
-exports.getTestTimeout = function() {
+exports.getTestTimeout = () => {
   if (process.env.CI) {
     return 30000;
   }

--- a/packages/collector/test/logger_test.js
+++ b/packages/collector/test/logger_test.js
@@ -3,18 +3,18 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var bunyan = require('bunyan');
-var semver = require('semver');
-var pino;
+const expect = require('chai').expect;
+const bunyan = require('bunyan');
+const semver = require('semver');
+let pino;
 if (semver.gte(process.versions.node, '6.0.0')) {
   // pino needs Node.js >= 6
   pino = require('pino');
 }
 
-var log = require('../src/logger');
+const log = require('../src/logger');
 
-describe('logger', function() {
+describe('logger', () => {
   beforeEach(resetEnv);
   afterEach(resetEnv);
 
@@ -23,100 +23,100 @@ describe('logger', function() {
     delete process.env['INSTANA_DEBUG'];
   }
 
-  it('should return the default parent logger if no config is available', function() {
+  it('should return the default parent logger if no config is available', () => {
     log.init({});
-    var logger = log.getLogger('myLogger');
+    const logger = log.getLogger('myLogger');
     expect(logger).to.be.an.instanceOf(bunyan);
   });
 
-  it('should return a child logger if requested', function() {
+  it('should return a child logger if requested', () => {
     log.init({});
-    var logger = log.getLogger('childName');
+    const logger = log.getLogger('childName');
     expect(logger).to.be.an.instanceOf(bunyan);
     expect(logger.fields).to.have.property('module');
     expect(logger.fields.module).to.equal('childName');
   });
 
-  it('should use the parent logger if defined', function() {
-    var logger = bunyan.createLogger({ name: 'myParentLogger' });
-    log.init({ logger: logger });
-    var childLogger = log.getLogger('childName');
+  it('should use the parent logger if defined', () => {
+    const logger = bunyan.createLogger({ name: 'myParentLogger' });
+    log.init({ logger });
+    const childLogger = log.getLogger('childName');
 
     expect(logger).to.be.an.instanceOf(bunyan);
     expect(childLogger.fields).to.have.property('module');
     expect(childLogger.fields.module).to.equal('childName');
   });
 
-  it('should add child logger to defined parent', function() {
+  it('should add child logger to defined parent', () => {
     log.init({ logger: bunyan.createLogger({ name: 'myParentLogger' }) });
-    var logger = log.getLogger('childName');
+    const logger = log.getLogger('childName');
 
     expect(logger.fields).to.have.property('module');
     expect(logger.fields.module).to.equal('childName');
   });
 
-  it('should use default log level if not defined', function() {
+  it('should use default log level if not defined', () => {
     log.init({ logger: bunyan.createLogger({ name: 'myParentLogger' }) });
-    var logger = log.getLogger('childName');
+    const logger = log.getLogger('childName');
 
     expect(logger.level()).to.equal(30);
   });
 
-  it('should use defined log level', function() {
+  it('should use defined log level', () => {
     log.init({ level: 'error', logger: bunyan.createLogger({ name: 'myParentLogger' }) });
-    var logger = log.getLogger('childName');
+    const logger = log.getLogger('childName');
 
     expect(logger.level()).to.equal(50);
   });
 
-  it('should use log level from env var', function() {
+  it('should use log level from env var', () => {
     process.env['INSTANA_LOG_LEVEL'] = 'warn';
     log.init({});
-    var logger = log.getLogger('childName');
+    const logger = log.getLogger('childName');
     expect(logger.level()).to.equal(40);
   });
 
-  it('should use debug log level when INSTANA_DEBUG is set', function() {
+  it('should use debug log level when INSTANA_DEBUG is set', () => {
     process.env['INSTANA_DEBUG'] = 'true';
     log.init({});
-    var logger = log.getLogger('childName');
+    const logger = log.getLogger('childName');
     expect(logger.level()).to.equal(20);
   });
 
-  it('should not detect pino as bunyan', function() {
+  it('should not detect pino as bunyan', () => {
     if (!pino) {
       // This test is skipped in Node.js 4 since pino only supports Node.js >= 6.
       return;
     }
-    var pinoLogger = pino();
+    const pinoLogger = pino();
     log.init({ logger: pinoLogger });
-    var logger = log.getLogger('myLogger');
+    const logger = log.getLogger('myLogger');
     expect(logger).to.not.be.an.instanceOf(bunyan);
     expect(logger.constructor.name).to.equal('Pino');
   });
 
-  it('should create a child logger for pino', function() {
+  it('should create a child logger for pino', () => {
     if (!pino) {
       // This test is skipped in Node.js 4 since pino only supports Node.js >= 6.
       return;
     }
-    var pinoLogger = pino();
+    const pinoLogger = pino();
     log.init({ logger: pinoLogger });
-    var logger = log.getLogger('myLogger');
+    const logger = log.getLogger('myLogger');
     expect(logger === pinoLogger).to.be.not.true;
   });
 
-  it('should not accept non-bunyan loggers without necessary logging functions', function() {
-    var nonBunyanLogger = {};
+  it('should not accept non-bunyan loggers without necessary logging functions', () => {
+    const nonBunyanLogger = {};
 
     log.init({ logger: nonBunyanLogger });
 
-    var logger = log.getLogger('myLogger');
+    const logger = log.getLogger('myLogger');
     expect(logger).to.be.an.instanceOf(bunyan);
   });
 
-  it('should accept non-bunyan loggers with necessary logging functions', function() {
-    var nonBunyanLogger = {
+  it('should accept non-bunyan loggers with necessary logging functions', () => {
+    const nonBunyanLogger = {
       debug: function() {},
       info: function() {},
       warn: function() {},
@@ -125,15 +125,15 @@ describe('logger', function() {
 
     log.init({ logger: nonBunyanLogger });
 
-    var logger = log.getLogger('myLogger');
+    const logger = log.getLogger('myLogger');
     expect(logger).not.to.be.an.instanceOf(bunyan);
   });
 
-  it('should reset loggers when the logger is set after initialization', function() {
+  it('should reset loggers when the logger is set after initialization', () => {
     log.init({});
-    var reInitCalled = false;
-    var logger;
-    logger = log.getLogger('myLogger', function(newLogger) {
+    let reInitCalled = false;
+    let logger;
+    logger = log.getLogger('myLogger', newLogger => {
       reInitCalled = true;
       logger = newLogger;
     });
@@ -141,9 +141,9 @@ describe('logger', function() {
     // first getLogger call should yield the default bunyan logger
     expect(logger).to.be.an.instanceOf(bunyan);
     expect(logger.fields.name).to.equal('@instana/collector');
-    var originalLogger = logger;
+    const originalLogger = logger;
 
-    var logger2 = bunyan.createLogger({ name: 'new-logger' });
+    const logger2 = bunyan.createLogger({ name: 'new-logger' });
     log.init({ logger: logger2 }, true);
 
     expect(reInitCalled).to.be.true;
@@ -152,15 +152,15 @@ describe('logger', function() {
     expect(logger.fields.name).to.equal('new-logger');
   });
 
-  it('should not choke on re-initialization when there is no reInit callback', function() {
+  it('should not choke on re-initialization when there is no reInit callback', () => {
     log.init({});
-    var logger = log.getLogger('myLogger');
+    const logger = log.getLogger('myLogger');
 
     // first getLogger call should yield the default bunyan logger
     expect(logger).to.be.an.instanceOf(bunyan);
     expect(logger.fields.name).to.equal('@instana/collector');
 
-    var logger2 = bunyan.createLogger({ name: 'new-logger' });
+    const logger2 = bunyan.createLogger({ name: 'new-logger' });
     log.init({ logger: logger2 });
   });
 });

--- a/packages/collector/test/metrics/app.js
+++ b/packages/collector/test/metrics/app.js
@@ -10,26 +10,24 @@ require('../../')({
   }
 });
 
-var express = require('express');
-var morgan = require('morgan');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
-app.get('/', function(req, res) {
-  return res.sendStatus(200);
-});
+app.get('/', (req, res) => res.sendStatus(200));
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/metrics/controls.js
+++ b/packages/collector/test/metrics/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../tracing/AbstractControls');
+const AbstractControls = require('../tracing/AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   opts.port = 3216;
   AbstractControls.call(this, opts);

--- a/packages/collector/test/metrics/healthchecks_test.js
+++ b/packages/collector/test/metrics/healthchecks_test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var expect = require('chai').expect;
-var semver = require('semver');
-var config = require('../config');
-var utils = require('../utils');
+const expect = require('chai').expect;
+const semver = require('semver');
+const config = require('../config');
+const utils = require('../utils');
 
 describe('metrics/healthchecks', function() {
   // admin uses JavaScript language features which aren't available in all
@@ -12,46 +12,38 @@ describe('metrics/healthchecks', function() {
     return;
   }
 
-  var agentStubControls = require('../apps/agentStubControls');
-  var expressControls = require('../apps/expressControls');
+  const agentStubControls = require('../apps/agentStubControls');
+  const expressControls = require('../apps/expressControls');
 
   this.timeout(config.getTestTimeout());
 
-  var start = new Date().getTime();
+  const start = new Date().getTime();
 
   agentStubControls.registerTestHooks();
   expressControls.registerTestHooks({
     enableTracing: false
   });
 
-  beforeEach(function() {
-    return agentStubControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid());
-  });
+  beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid()));
 
-  it('must report health status', function() {
-    var healthyTimestamp;
+  it('must report health status', () => {
+    let healthyTimestamp;
     return utils
-      .retry(function() {
-        return agentStubControls
-          .getLastMetricValue(expressControls.getPid(), ['healthchecks'])
-          .then(function(healthchecks) {
-            expect(healthchecks.configurable.healthy).to.equal(1);
-            expect(healthchecks.configurable.since).to.be.gte(start);
-            healthyTimestamp = healthchecks.configurable.since;
-          });
-      })
-      .then(function() {
-        return expressControls.setUnhealthy();
-      })
-      .then(function() {
-        return utils.retry(function() {
-          return agentStubControls
-            .getLastMetricValue(expressControls.getPid(), ['healthchecks'])
-            .then(function(healthchecks) {
-              expect(healthchecks.configurable.healthy).to.equal(0);
-              expect(healthchecks.configurable.since).to.be.gt(healthyTimestamp);
-            });
-        });
-      });
+      .retry(() =>
+        agentStubControls.getLastMetricValue(expressControls.getPid(), ['healthchecks']).then(healthchecks => {
+          expect(healthchecks.configurable.healthy).to.equal(1);
+          expect(healthchecks.configurable.since).to.be.gte(start);
+          healthyTimestamp = healthchecks.configurable.since;
+        })
+      )
+      .then(() => expressControls.setUnhealthy())
+      .then(() =>
+        utils.retry(() =>
+          agentStubControls.getLastMetricValue(expressControls.getPid(), ['healthchecks']).then(healthchecks => {
+            expect(healthchecks.configurable.healthy).to.equal(0);
+            expect(healthchecks.configurable.since).to.be.gt(healthyTimestamp);
+          })
+        )
+      );
   });
 });

--- a/packages/collector/test/metrics/test.js
+++ b/packages/collector/test/metrics/test.js
@@ -1,44 +1,41 @@
 'use strict';
 
-var expect = require('chai').expect;
-var _ = require('lodash');
+const expect = require('chai').expect;
+const _ = require('lodash');
 
-var config = require('../config');
-var utils = require('../utils');
+const config = require('../config');
+const utils = require('../utils');
 
 describe('metrics', function() {
   this.timeout(config.getTestTimeout());
 
-  var agentControls = require('../apps/agentStubControls');
-  var expressControls = require('../apps/expressControls');
+  const agentControls = require('../apps/agentStubControls');
+  const expressControls = require('../apps/expressControls');
 
   agentControls.registerTestHooks();
   expressControls.registerTestHooks({
     enableTracing: false
   });
 
-  beforeEach(function() {
-    return agentControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid());
-  });
+  beforeEach(() => agentControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid()));
 
-  it('must report metrics', function() {
-    return utils.retry(function() {
-      return agentControls.getAllMetrics(expressControls.getPid()).then(function(allMetrics) {
+  it('must report metrics', () =>
+    utils.retry(() =>
+      agentControls.getAllMetrics(expressControls.getPid()).then(allMetrics => {
         expect(findMetric(allMetrics, ['activeHandles'])).to.exist;
         expect(findMetric(allMetrics, ['gc', 'minorGcs'])).to.exist;
         expect(findMetric(allMetrics, ['gc', 'majorGcs'])).to.exist;
         expect(findMetric(allMetrics, ['healthchecks'])).to.exist;
         expect(findMetric(allMetrics, ['healthchecks'])).to.exist;
         expect(findMetric(allMetrics, ['versions'])).to.exist;
-        expect('v' + findMetric(allMetrics, ['versions', 'node'])).to.equal(process.version);
-      });
-    });
-  });
+        expect(`v${findMetric(allMetrics, ['versions', 'node'])}`).to.equal(process.version);
+      })
+    ));
 });
 
 function findMetric(allMetrics, _path) {
-  for (var i = allMetrics.length - 1; i >= 0; i--) {
-    var value = _.get(allMetrics[i], ['data'].concat(_path));
+  for (let i = allMetrics.length - 1; i >= 0; i--) {
+    const value = _.get(allMetrics[i], ['data'].concat(_path));
     if (value !== undefined) {
       return value;
     }

--- a/packages/collector/test/pidStore/pidStore_test.js
+++ b/packages/collector/test/pidStore/pidStore_test.js
@@ -2,17 +2,17 @@
 
 'use strict';
 
-var proxyquire = require('proxyquire');
-var expect = require('chai').expect;
-var sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const expect = require('chai').expect;
+const sinon = require('sinon');
 
-describe('pidStore', function() {
-  var pidStore;
-  var readFileSync;
+describe('pidStore', () => {
+  let pidStore;
+  let readFileSync;
 
-  var prevCiFlag;
+  let prevCiFlag;
 
-  beforeEach(function() {
+  beforeEach(() => {
     prevCiFlag = process.env.CONTINUOUS_INTEGRATION;
     delete process.env.CONTINUOUS_INTEGRATION;
 
@@ -21,14 +21,14 @@ describe('pidStore', function() {
     pidStore = null;
   });
 
-  afterEach(function() {
+  afterEach(() => {
     process.env.CONTINUOUS_INTEGRATION = prevCiFlag;
   });
 
   function doRequire() {
     pidStore = proxyquire('../../src/pidStore', {
       fs: {
-        readFileSync: readFileSync
+        readFileSync
       },
       './internalPidStore': {
         pid: process.pid
@@ -36,31 +36,31 @@ describe('pidStore', function() {
     });
   }
 
-  it('should by default return the process pid', function() {
+  it('should by default return the process pid', () => {
     doRequire();
     expect(pidStore.pid).to.equal(process.pid);
   });
 
-  it('should allow changing the pid', function() {
+  it('should allow changing the pid', () => {
     doRequire();
-    var newPid = 42;
+    const newPid = 42;
     pidStore.pid = newPid;
     expect(pidStore.pid).to.equal(newPid);
   });
 
-  it('should provide means to observe pid changes', function() {
+  it('should provide means to observe pid changes', () => {
     doRequire();
-    var observer = sinon.stub();
+    const observer = sinon.stub();
     pidStore.onPidChange(observer);
 
-    var newPid = 512;
+    const newPid = 512;
     pidStore.pid = newPid;
 
     expect(observer.callCount).to.equal(1);
     expect(observer.getCall(0).args[0]).to.equal(newPid);
   });
 
-  it('should use the PID from the parent namespace when found', function() {
+  it('should use the PID from the parent namespace when found', () => {
     readFileSync.returns(
       'node (15926, #threads: 10)\n-------------------------------------------------------------------\n' +
         'se.exec_start                                :    1093303068.953905'
@@ -69,7 +69,7 @@ describe('pidStore', function() {
     expect(pidStore.pid).to.equal(15926);
   });
 
-  it('should not rely on specific command name', function() {
+  it('should not rely on specific command name', () => {
     readFileSync.returns(
       'ddasdasd\nsyslog-ng (19841, #threads: 1)\n' +
         '-------------------------------------------------------------------\n' +
@@ -79,7 +79,7 @@ describe('pidStore', function() {
     expect(pidStore.pid).to.equal(19841);
   });
 
-  it('should accept wider range of command names', function() {
+  it('should accept wider range of command names', () => {
     readFileSync.returns(
       'ui-client.sh (105065, #threads: 1)\n' +
         '-------------------------------------------------------------------\n' +
@@ -89,13 +89,13 @@ describe('pidStore', function() {
     expect(pidStore.pid).to.equal(105065);
   });
 
-  it('should not rely on specific command name', function() {
+  it('should not rely on specific command name', () => {
     readFileSync.returns('ddasdasd\n_-0918log-ng (1941, #threads: 1)\n§"!?=joidsajio90\n312903i .-.d-"');
     doRequire();
     expect(pidStore.pid).to.equal(1941);
   });
 
-  it('should not fail when the sched file does not contain a parseable parent PID header', function() {
+  it('should not fail when the sched file does not contain a parseable parent PID header', () => {
     readFileSync.returns('something which we cannot parse');
     doRequire();
     expect(pidStore.pid).to.equal(process.pid);

--- a/packages/collector/test/setLogger_test.js
+++ b/packages/collector/test/setLogger_test.js
@@ -2,49 +2,50 @@
 
 'use strict';
 
-var fs = require('fs');
-var os = require('os');
-var path = require('path');
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
 
-var config = require('./config');
-var utils = require('./utils');
+const config = require('./config');
+const utils = require('./utils');
 
 describe('setLogger', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentStubControls = require('./apps/agentStubControls');
-  var expressControls = require('./apps/expressControls');
+  const agentStubControls = require('./apps/agentStubControls');
+  const expressControls = require('./apps/expressControls');
 
   this.timeout(config.getTestTimeout());
 
   agentStubControls.registerTestHooks();
   expressControls.registerTestHooks();
 
-  var dummyLogFile = path.join(os.tmpdir(), 'instana-nodejs-dummy-test.log');
+  const dummyLogFile = path.join(os.tmpdir(), 'instana-nodejs-dummy-test.log');
 
-  afterEach(function() {
+  afterEach(() => {
     fs.unlinkSync(dummyLogFile);
   });
 
-  it('must reinitialize all loggers on setLogger', function() {
+  it('must reinitialize all loggers on setLogger', () => {
     expressControls.setLogger(false, dummyLogFile);
-    return utils.retry(function() {
-      return new Promise(function(resolve, reject) {
-        fs.readFile(dummyLogFile, 'utf-8', function(err, data) {
-          if (err) {
-            return reject(err);
-          }
-          // wait for arbitrary number of characters to be written
-          if (data.length > 50) {
-            resolve(data);
-          } else {
-            reject(new Error('Did not log enough: ' + data));
-          }
-        });
-      });
-    });
+    return utils.retry(
+      () =>
+        new Promise((resolve, reject) => {
+          fs.readFile(dummyLogFile, 'utf-8', (err, data) => {
+            if (err) {
+              return reject(err);
+            }
+            // wait for arbitrary number of characters to be written
+            if (data.length > 50) {
+              resolve(data);
+            } else {
+              reject(new Error(`Did not log enough: ${data}`));
+            }
+          });
+        })
+    );
   });
 });

--- a/packages/collector/test/test_util/delay.js
+++ b/packages/collector/test/test_util/delay.js
@@ -6,7 +6,7 @@
  * A simple delay based on native promises.
  */
 module.exports = exports = function delay(ms) {
-  return new Promise(function(resolve) {
+  return new Promise(resolve => {
     setTimeout(resolve, ms);
   });
 };

--- a/packages/collector/test/tracing/AbstractControls.js
+++ b/packages/collector/test/tracing/AbstractControls.js
@@ -3,21 +3,21 @@
 
 'use strict';
 
-var fork = require('child_process').fork;
-var request = require('request-promise');
-var _ = require('lodash');
+const fork = require('child_process').fork;
+const request = require('request-promise');
+const _ = require('lodash');
 
-var agentPort = require('../apps/agentStubControls').agentPort;
-var config = require('../config');
-var utils = require('../utils');
+const agentPort = require('../apps/agentStubControls').agentPort;
+const config = require('../config');
+const utils = require('../utils');
 
-var AbstractControls = (module.exports = function AbstractControls(opts) {
+const AbstractControls = (module.exports = function AbstractControls(opts) {
   // absolute path to .js file that should be executed
   this.appPath = opts.appPath;
   this.port = opts.port || process.env.APP_PORT || 3215;
   this.tracingEnabled = opts.tracingEnabled !== false;
   this.useHttps = opts.env && !!opts.env.USE_HTTPS;
-  this.baseUrl = (this.useHttps ? 'https' : 'http') + '://127.0.0.1:' + this.port;
+  this.baseUrl = `${this.useHttps ? 'https' : 'http'}://127.0.0.1:${this.port}`;
   // optional agent controls which will result in a beforeEach call which ensures that the
   // collector is successfully connected to the agent.
   this.agentControls = opts.agentControls;
@@ -35,29 +35,23 @@ var AbstractControls = (module.exports = function AbstractControls(opts) {
 });
 
 AbstractControls.prototype.registerTestHooks = function registerTestHooks() {
-  beforeEach(
-    function() {
-      var that = this;
-      this.receivedIpcMessages = [];
+  beforeEach(() => {
+    const that = this;
+    this.receivedIpcMessages = [];
 
-      this.process = fork(this.appPath, {
-        stdio: config.getAppStdio(),
-        env: this.env
-      });
+    this.process = fork(this.appPath, {
+      stdio: config.getAppStdio(),
+      env: this.env
+    });
 
-      this.process.on('message', function(message) {
-        that.receivedIpcMessages.push(message);
-      });
-      return this.waitUntilServerIsUp();
-    }.bind(this)
-  );
+    this.process.on('message', message => {
+      that.receivedIpcMessages.push(message);
+    });
+    return this.waitUntilServerIsUp();
+  });
 
   if (this.agentControls) {
-    beforeEach(
-      function() {
-        return this.agentControls.waitUntilAppIsCompletelyInitialized(this.getPid());
-      }.bind(this)
-    );
+    beforeEach(() => this.agentControls.waitUntilAppIsCompletelyInitialized(this.getPid()));
   }
 
   afterEach(this.kill.bind(this));
@@ -67,26 +61,22 @@ AbstractControls.prototype.kill = function kill() {
   if (this.process.killed || this.dontKillInAfterHook) {
     return Promise.resolve();
   }
-  return new Promise(
-    function(resolve) {
-      this.process.once('exit', resolve);
-      this.process.kill();
-    }.bind(this)
-  );
+  return new Promise(resolve => {
+    this.process.once('exit', resolve);
+    this.process.kill();
+  });
 };
 
 AbstractControls.prototype.waitUntilServerIsUp = function waitUntilServerIsUp() {
-  return utils.retry(
-    function() {
-      return request({
-        method: 'GET',
-        url: this.baseUrl,
-        headers: {
-          'X-INSTANA-L': '0'
-        },
-        strictSSL: false
-      });
-    }.bind(this)
+  return utils.retry(() =>
+    request({
+      method: 'GET',
+      url: this.baseUrl,
+      headers: {
+        'X-INSTANA-L': '0'
+      },
+      strictSSL: false
+    })
   );
 };
 
@@ -95,7 +85,7 @@ AbstractControls.prototype.getPid = function getPid() {
 };
 
 AbstractControls.prototype.sendRequest = function(opts) {
-  var headers = opts.headers || {};
+  const headers = opts.headers || {};
   if (opts.suppressTracing === true) {
     headers['X-INSTANA-L'] = '0';
   }
@@ -105,7 +95,7 @@ AbstractControls.prototype.sendRequest = function(opts) {
     url: this.baseUrl + opts.path,
     json: true,
     body: opts.body,
-    headers: headers,
+    headers,
     qs: opts.qs,
     simple: opts.simple,
     resolveWithFullResponse: opts.resolveWithFullResponse,

--- a/packages/collector/test/tracing/api/app.js
+++ b/packages/collector/test/tracing/api/app.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var instana = require('../../../')({
+const instana = require('../../../')({
   agentPort: process.env.AGENT_PORT,
   level: 'warn',
   tracing: {
@@ -11,32 +11,32 @@ var instana = require('../../../')({
   }
 });
 
-var express = require('express');
-var morgan = require('morgan');
-var bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
+const bodyParser = require('body-parser');
 
-var app = express();
-var logPrefix = 'API: Server (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `API: Server (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/span/active', function(req, res) {
-  var span = instana.currentSpan();
+app.get('/span/active', (req, res) => {
+  const span = instana.currentSpan();
   res.json({
     span: serialize(span)
   });
 });
 
-app.get('/span/manuallyended', function(req, res) {
-  var span = instana.currentSpan();
+app.get('/span/manuallyended', (req, res) => {
+  const span = instana.currentSpan();
   span.disableAutoEnd();
   span.end(42);
   res.json({
@@ -44,8 +44,8 @@ app.get('/span/manuallyended', function(req, res) {
   });
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function serialize(span) {
@@ -65,7 +65,7 @@ function serialize(span) {
 }
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/api/controls.js
+++ b/packages/collector/test/tracing/api/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../AbstractControls');
+const AbstractControls = require('../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/api/test.js
+++ b/packages/collector/test/tracing/api/test.js
@@ -1,37 +1,37 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../config');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../config');
 
 describe('tracing/api', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../../apps/agentStubControls');
-  var Controls = require('./controls');
+  const agentControls = require('../../apps/agentStubControls');
+  const Controls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  describe('when tracing is enabled', function() {
-    var controls = new Controls({
-      agentControls: agentControls
+  describe('when tracing is enabled', () => {
+    const controls = new Controls({
+      agentControls
     });
     controls.registerTestHooks();
 
-    it('must provide details for currently active span', function() {
-      var now = Date.now();
+    it('must provide details for currently active span', () => {
+      const now = Date.now();
       return controls
         .sendRequest({
           method: 'GET',
           path: '/span/active'
         })
-        .then(function(response) {
-          var span = response.span;
+        .then(response => {
+          const span = response.span;
           expect(span).to.exist;
           expect(span.traceId).to.be.not.null;
           expect(span.spanId).to.be.not.null;
@@ -49,15 +49,15 @@ describe('tracing/api', function() {
         });
     });
 
-    it('must manually end the currently active span', function() {
-      var now = Date.now();
+    it('must manually end the currently active span', () => {
+      const now = Date.now();
       return controls
         .sendRequest({
           method: 'GET',
           path: '/span/manuallyended'
         })
-        .then(function(response) {
-          var span = response.span;
+        .then(response => {
+          const span = response.span;
           expect(span).to.exist;
           expect(span.traceId).to.be.not.null;
           expect(span.spanId).to.be.not.null;
@@ -75,21 +75,21 @@ describe('tracing/api', function() {
     });
   });
 
-  describe('when tracing is not enabled', function() {
-    var controls = new Controls({
-      agentControls: agentControls,
+  describe('when tracing is not enabled', () => {
+    const controls = new Controls({
+      agentControls,
       tracingEnabled: false
     });
     controls.registerTestHooks();
 
-    it('must provide a noop span handle', function() {
-      return controls
+    it('must provide a noop span handle', () =>
+      controls
         .sendRequest({
           method: 'GET',
           path: '/span/active'
         })
-        .then(function(response) {
-          var span = response.span;
+        .then(response => {
+          const span = response.span;
           expect(span).to.exist;
           expect(span.traceId).to.be.null;
           expect(span.spanId).to.be.null;
@@ -102,17 +102,16 @@ describe('tracing/api', function() {
           expect(span.duration).to.equal(0);
           expect(span.errorCount).to.equal(0);
           expect(span.handleConstructorName).to.equal('NoopSpanHandle');
-        });
-    });
+        }));
 
-    it('must do nothing when trying to manually end the currently active span', function() {
-      return controls
+    it('must do nothing when trying to manually end the currently active span', () =>
+      controls
         .sendRequest({
           method: 'GET',
           path: '/span/manuallyended'
         })
-        .then(function(response) {
-          var span = response.span;
+        .then(response => {
+          const span = response.span;
           expect(span).to.exist;
           expect(span.traceId).to.be.null;
           expect(span.spanId).to.be.null;
@@ -125,7 +124,6 @@ describe('tracing/api', function() {
           expect(span.duration).to.equal(0);
           expect(span.errorCount).to.equal(0);
           expect(span.handleConstructorName).to.equal('NoopSpanHandle');
-        });
-    });
+        }));
   });
 });

--- a/packages/collector/test/tracing/control_flow/async_await/app.js
+++ b/packages/collector/test/tracing/control_flow/async_await/app.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 
+'use strict';
+
 const rp = require('request-promise');
 const request = require('request');
 
@@ -20,9 +22,7 @@ app.get('/', (req, res) => res.sendStatus(200));
 // simulating async middleware
 app.use((req, res, next) => setTimeout(() => next(), 50));
 
-const asyncHandler = fn => (req, res, next) => {
-  return Promise.resolve(fn(req, res, next)).catch(next);
-};
+const asyncHandler = fn => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
 
 app.get(
   '/getSomething',
@@ -40,12 +40,12 @@ app.get(
 async function executeCallSequence() {
   const { statusCode } = await sendRequest({
     method: 'GET',
-    uri: 'http://127.0.0.1:' + process.env.UPSTREAM_PORT + '/foo'
+    uri: `http://127.0.0.1:${process.env.UPSTREAM_PORT}/foo`
   });
 
   const { statusCode: statusCode2 } = await sendRequest({
     method: 'GET',
-    uri: 'http://127.0.0.1:' + process.env.UPSTREAM_PORT + '/bar',
+    uri: `http://127.0.0.1:${process.env.UPSTREAM_PORT}/bar`,
     query: {
       foo: statusCode
     }
@@ -82,12 +82,12 @@ async function sendRequest(requestOptions) {
   return response;
 }
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
   const args = Array.prototype.slice.call(arguments);
-  args[0] = 'Express Async Await App (' + process.pid + '):\t' + args[0];
+  args[0] = `Express Async Await App (${process.pid}):\t${args[0]}`;
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/control_flow/async_await/controls.js
+++ b/packages/collector/test/tracing/control_flow/async_await/controls.js
@@ -2,22 +2,22 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../../../utils');
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
-var appPort = (exports.appPort = 3217);
+const utils = require('../../../utils');
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
+const appPort = (exports.appPort = 3217);
 
-var expressApp;
+let expressApp;
 
-exports.registerTestHooks = function(opts) {
-  beforeEach(function() {
+exports.registerTestHooks = opts => {
+  beforeEach(() => {
     opts = opts || {};
 
-    var env = Object.create(process.env);
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.UPSTREAM_PORT = opts.upstreamPort;
@@ -25,37 +25,34 @@ exports.registerTestHooks = function(opts) {
 
     expressApp = spawn('node', [path.join(__dirname, 'app.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     expressApp.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return expressApp.pid;
-};
+exports.getPid = () => expressApp.pid;
 
-exports.sendRequest = function() {
-  return request({
+exports.sendRequest = () =>
+  request({
     method: 'GET',
-    url: 'http://127.0.0.1:' + appPort + '/getSomething',
+    url: `http://127.0.0.1:${appPort}/getSomething`,
     resolveWithFullResponse: true
   });
-};

--- a/packages/collector/test/tracing/control_flow/bluebird/app.js
+++ b/packages/collector/test/tracing/control_flow/bluebird/app.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-var instana = require('../../../../');
+const instana = require('../../../../');
 instana({
   agentPort: process.env.AGENT_PORT,
   level: 'warn',
@@ -12,84 +12,76 @@ instana({
   }
 });
 
-var request = require('request-promise');
-var bodyParser = require('body-parser');
-var EventEmitter = require('events');
-var Promise = require('bluebird');
-var express = require('express');
-var morgan = require('morgan');
+const request = require('request-promise');
+const bodyParser = require('body-parser');
+const EventEmitter = require('events');
+const Promise = require('bluebird');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express / bluebird App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express / bluebird App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/delayed', function(req, res) {
+app.get('/delayed', (req, res) => {
   Promise.delay(50).then(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/childPromise', function(req, res) {
+app.get('/childPromise', (req, res) => {
   Promise.delay(50)
-    .then(function() {
-      return Promise.delay(20);
-    })
+    .then(() => Promise.delay(20))
     .then(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/childPromiseWithChildSend', function(req, res) {
-  Promise.delay(50).then(function() {
-    return Promise.delay(20).then(sendActiveTraceContext.bind(null, res));
-  });
+app.get('/childPromiseWithChildSend', (req, res) => {
+  Promise.delay(50).then(() => Promise.delay(20).then(sendActiveTraceContext.bind(null, res)));
 });
 
-app.get('/combined', function(req, res) {
+app.get('/combined', (req, res) => {
   Promise.all([Promise.delay(50), Promise.delay(40)]).then(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/rejected', function(req, res) {
+app.get('/rejected', (req, res) => {
   Promise.all([Promise.delay(50), Promise.reject(new Error('bad timing'))]).catch(
     sendActiveTraceContext.bind(null, res)
   );
 });
 
-app.get('/childHttpCall', function(req, res) {
+app.get('/childHttpCall', (req, res) => {
   request('http://127.0.0.1:65212')
-    .catch(function() {
-      return Promise.delay(20);
-    })
-    .then(function() {
+    .catch(() => Promise.delay(20))
+    .then(() => {
       sendActiveTraceContext(res);
     });
 });
 
-app.get('/rejected', function(req, res) {
+app.get('/rejected', (req, res) => {
   Promise.all([Promise.delay(50), Promise.reject(new Error('bad timing'))]).catch(
     sendActiveTraceContext.bind(null, res)
   );
 });
 
-app.get('/map', function(req, res) {
-  Promise.map([Promise.delay(20), Promise.resolve(42)], function(v) {
-    return v * 2;
-  }).then(sendActiveTraceContext.bind(null, res));
+app.get('/map', (req, res) => {
+  Promise.map([Promise.delay(20), Promise.resolve(42)], v => v * 2).then(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/eventEmitterBased', function(req, res) {
-  var emitter = new EventEmitter();
+app.get('/eventEmitterBased', (req, res) => {
+  const emitter = new EventEmitter();
 
-  new Promise(function(resolve) {
-    emitter.on('a', function(value) {
+  new Promise(resolve => {
+    emitter.on('a', value => {
       resolve(value);
     });
-  }).then(function() {
+  }).then(() => {
     sendActiveTraceContext(res);
   });
 
@@ -100,12 +92,12 @@ function sendActiveTraceContext(res) {
   res.json(instana.opentracing.getCurrentlyActiveInstanaSpanContext());
 }
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/control_flow/bluebird/controls.js
+++ b/packages/collector/test/tracing/control_flow/bluebird/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/control_flow/bluebird/test.js
+++ b/packages/collector/test/tracing/control_flow/bluebird/test.js
@@ -2,27 +2,27 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/bluebird', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../../../apps/agentStubControls');
-  var BluebirdControls = require('./controls');
+  const agentControls = require('../../../apps/agentStubControls');
+  const BluebirdControls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var bluebirdControls = new BluebirdControls({
-    agentControls: agentControls
+  const bluebirdControls = new BluebirdControls({
+    agentControls
   });
   bluebirdControls.registerTestHooks();
 
@@ -38,52 +38,47 @@ describe('tracing/bluebird', function() {
   function check(path, checker) {
     checker = checker || defaultChecker;
 
-    it('must trace: ' + path, function() {
+    it(`must trace: ${path}`, () =>
       // trigger tracing
-      return (
-        bluebirdControls
-          .sendRequest({
-            method: 'GET',
-            path: path
-          })
+      bluebirdControls
+        .sendRequest({
+          method: 'GET',
+          path
+        })
 
-          // validate the data
-          .then(function(spanContext) {
-            return (
-              utils
-                .retry(function() {
-                  return agentControls.getSpans().then(function(spans) {
-                    checker(spanContext, spans, path);
-                  });
-                })
+        // validate the data
+        .then(spanContext =>
+          utils
+            .retry(() =>
+              agentControls.getSpans().then(spans => {
+                checker(spanContext, spans, path);
+              })
+            )
 
-                // actionable error reporting
-                .catch(function(error) {
-                  return agentControls.getSpans().then(function(spans) {
-                    // eslint-disable-next-line no-console
-                    console.error(
-                      'Span context %s does not match expectation.\n\nError: %s\n\nSpans: %s',
-                      JSON.stringify(spanContext, 0, 2),
-                      error,
-                      JSON.stringify(spans, 0, 2)
-                    );
-                    return Promise.reject(error);
-                  });
-                })
-            );
-          })
-      );
-    });
+            // actionable error reporting
+            .catch(error =>
+              agentControls.getSpans().then(spans => {
+                // eslint-disable-next-line no-console
+                console.error(
+                  'Span context %s does not match expectation.\n\nError: %s\n\nSpans: %s',
+                  JSON.stringify(spanContext, 0, 2),
+                  error,
+                  JSON.stringify(spans, 0, 2)
+                );
+                return Promise.reject(error);
+              })
+            )
+        ));
   }
 
   function defaultChecker(spanContext, spans, path) {
-    var entrySpan = getEntrySpans(spans, path);
+    const entrySpan = getEntrySpans(spans, path);
     expect(spanContext.t).to.equal(entrySpan.t);
     expect(spanContext.s).to.equal(entrySpan.s);
   }
 
   function getEntrySpans(spans, path) {
-    return utils.expectOneMatching(spans, function(span) {
+    return utils.expectOneMatching(spans, span => {
       expect(span.p).to.equal(undefined);
       expect(span.n).to.equal('node.http.server');
       expect(span.k).to.equal(constants.ENTRY);

--- a/packages/collector/test/tracing/control_flow/native_promise/app.js
+++ b/packages/collector/test/tracing/control_flow/native_promise/app.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-var instana = require('../../../../');
+const instana = require('../../../../');
 instana({
   agentPort: process.env.AGENT_PORT,
   level: 'warn',
@@ -12,54 +12,50 @@ instana({
   }
 });
 
-var request = require('request');
-var bodyParser = require('body-parser');
-var EventEmitter = require('events');
-var express = require('express');
-var morgan = require('morgan');
+const request = require('request');
+const bodyParser = require('body-parser');
+const EventEmitter = require('events');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express app with native promises (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express app with native promises (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/delayed', function(req, res) {
+app.get('/delayed', (req, res) => {
   delay(50).then(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/childPromise', function(req, res) {
+app.get('/childPromise', (req, res) => {
   delay(50)
-    .then(function() {
-      return delay(20);
-    })
+    .then(() => delay(20))
     .then(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/childPromiseWithChildSend', function(req, res) {
-  delay(50).then(function() {
-    return delay(20).then(sendActiveTraceContext.bind(null, res));
-  });
+app.get('/childPromiseWithChildSend', (req, res) => {
+  delay(50).then(() => delay(20).then(sendActiveTraceContext.bind(null, res)));
 });
 
-app.get('/combined', function(req, res) {
+app.get('/combined', (req, res) => {
   Promise.all([delay(50), delay(40)]).then(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/rejected', function(req, res) {
+app.get('/rejected', (req, res) => {
   Promise.all([delay(50), Promise.reject(new Error('bad timing'))]).catch(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/childHttpCall', function(req, res) {
-  new Promise(function(resolve, reject) {
-    request('http://127.0.0.1:65212', function(err, response) {
+app.get('/childHttpCall', (req, res) => {
+  new Promise((resolve, reject) => {
+    request('http://127.0.0.1:65212', (err, response) => {
       if (err) {
         reject(err);
       } else {
@@ -67,26 +63,24 @@ app.get('/childHttpCall', function(req, res) {
       }
     });
   })
-    .catch(function() {
-      return delay(20);
-    })
-    .then(function() {
+    .catch(() => delay(20))
+    .then(() => {
       sendActiveTraceContext(res);
     });
 });
 
-app.get('/rejected', function(req, res) {
+app.get('/rejected', (req, res) => {
   Promise.all([delay(50), Promise.reject(new Error('bad timing'))]).catch(sendActiveTraceContext.bind(null, res));
 });
 
-app.get('/eventEmitterBased', function(req, res) {
-  var emitter = new EventEmitter();
+app.get('/eventEmitterBased', (req, res) => {
+  const emitter = new EventEmitter();
 
-  new Promise(function(resolve) {
-    emitter.on('a', function(value) {
+  new Promise(resolve => {
+    emitter.on('a', value => {
       resolve(value);
     });
-  }).then(function() {
+  }).then(() => {
     sendActiveTraceContext(res);
   });
 
@@ -97,19 +91,19 @@ function sendActiveTraceContext(res) {
   res.json(instana.opentracing.getCurrentlyActiveInstanaSpanContext());
 }
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }
 
 function delay(ms) {
-  return new Promise(function(resolve) {
-    setTimeout(function() {
+  return new Promise(resolve => {
+    setTimeout(() => {
       resolve();
     }, ms);
   });

--- a/packages/collector/test/tracing/control_flow/native_promise/controls.js
+++ b/packages/collector/test/tracing/control_flow/native_promise/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/control_flow/native_promise/test.js
+++ b/packages/collector/test/tracing/control_flow/native_promise/test.js
@@ -2,27 +2,27 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/native-promise', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../../../apps/agentStubControls');
-  var NativePromiseControls = require('./controls');
+  const agentControls = require('../../../apps/agentStubControls');
+  const NativePromiseControls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var promiseControls = new NativePromiseControls({
-    agentControls: agentControls
+  const promiseControls = new NativePromiseControls({
+    agentControls
   });
   promiseControls.registerTestHooks();
 
@@ -37,52 +37,47 @@ describe('tracing/native-promise', function() {
   function check(path, checker) {
     checker = checker || defaultChecker;
 
-    it('must trace: ' + path, function() {
+    it(`must trace: ${path}`, () =>
       // trigger tracing
-      return (
-        promiseControls
-          .sendRequest({
-            method: 'GET',
-            path: path
-          })
+      promiseControls
+        .sendRequest({
+          method: 'GET',
+          path
+        })
 
-          // validate the data
-          .then(function(spanContext) {
-            return (
-              utils
-                .retry(function() {
-                  return agentControls.getSpans().then(function(spans) {
-                    checker(spanContext, spans, path);
-                  });
-                })
+        // validate the data
+        .then(spanContext =>
+          utils
+            .retry(() =>
+              agentControls.getSpans().then(spans => {
+                checker(spanContext, spans, path);
+              })
+            )
 
-                // actionable error reporting
-                .catch(function(error) {
-                  return agentControls.getSpans().then(function(spans) {
-                    // eslint-disable-next-line no-console
-                    console.error(
-                      'Span context %s does not match expectation.\n\nError: %s\n\nSpans: %s',
-                      JSON.stringify(spanContext, 0, 2),
-                      error,
-                      JSON.stringify(spans, 0, 2)
-                    );
-                    return Promise.reject(error);
-                  });
-                })
-            );
-          })
-      );
-    });
+            // actionable error reporting
+            .catch(error =>
+              agentControls.getSpans().then(spans => {
+                // eslint-disable-next-line no-console
+                console.error(
+                  'Span context %s does not match expectation.\n\nError: %s\n\nSpans: %s',
+                  JSON.stringify(spanContext, 0, 2),
+                  error,
+                  JSON.stringify(spans, 0, 2)
+                );
+                return Promise.reject(error);
+              })
+            )
+        ));
   }
 
   function defaultChecker(spanContext, spans, path) {
-    var entrySpan = getEntySpan(spans, path);
+    const entrySpan = getEntySpan(spans, path);
     expect(spanContext.t).to.equal(entrySpan.t);
     expect(spanContext.s).to.equal(entrySpan.s);
   }
 
   function getEntySpan(spans, path) {
-    return utils.expectOneMatching(spans, function(span) {
+    return utils.expectOneMatching(spans, span => {
       expect(span.p).to.equal(undefined);
       expect(span.n).to.equal('node.http.server');
       expect(span.k).to.equal(constants.ENTRY);

--- a/packages/collector/test/tracing/database/elasticsearch/app.js
+++ b/packages/collector/test/tracing/database/elasticsearch/app.js
@@ -11,31 +11,31 @@ require('../../../../')({
   }
 });
 
-var elasticsearch = require('elasticsearch');
-var bodyParser = require('body-parser');
-var request = require('request-promise-native');
-var express = require('express');
-var app = express();
+const elasticsearch = require('elasticsearch');
+const bodyParser = require('body-parser');
+const request = require('request-promise-native');
+const express = require('express');
+const app = express();
 
 app.use(bodyParser.json());
 
-var client = new elasticsearch.Client({
+const client = new elasticsearch.Client({
   host: process.env.ELASTICSEARCH,
   log: 'info'
 });
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/get', function(req, res) {
+app.get('/get', (req, res) => {
   client.get(
     {
       index: req.query.index || 'myindex',
       type: 'mytype',
       id: req.query.id
     },
-    function(error, response) {
+    (error, response) => {
       if (error) {
         res.status(500).json(error);
       } else {
@@ -45,7 +45,7 @@ app.get('/get', function(req, res) {
   );
 });
 
-app.get('/search', function(req, res) {
+app.get('/search', (req, res) => {
   client
     .search({
       index: req.query.index || 'myindex',
@@ -53,17 +53,17 @@ app.get('/search', function(req, res) {
       q: req.query.q
     })
     .then(
-      function(response) {
+      response => {
         res.json(response);
       },
-      function(error) {
+      error => {
         res.status(500).json(error);
       }
     );
 });
 
-app.get('/mget1', function(req, res) {
-  var ids = req.query.id;
+app.get('/mget1', (req, res) => {
+  const ids = req.query.id;
   if (!Array.isArray(ids) || ids.length < 2) {
     return res.status(400).json({ error: 'You need to provide an array of at least two document IDs.' });
   }
@@ -76,7 +76,7 @@ app.get('/mget1', function(req, res) {
         ]
       }
     },
-    function(error, response) {
+    (error, response) => {
       if (error) {
         res.status(500).json(error);
       } else {
@@ -86,8 +86,8 @@ app.get('/mget1', function(req, res) {
   );
 });
 
-app.get('/mget2', function(req, res) {
-  var ids = req.query.id;
+app.get('/mget2', (req, res) => {
+  const ids = req.query.id;
   if (!Array.isArray(ids) || ids.length < 2) {
     return res.status(400).json({ error: 'You need to provide an array of at least two document IDs.' });
   }
@@ -96,10 +96,10 @@ app.get('/mget2', function(req, res) {
       index: req.query.index || 'myindex',
       type: 'mytype',
       body: {
-        ids: ids
+        ids
       }
     },
-    function(error, response) {
+    (error, response) => {
       if (error) {
         res.status(500).json(error);
       } else {
@@ -109,12 +109,12 @@ app.get('/mget2', function(req, res) {
   );
 });
 
-app.get('/msearch', function(req, res) {
-  var queryStrings = req.query.q;
+app.get('/msearch', (req, res) => {
+  const queryStrings = req.query.q;
   if (!Array.isArray(queryStrings) || queryStrings.length < 2) {
     return res.status(400).json({ error: 'You need to provide an array of at least two query params' });
   }
-  var query = {
+  const query = {
     body: [
       { index: req.query.index || 'myindex', type: 'mytype' },
       { query: { query_string: { query: req.query.q[0] } } },
@@ -123,77 +123,75 @@ app.get('/msearch', function(req, res) {
     ]
   };
   client.msearch(query).then(
-    function(response) {
+    response => {
       res.json(response);
     },
-    function(error) {
+    error => {
       res.status(500).json(error);
     }
   );
 });
 
-app.post('/index', function(req, res) {
+app.post('/index', (req, res) => {
   client
     .index({
       index: req.query.index || 'myindex',
       type: 'mytype',
       body: req.body
     })
-    .then(function(response) {
-      return client.indices
+    .then(response =>
+      client.indices
         .refresh({
           index: '_all',
           ignoreUnavailable: true,
           force: true
         })
         .then(
-          function() {
-            return response;
-          },
-          function(error) {
+          () => response,
+          error => {
             log('Index refresh failed.', error);
             throw error;
           }
-        );
-    })
+        )
+    )
     .then(
-      function(response) {
+      response => {
         res.json(response);
       },
-      function(error) {
+      error => {
         log('Sending indexing error.', error);
         res.status(500).json(error);
       }
     );
 });
 
-app.get('/searchAndGet', function(req, res) {
+app.get('/searchAndGet', (req, res) => {
   request({
     method: 'GET',
     url: 'http://google.com'
   })
-    .then(function() {
-      return client.search({
+    .then(() =>
+      client.search({
         index: req.query.index || 'myindex',
         type: 'mytype',
         q: req.query.q,
         ignoreUnavailable: true
-      });
-    })
-    .then(function(response) {
+      })
+    )
+    .then(response => {
       res.json(response);
     })
-    .catch(function(error) {
+    .catch(error => {
       res.status(500).json(error);
     });
 });
 
-app.delete('/database', function(req, res) {
+app.delete('/database', (req, res) => {
   client.indices
     .exists({
       index: req.query.index || 'myindex'
     })
-    .then(function(response) {
+    .then(response => {
       if (response === false) {
         return response;
       }
@@ -202,20 +200,20 @@ app.delete('/database', function(req, res) {
         index: req.query.index || 'myindex'
       });
     })
-    .then(function(response) {
+    .then(response => {
       res.json(response);
     })
-    .catch(function(error) {
+    .catch(error => {
       res.status(500).json(error);
     });
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
-  args[0] = 'Express / Elasticsearch (' + process.pid + '):\t' + args[0];
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `Express / Elasticsearch (${process.pid}):\t${args[0]}`;
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/database/ioredis/controls.js
+++ b/packages/collector/test/tracing/database/ioredis/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/database/mongoose/app.js
+++ b/packages/collector/test/tracing/database/mongoose/app.js
@@ -10,14 +10,14 @@ require('../../../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var mongoose = require('mongoose');
-var express = require('express');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const mongoose = require('mongoose');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express / Mongoose App (' + process.pid + '):\t';
-var connectedToMongo = false;
+const app = express();
+const logPrefix = `Express / Mongoose App (${process.pid}):\t`;
+let connectedToMongo = false;
 
 mongoose.Promise = global.Promise;
 
@@ -28,9 +28,9 @@ mongoose.model(
     age: Number
   })
 );
-var Person = mongoose.model('Person');
+const Person = mongoose.model('Person');
 
-mongoose.connect('mongodb://' + process.env.MONGODB + '/mongoose', function(err) {
+mongoose.connect(`mongodb://${process.env.MONGODB}/mongoose`, err => {
   if (err) {
     log('Failed to connect to Mongodb', err);
     process.exit(1);
@@ -39,12 +39,12 @@ mongoose.connect('mongodb://' + process.env.MONGODB + '/mongoose', function(err)
 });
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   if (!connectedToMongo) {
     res.sendStatus(500);
   } else {
@@ -52,35 +52,35 @@ app.get('/', function(req, res) {
   }
 });
 
-app.post('/insert', function(req, res) {
+app.post('/insert', (req, res) => {
   Person.create(req.body)
-    .then(function(r) {
+    .then(r => {
       res.json(r);
     })
-    .catch(function(e) {
+    .catch(e => {
       log('Failed to write document', e);
       res.sendStatus(500);
     });
 });
 
-app.post('/find', function(req, res) {
+app.post('/find', (req, res) => {
   Person.findOne(req.body)
     .exec()
-    .then(function(r) {
+    .then(r => {
       res.json(r);
     })
-    .catch(function(e) {
+    .catch(e => {
       log('Failed to find document', e);
       res.sendStatus(500);
     });
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/database/mongoose/controls.js
+++ b/packages/collector/test/tracing/database/mongoose/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/database/mongoose/test.js
+++ b/packages/collector/test/tracing/database/mongoose/test.js
@@ -1,32 +1,32 @@
 'use strict';
 
-var expect = require('chai').expect;
-var uuid = require('uuid/v4');
+const expect = require('chai').expect;
+const uuid = require('uuid/v4');
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/mongoose', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../../../apps/agentStubControls');
-  var MongooseControls = require('./controls');
+  const agentControls = require('../../../apps/agentStubControls');
+  const MongooseControls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var mongooseControls = new MongooseControls({
-    agentControls: agentControls
+  const mongooseControls = new MongooseControls({
+    agentControls
   });
   mongooseControls.registerTestHooks();
 
-  it('must trace create calls', function() {
-    return mongooseControls
+  it('must trace create calls', () =>
+    mongooseControls
       .sendRequest({
         method: 'POST',
         path: '/insert',
@@ -35,10 +35,10 @@ describe('tracing/mongoose', function() {
           age: 999
         }
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var entrySpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const entrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.f.e).to.equal(String(mongooseControls.getPid()));
               expect(span.f.h).to.equal('agent-stub-uuid');
@@ -46,7 +46,7 @@ describe('tracing/mongoose', function() {
               expect(span.error).to.equal(false);
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.t).to.equal(entrySpan.t);
               expect(span.p).to.equal(entrySpan.s);
               expect(span.n).to.equal('mongo');
@@ -59,13 +59,12 @@ describe('tracing/mongoose', function() {
               expect(span.data.mongo.service).to.equal(process.env.MONGODB);
               expect(span.data.mongo.namespace).to.equal('mongoose.people');
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace findOne calls', function() {
-    var randomName = uuid();
+  it('must trace findOne calls', () => {
+    const randomName = uuid();
     return mongooseControls
       .sendRequest({
         method: 'POST',
@@ -75,20 +74,20 @@ describe('tracing/mongoose', function() {
           age: 42
         }
       })
-      .then(function() {
-        return mongooseControls.sendRequest({
+      .then(() =>
+        mongooseControls.sendRequest({
           method: 'POST',
           path: '/find',
           body: {
             name: randomName,
             age: 42
           }
-        });
-      })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var entrySpan = utils.expectOneMatching(spans, function(span) {
+        })
+      )
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const entrySpan = utils.expectOneMatching(spans, span => {
               expect(span.data.http.url).to.equal('/find');
               expect(span.n).to.equal('node.http.server');
               expect(span.f.e).to.equal(String(mongooseControls.getPid()));
@@ -97,7 +96,7 @@ describe('tracing/mongoose', function() {
               expect(span.error).to.equal(false);
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.t).to.equal(entrySpan.t);
               expect(span.p).to.equal(entrySpan.s);
               expect(span.n).to.equal('mongo');
@@ -110,10 +109,10 @@ describe('tracing/mongoose', function() {
               expect(span.data.mongo.service).to.equal(process.env.MONGODB);
               expect(span.data.mongo.namespace).to.equal('mongoose.people');
               expect(span.data.mongo.filter).to.contain('"age":42');
-              expect(span.data.mongo.filter).to.contain('"name":"' + randomName + '"');
+              expect(span.data.mongo.filter).to.contain(`"name":"${randomName}"`);
             });
-          });
-        });
-      });
+          })
+        )
+      );
   });
 });

--- a/packages/collector/test/tracing/database/mssql/controls.js
+++ b/packages/collector/test/tracing/database/mssql/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/database/mssql/test.js
+++ b/packages/collector/test/tracing/database/mssql/test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var errors = require('request-promise/errors');
-var expect = require('chai').expect;
+const errors = require('request-promise/errors');
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/mssql', function() {
   if (!supportedVersion(process.versions.node)) {
@@ -14,362 +14,346 @@ describe('tracing/mssql', function() {
   }
 
   this.timeout(config.getTestTimeout());
-  var agentControls = require('../../../apps/agentStubControls');
+  const agentControls = require('../../../apps/agentStubControls');
   agentControls.registerTestHooks();
-  var AppControls = require('./controls');
-  var appControls = new AppControls({
-    agentControls: agentControls
+  const AppControls = require('./controls');
+  const appControls = new AppControls({
+    agentControls
   });
   appControls.registerTestHooks();
 
-  it('must trace dummy select', function() {
-    return appControls
+  it('must trace dummy select', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/select-getdate'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.length).to.equal(1);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select-getdate');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT GETDATE()');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace static dummy select', function() {
-    return appControls
+  it('must trace static dummy select', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/select-static'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.length).to.equal(1);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select-static');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT GETDATE()');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace errors', function() {
-    return appControls
+  it('must trace errors', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/error-callback'
       })
-      .catch(errors.StatusCodeError, function(reason) {
-        return reason;
-      })
-      .then(function(response) {
+      .catch(errors.StatusCodeError, reason => reason)
+      .then(response => {
         expect(response.statusCode).to.equal(500);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/error-callback');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlErrorSpan(span, httpEntrySpan, "Invalid object name 'non_existing_table'");
               expect(span.data.mssql.stmt).to.equal('SELECT name, email FROM non_existing_table');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace select via promise', function() {
-    return appControls
+  it('must trace select via promise', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/select-promise'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.length).to.equal(1);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select-promise');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT GETDATE()');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace errors via promise', function() {
-    return appControls
+  it('must trace errors via promise', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/error-promise'
       })
-      .catch(errors.StatusCodeError, function(reason) {
-        return reason;
-      })
-      .then(function(response) {
+      .catch(errors.StatusCodeError, reason => reason)
+      .then(response => {
         expect(response.statusCode).to.equal(500);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/error-promise');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlErrorSpan(span, httpEntrySpan, "Invalid object name 'non_existing_table'");
               expect(span.data.mssql.stmt).to.equal('SELECT name, email FROM non_existing_table');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace standard pool', function() {
-    return appControls
+  it('must trace standard pool', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/select-standard-pool'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.length).to.equal(1);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select-standard-pool');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT 1 AS NUMBER');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace custom pool', function() {
-    return appControls
+  it('must trace custom pool', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/select-custom-pool'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.length).to.equal(1);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select-custom-pool');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT 1 AS NUMBER');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace insert and select', function() {
-    return appControls
+  it('must trace insert and select', () =>
+    appControls
       .sendRequest({
         method: 'POST',
         path: '/insert'
       })
-      .then(function() {
-        return appControls.sendRequest({
+      .then(() =>
+        appControls.sendRequest({
           method: 'POST',
           path: '/insert-params'
-        });
-      })
-      .then(function() {
-        return appControls.sendRequest({
+        })
+      )
+      .then(() =>
+        appControls.sendRequest({
           method: 'GET',
           path: '/select'
-        });
-      })
-      .then(function(response) {
+        })
+      )
+      .then(response => {
         expect(response.length).to.equal(2);
         expect(response[0].name).to.equal('gaius');
         expect(response[0].email).to.equal('gaius@julius.com');
         expect(response[1].name).to.equal('augustus');
         expect(response[1].email).to.equal('augustus@julius.com');
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var firstWriteEntry = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const firstWriteEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/insert');
             });
-            var secondWriteEntry = utils.expectOneMatching(spans, function(span) {
+            const secondWriteEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/insert-params');
             });
-            var readEntry = utils.expectOneMatching(spans, function(span) {
+            const readEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, firstWriteEntry);
               expect(span.data.mssql.stmt).to.equal(
                 "INSERT INTO UserTable (name, email) VALUES (N'gaius', N'gaius@julius.com')"
               );
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, secondWriteEntry);
               expect(span.data.mssql.stmt).to.equal('INSERT INTO UserTable (name, email) VALUES (@username, @email)');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, readEntry);
               expect(span.data.mssql.stmt).to.equal('SELECT name, email FROM UserTable');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace prepared statements via callback', function() {
-    return appControls
+  it('must trace prepared statements via callback', () =>
+    appControls
       .sendRequest({
         method: 'POST',
         path: '/insert-prepared-callback'
       })
-      .then(function() {
-        return appControls.sendRequest({
+      .then(() =>
+        appControls.sendRequest({
           method: 'GET',
           path: '/select-by-name/tiberius'
-        });
-      })
-      .then(function(response) {
+        })
+      )
+      .then(response => {
         expect(response).to.equal('tiberius@claudius.com');
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var writeEntry = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const writeEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/insert-prepared-callback');
             });
-            var readEntry = utils.expectOneMatching(spans, function(span) {
+            const readEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select-by-name/tiberius');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, writeEntry);
               expect(span.data.mssql.stmt).to.equal('INSERT INTO UserTable (name, email) VALUES (@username, @email)');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, readEntry);
               expect(span.data.mssql.stmt).to.equal('SELECT name, email FROM UserTable WHERE name=@username');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace prepared statements via promise', function() {
-    return appControls
+  it('must trace prepared statements via promise', () =>
+    appControls
       .sendRequest({
         method: 'POST',
         path: '/insert-prepared-promise'
       })
-      .then(function() {
-        return appControls.sendRequest({
+      .then(() =>
+        appControls.sendRequest({
           method: 'GET',
           path: '/select-by-name/caligula'
-        });
-      })
-      .then(function(response) {
+        })
+      )
+      .then(response => {
         expect(response).to.equal('caligula@julioclaudian.com');
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var writeEntry = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const writeEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/insert-prepared-promise');
             });
-            var readEntry = utils.expectOneMatching(spans, function(span) {
+            const readEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/select-by-name/caligula');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, writeEntry);
               expect(span.data.mssql.stmt).to.equal('INSERT INTO UserTable (name, email) VALUES (@username, @email)');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, readEntry);
               expect(span.data.mssql.stmt).to.equal('SELECT name, email FROM UserTable WHERE name=@username');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace errors in prepared statements via callback', function() {
-    return appControls
+  it('must trace errors in prepared statements via callback', () =>
+    appControls
       .sendRequest({
         method: 'POST',
         path: '/insert-prepared-error-callback'
       })
-      .catch(errors.StatusCodeError, function(reason) {
-        return reason;
-      })
-      .then(function(response) {
+      .catch(errors.StatusCodeError, reason => reason)
+      .then(response => {
         expect(response.statusCode).to.equal(500);
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var writeEntry = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const writeEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/insert-prepared-error-callback');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlErrorSpan(
                 span,
                 writeEntry,
@@ -378,30 +362,27 @@ describe('tracing/mssql', function() {
               );
               expect(span.data.mssql.stmt).to.equal('INSERT INTO UserTable (name, email) VALUES (@username, @email)');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace errors in prepared statements via promise', function() {
-    return appControls
+  it('must trace errors in prepared statements via promise', () =>
+    appControls
       .sendRequest({
         method: 'POST',
         path: '/insert-prepared-error-promise'
       })
-      .catch(errors.StatusCodeError, function(reason) {
-        return reason;
-      })
-      .then(function(response) {
+      .catch(errors.StatusCodeError, reason => reason)
+      .then(response => {
         expect(response.statusCode).to.equal(500);
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var writeEntry = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const writeEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/insert-prepared-error-promise');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlErrorSpan(
                 span,
                 writeEntry,
@@ -410,248 +391,238 @@ describe('tracing/mssql', function() {
               );
               expect(span.data.mssql.stmt).to.equal('INSERT INTO UserTable (name, email) VALUES (@username, @email)');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace transactions with callbacks', function() {
-    return appControls
+  it('must trace transactions with callbacks', () =>
+    appControls
       .sendRequest({
         method: 'POST',
         path: '/transaction-callback'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.equal('vespasian@flavius.com');
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntry = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/transaction-callback');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntry);
               expect(span.data.mssql.stmt).to.equal('INSERT INTO UserTable (name, email) VALUES (@username, @email)');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntry);
               expect(span.data.mssql.stmt).to.equal("SELECT name, email FROM UserTable WHERE name=N'vespasian'");
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace transactions with promises', function() {
-    return appControls
+  it('must trace transactions with promises', () =>
+    appControls
       .sendRequest({
         method: 'POST',
         path: '/transaction-promise'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.equal('titus@flavius.com');
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntry = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntry = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('POST');
               expect(span.data.http.url).to.equal('/transaction-promise');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntry);
               expect(span.data.mssql.stmt).to.equal('INSERT INTO UserTable (name, email) VALUES (@username, @email)');
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntry);
               expect(span.data.mssql.stmt).to.equal("SELECT name, email FROM UserTable WHERE name=N'titus'");
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace stored procedure execution', function() {
-    return appControls
+  it('must trace stored procedure execution', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/stored-procedure-callback'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.recordset).to.exist;
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/stored-procedure-callback');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('testProcedure');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace the streaming API', function() {
-    return appControls
+  it('must trace the streaming API', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/streaming'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.rows).to.exist;
         expect(response.errors.length).to.equal(0);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/streaming');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT name, email FROM UserTable');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace the pipe API', function() {
-    return appControls
+  it('must trace the pipe API', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/pipe'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/pipe');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT name, email FROM UserTable');
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace batch with callback', function() {
-    return appControls
+  it('must trace batch with callback', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/batch-callback'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.length).to.equal(1);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/batch-callback');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT GETDATE()');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace batch with promise', function() {
-    return appControls
+  it('must trace batch with promise', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/batch-promise'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.length).to.equal(1);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/batch-promise');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('SELECT GETDATE()');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace bulk operations', function() {
-    return appControls
+  it('must trace bulk operations', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/bulk'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.rowsAffected).to.equal(3);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/bulk');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlSpan(span, httpEntrySpan);
               expect(span.data.mssql.stmt).to.equal('MSSQL bulk operation');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace cancel', function() {
-    return appControls
+  it('must trace cancel', () =>
+    appControls
       .sendRequest({
         method: 'GET',
         path: '/cancel'
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.name).to.equal('RequestError');
         expect(response.code).to.equal('ECANCEL');
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var httpEntrySpan = utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const httpEntrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.data.http.method).to.equal('GET');
               expect(span.data.http.url).to.equal('/cancel');
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               checkMssqlErrorSpan(span, httpEntrySpan, 'Canceled.');
               expect(span.data.mssql.stmt).to.equal("WAITFOR DELAY '00:00:05'; SELECT 1 as NUMBER");
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
   function checkMssqlSpan(span, parent) {
     checkMssqlInternally(span, parent, false);

--- a/packages/collector/test/tracing/database/mysql/controls.js
+++ b/packages/collector/test/tracing/database/mysql/controls.js
@@ -2,22 +2,22 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../../../utils');
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
-var upstreamPort = require('../../../apps/expressControls').appPort;
-var appPort = (exports.appPort = 3215);
+const utils = require('../../../utils');
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
+const upstreamPort = require('../../../apps/expressControls').appPort;
+const appPort = (exports.appPort = 3215);
 
-var expressMysqlApp;
+let expressMysqlApp;
 
-exports.registerTestHooks = function(opts) {
+exports.registerTestHooks = opts => {
   opts = opts || {};
-  beforeEach(function() {
-    var env = Object.create(process.env);
+  beforeEach(() => {
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.UPSTREAM_PORT = upstreamPort;
@@ -35,66 +35,60 @@ exports.registerTestHooks = function(opts) {
 
     expressMysqlApp = spawn('node', [path.join(__dirname, 'app.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     expressMysqlApp.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return expressMysqlApp.pid;
-};
+exports.getPid = () => expressMysqlApp.pid;
 
-exports.addValue = function(value) {
-  return request({
+exports.addValue = value =>
+  request({
     method: 'post',
-    url: 'http://127.0.0.1:' + appPort + '/values',
+    url: `http://127.0.0.1:${appPort}/values`,
     qs: {
-      value: value
+      value
     }
   });
-};
 
 /**
  * Executes a MySQL INSERT and then does an HTTP client call. Used to verify that the tracing context is not corrupted.
  */
-exports.addValueAndDoCall = function(value) {
-  return request({
+exports.addValueAndDoCall = value =>
+  request({
     method: 'post',
-    url: 'http://127.0.0.1:' + appPort + '/valuesAndCall',
+    url: `http://127.0.0.1:${appPort}/valuesAndCall`,
     qs: {
-      value: value
+      value
     }
   });
-};
 
-exports.getValues = function() {
-  return request({
+exports.getValues = () =>
+  request({
     method: 'get',
-    url: 'http://127.0.0.1:' + appPort + '/values'
+    url: `http://127.0.0.1:${appPort}/values`
   });
-};
 
-exports.getValuesAndProduceError = function() {
-  return request({
+exports.getValuesAndProduceError = () =>
+  request({
     method: 'get',
-    url: 'http://127.0.0.1:' + appPort + '/values/error'
+    url: `http://127.0.0.1:${appPort}/values/error`
   });
-};

--- a/packages/collector/test/tracing/database/pg/app.js
+++ b/packages/collector/test/tracing/database/pg/app.js
@@ -11,22 +11,22 @@ require('../../../../')({
   }
 });
 
-var _pg = require('pg');
-var Pool = _pg.Pool;
-var Client = _pg.Client;
-var express = require('express');
-var morgan = require('morgan');
-var bodyParser = require('body-parser');
+const _pg = require('pg');
+const Pool = _pg.Pool;
+const Client = _pg.Client;
+const express = require('express');
+const morgan = require('morgan');
+const bodyParser = require('body-parser');
 
-var app = express();
-var logPrefix = 'Express / Postgres App (' + process.pid + '):\t';
-var pool = new Pool({
+const app = express();
+const logPrefix = `Express / Postgres App (${process.pid}):\t`;
+const pool = new Pool({
   user: process.env.POSTGRES_USER,
   host: process.env.POSTGRES_HOST,
   database: process.env.POSTGRES_DB,
   password: process.env.POSTGRES_PASSWORD
 });
-var client = new Client({
+const client = new Client({
   user: process.env.POSTGRES_USER,
   host: process.env.POSTGRES_HOST,
   database: process.env.POSTGRES_DB,
@@ -34,27 +34,27 @@ var client = new Client({
 });
 client.connect();
 
-var createTableQuery =
+const createTableQuery =
   'CREATE TABLE IF NOT EXISTS users(id serial primary key, name varchar(40) NOT NULL, email varchar(40) NOT NULL)';
 
-pool.query(createTableQuery, function(err) {
+pool.query(createTableQuery, err => {
   if (err) {
     log('Failed create table query', err);
   }
 });
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/select-now-pool', function(req, res) {
-  pool.query('SELECT NOW()', function(err, results) {
+app.get('/select-now-pool', (req, res) => {
+  pool.query('SELECT NOW()', (err, results) => {
     if (err) {
       log('Failed to execute select now query', err);
       return res.sendStatus(500);
@@ -63,8 +63,8 @@ app.get('/select-now-pool', function(req, res) {
   });
 });
 
-app.get('/select-now-no-pool-callback', function(req, res) {
-  client.query('SELECT NOW()', function(err, results) {
+app.get('/select-now-no-pool-callback', (req, res) => {
+  client.query('SELECT NOW()', (err, results) => {
     if (err) {
       log('Failed to execute select now query', err);
       return res.sendStatus(500);
@@ -73,13 +73,13 @@ app.get('/select-now-no-pool-callback', function(req, res) {
   });
 });
 
-app.get('/select-now-no-pool-promise', function(req, res) {
+app.get('/select-now-no-pool-promise', (req, res) => {
   client
     .query('SELECT NOW()')
-    .then(function(results) {
+    .then(results => {
       res.json(results);
     })
-    .catch(function(err) {
+    .catch(err => {
       if (err) {
         log('Failed to execute select now query', err);
         return res.sendStatus(500);
@@ -87,11 +87,11 @@ app.get('/select-now-no-pool-promise', function(req, res) {
     });
 });
 
-app.get('/pool-string-insert', function(req, res) {
-  var insert = 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *';
-  var values = ['beaker', 'beaker@muppets.com'];
+app.get('/pool-string-insert', (req, res) => {
+  const insert = 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *';
+  const values = ['beaker', 'beaker@muppets.com'];
 
-  pool.query(insert, values, function(err, results) {
+  pool.query(insert, values, (err, results) => {
     if (err) {
       log('Failed to execute pool insert', err);
       return res.sendStatus(500);
@@ -100,12 +100,12 @@ app.get('/pool-string-insert', function(req, res) {
   });
 });
 
-app.get('/pool-config-select', function(req, res) {
-  var query = {
+app.get('/pool-config-select', (req, res) => {
+  const query = {
     text: 'SELECT name, email FROM users'
   };
 
-  pool.query(query, function(err, results) {
+  pool.query(query, (err, results) => {
     if (err) {
       log('Failed to execute pool config insert', err);
       return res.sendStatus(500);
@@ -114,28 +114,28 @@ app.get('/pool-config-select', function(req, res) {
   });
 });
 
-app.get('/pool-config-select-promise', function(req, res) {
-  var query = {
+app.get('/pool-config-select-promise', (req, res) => {
+  const query = {
     text: 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *',
     values: ['beaker', 'beaker@muppets.com']
   };
 
   pool
     .query(query)
-    .then(function(results) {
+    .then(results => {
       res.json(results);
     })
-    .catch(function(e) {
+    .catch(e => {
       log(e.stack);
       return res.sendStatus(500);
     });
 });
 
-app.get('/client-string-insert', function(req, res) {
-  var insert = 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *';
-  var values = ['beaker', 'beaker@muppets.com'];
+app.get('/client-string-insert', (req, res) => {
+  const insert = 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *';
+  const values = ['beaker', 'beaker@muppets.com'];
 
-  client.query(insert, values, function(err, results) {
+  client.query(insert, values, (err, results) => {
     if (err) {
       log('Failed to execute client insert', err);
       return res.sendStatus(500);
@@ -144,12 +144,12 @@ app.get('/client-string-insert', function(req, res) {
   });
 });
 
-app.get('/client-config-select', function(req, res) {
-  var query = {
+app.get('/client-config-select', (req, res) => {
+  const query = {
     text: 'SELECT name, email FROM users'
   };
 
-  client.query(query, function(err, results) {
+  client.query(query, (err, results) => {
     if (err) {
       log('Failed to execute client select', err);
       return res.sendStatus(500);
@@ -158,39 +158,35 @@ app.get('/client-config-select', function(req, res) {
   });
 });
 
-app.get('/table-doesnt-exist', function(req, res) {
+app.get('/table-doesnt-exist', (req, res) => {
   pool
     .query('SELECT name, email FROM nonexistanttable')
-    .then(function(r) {
+    .then(r => {
       res.json(r);
     })
-    .catch(function(e) {
-      return res.status(500).json(e);
-    });
+    .catch(e => res.status(500).json(e));
 });
 
-app.get('/transaction', function(req, res) {
-  client.query('BEGIN', function(err1) {
+app.get('/transaction', (req, res) => {
+  client.query('BEGIN', err1 => {
     if (err1) {
       log('Failed to execute client transaction', err1);
       return res.status(500).json(err1);
     }
 
-    client.query('INSERT INTO users(name, email) VALUES($1, $2) RETURNING *', ['trans1', 'nodejstests@blah'], function(
-      err2
-    ) {
+    client.query('INSERT INTO users(name, email) VALUES($1, $2) RETURNING *', ['trans1', 'nodejstests@blah'], err2 => {
       if (err2) {
         log('Failed to execute client transaction', err2);
         return res.status(500).json(err2);
       }
-      var insertTrans2 = 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *';
-      var insertTrans2Values = ['trans2', 'nodejstests@blah'];
-      client.query(insertTrans2, insertTrans2Values, function(err3, result3) {
+      const insertTrans2 = 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *';
+      const insertTrans2Values = ['trans2', 'nodejstests@blah'];
+      client.query(insertTrans2, insertTrans2Values, (err3, result3) => {
         if (err3) {
           log('Failed to execute client transaction', err3);
           return res.status(500).json(err3);
         }
-        client.query('COMMIT', function(err4) {
+        client.query('COMMIT', err4 => {
           if (err4) {
             log('Failed to execute client transaction', err4);
             return res.status(500).json(err4);
@@ -202,12 +198,12 @@ app.get('/transaction', function(req, res) {
   });
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/database/pg/test.js
+++ b/packages/collector/test/tracing/database/pg/test.js
@@ -1,53 +1,51 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/pg', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var expressPgControls = require('./controls');
-  var agentStubControls = require('../../../apps/agentStubControls');
+  const expressPgControls = require('./controls');
+  const agentStubControls = require('../../../apps/agentStubControls');
 
   this.timeout(config.getTestTimeout());
 
   agentStubControls.registerTestHooks();
   expressPgControls.registerTestHooks();
 
-  beforeEach(function() {
-    return agentStubControls.waitUntilAppIsCompletelyInitialized(expressPgControls.getPid());
-  });
+  beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(expressPgControls.getPid()));
 
-  it('must trace pooled select now', function() {
-    return expressPgControls
+  it('must trace pooled select now', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/select-now-pool',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('SELECT');
         expect(response.rowCount).to.equal(1);
         expect(response.rows.length).to.equal(1);
         expect(response.rows[0].now).to.be.a('string');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -61,35 +59,34 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('SELECT NOW()');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace non-pooled query with callback', function() {
-    return expressPgControls
+  it('must trace non-pooled query with callback', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/select-now-no-pool-callback',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('SELECT');
         expect(response.rowCount).to.equal(1);
         expect(response.rows.length).to.equal(1);
         expect(response.rows[0].now).to.be.a('string');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -103,35 +100,34 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('SELECT NOW()');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace non-pooled query with promise', function() {
-    return expressPgControls
+  it('must trace non-pooled query with promise', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/select-now-no-pool-promise',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('SELECT');
         expect(response.rowCount).to.equal(1);
         expect(response.rows.length).to.equal(1);
         expect(response.rows[0].now).to.be.a('string');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -145,19 +141,18 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('SELECT NOW()');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace string based pool insert', function() {
-    return expressPgControls
+  it('must trace string based pool insert', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/pool-string-insert',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('INSERT');
         expect(response.rowCount).to.equal(1);
@@ -165,16 +160,16 @@ describe('tracing/pg', function() {
         expect(response.rows[0].name).to.equal('beaker');
         expect(response.rows[0].email).to.equal('beaker@muppets.com');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -188,33 +183,32 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('INSERT INTO users(name, email) VALUES($1, $2) RETURNING *');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace config object based pool select', function() {
-    return expressPgControls
+  it('must trace config object based pool select', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/pool-config-select',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('SELECT');
         expect(response.rowCount).to.be.a('number');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -228,19 +222,18 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('SELECT name, email FROM users');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace promise based pool select', function() {
-    return expressPgControls
+  it('must trace promise based pool select', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/pool-config-select-promise',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('INSERT');
         expect(response.rowCount).to.equal(1);
@@ -248,16 +241,16 @@ describe('tracing/pg', function() {
         expect(response.rows[0].name).to.equal('beaker');
         expect(response.rows[0].email).to.equal('beaker@muppets.com');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -271,19 +264,18 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('INSERT INTO users(name, email) VALUES($1, $2) RETURNING *');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace string based client insert', function() {
-    return expressPgControls
+  it('must trace string based client insert', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/client-string-insert',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('INSERT');
         expect(response.rowCount).to.equal(1);
@@ -291,16 +283,16 @@ describe('tracing/pg', function() {
         expect(response.rows[0].name).to.equal('beaker');
         expect(response.rows[0].email).to.equal('beaker@muppets.com');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -314,33 +306,32 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('INSERT INTO users(name, email) VALUES($1, $2) RETURNING *');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace config object based client select', function() {
-    return expressPgControls
+  it('must trace config object based client select', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/client-config-select',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('SELECT');
         expect(response.rowCount).to.be.a('number');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -354,35 +345,34 @@ describe('tracing/pg', function() {
             expect(pgSpan.error).to.equal(false);
             expect(pgSpan.ec).to.equal(0);
             expect(pgSpan.data.pg.stmt).to.equal('SELECT name, email FROM users');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must capture errors', function() {
-    return expressPgControls
+  it('must capture errors', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/table-doesnt-exist',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.name).to.equal('StatusCodeError');
         expect(response.statusCode).to.equal(500);
         // 42P01 -> PostgreSQL's code for "relation does not exist"
         expect(response.message).to.include('42P01');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(1);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan = pgSpans[0];
+            const entrySpan = entrySpans[0];
+            const pgSpan = pgSpans[0];
 
             expect(pgSpan.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan.f.h).to.equal('agent-stub-uuid');
@@ -397,19 +387,18 @@ describe('tracing/pg', function() {
             // expect(pgSpan.data.pg.error).to.equal('blah');
             expect(pgSpan.ec).to.equal(1);
             expect(pgSpan.data.pg.stmt).to.equal('SELECT name, email FROM nonexistanttable');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must not break vanilla postgres (not tracing)', function() {
-    return expressPgControls
+  it('must not break vanilla postgres (not tracing)', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/pool-string-insert',
         suppressTracing: true
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('INSERT');
         expect(response.rowCount).to.equal(1);
@@ -417,10 +406,10 @@ describe('tracing/pg', function() {
         expect(response.rows[0].name).to.equal('beaker');
         expect(response.rows[0].email).to.equal('beaker@muppets.com');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(0);
             expect(pgSpans).to.have.lengthOf(0);
@@ -428,19 +417,18 @@ describe('tracing/pg', function() {
             expect(response.rows).to.lengthOf(1);
             expect(response.rows[0].name).to.equal('beaker');
             expect(response.rows[0].email).to.equal('beaker@muppets.com');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must trace transactions', function() {
-    return expressPgControls
+  it('must trace transactions', () =>
+    expressPgControls
       .sendRequest({
         method: 'GET',
         path: '/transaction',
         body: {}
       })
-      .then(function(response) {
+      .then(response => {
         expect(response).to.exist;
         expect(response.command).to.equal('INSERT');
         expect(response.rowCount).to.equal(1);
@@ -448,19 +436,19 @@ describe('tracing/pg', function() {
         expect(response.rows[0].name).to.equal('trans2');
         expect(response.rows[0].email).to.equal('nodejstests@blah');
 
-        return utils.retry(function() {
-          return agentStubControls.getSpans().then(function(spans) {
-            var entrySpans = utils.getSpansByName(spans, 'node.http.server');
-            var pgSpans = utils.getSpansByName(spans, 'postgres');
+        return utils.retry(() =>
+          agentStubControls.getSpans().then(spans => {
+            const entrySpans = utils.getSpansByName(spans, 'node.http.server');
+            const pgSpans = utils.getSpansByName(spans, 'postgres');
 
             expect(entrySpans).to.have.lengthOf(1);
             expect(pgSpans).to.have.lengthOf(4);
 
-            var entrySpan = entrySpans[0];
-            var pgSpan1 = pgSpans[0];
-            var pgSpan2 = pgSpans[1];
-            var pgSpan3 = pgSpans[2];
-            var pgSpan4 = pgSpans[3];
+            const entrySpan = entrySpans[0];
+            const pgSpan1 = pgSpans[0];
+            const pgSpan2 = pgSpans[1];
+            const pgSpan3 = pgSpans[2];
+            const pgSpan4 = pgSpans[3];
 
             expect(pgSpan1.f.e).to.equal(String(expressPgControls.getPid()));
             expect(pgSpan1.f.h).to.equal('agent-stub-uuid');
@@ -513,8 +501,7 @@ describe('tracing/pg', function() {
             expect(pgSpan4.error).to.equal(false);
             expect(pgSpan4.ec).to.equal(0);
             expect(pgSpan4.data.pg.stmt).to.equal('COMMIT');
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 });

--- a/packages/collector/test/tracing/database/redis/app.js
+++ b/packages/collector/test/tracing/database/redis/app.js
@@ -10,27 +10,27 @@ require('../../../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
-var redis = require('redis');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
+const redis = require('redis');
 
-var app = express();
-var logPrefix = 'Express / Redis App (' + process.pid + '):\t';
-var connectedToRedis = false;
+const app = express();
+const logPrefix = `Express / Redis App (${process.pid}):\t`;
+let connectedToRedis = false;
 
-var client = redis.createClient('//' + process.env.REDIS);
-client.on('ready', function() {
+const client = redis.createClient(`//${process.env.REDIS}`);
+client.on('ready', () => {
   connectedToRedis = true;
 });
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   if (!connectedToRedis) {
     res.sendStatus(500);
   } else {
@@ -38,10 +38,10 @@ app.get('/', function(req, res) {
   }
 });
 
-app.post('/values', function(req, res) {
-  var key = req.query.key;
-  var value = req.query.value;
-  client.set(key, value, function(err) {
+app.post('/values', (req, res) => {
+  const key = req.query.key;
+  const value = req.query.value;
+  client.set(key, value, err => {
     if (err) {
       log('Set with key %s, value %s failed', key, value, err);
       res.sendStatus(500);
@@ -51,9 +51,9 @@ app.post('/values', function(req, res) {
   });
 });
 
-app.get('/values', function(req, res) {
-  var key = req.query.key;
-  client.get(key, function(err, redisRes) {
+app.get('/values', (req, res) => {
+  const key = req.query.key;
+  client.get(key, (err, redisRes) => {
     if (err) {
       log('Get with key %s failed', key, err);
       res.sendStatus(500);
@@ -63,9 +63,9 @@ app.get('/values', function(req, res) {
   });
 });
 
-app.get('/failure', function(req, res) {
+app.get('/failure', (req, res) => {
   // simulating wrong get usage
-  client.get('someCollection', 'someKey', 'someValue', function(err, redisRes) {
+  client.get('someCollection', 'someKey', 'someValue', (err, redisRes) => {
     if (err) {
       res.sendStatus(500);
     } else {
@@ -74,12 +74,12 @@ app.get('/failure', function(req, res) {
   });
 });
 
-app.get('/multi', function(req, res) {
+app.get('/multi', (req, res) => {
   client
     .multi()
     .hset('someCollection', 'key', 'value')
     .hget('someCollection', 'key')
-    .exec(function(err) {
+    .exec(err => {
       if (err) {
         log('Multi failed', err);
         res.sendStatus(500);
@@ -89,13 +89,13 @@ app.get('/multi', function(req, res) {
     });
 });
 
-app.get('/multiFailure', function(req, res) {
+app.get('/multiFailure', (req, res) => {
   // simulating wrong get usage
   client
     .multi()
     .hset('someCollection', 'key', 'value')
     .hget('someCollection', 'key', 'too', 'many', 'args')
-    .exec(function(err) {
+    .exec(err => {
       if (err) {
         log('Multi failed', err);
         res.sendStatus(500);
@@ -105,13 +105,13 @@ app.get('/multiFailure', function(req, res) {
     });
 });
 
-app.get('/batchFailure', function(req, res) {
+app.get('/batchFailure', (req, res) => {
   // simulating wrong get usage
   client
     .batch()
     .hset('someCollection', 'key', 'value')
     .hget('someCollection', 'key', 'too', 'many', 'args')
-    .exec(function(err) {
+    .exec(err => {
       if (err) {
         log('batch failed', err);
         res.sendStatus(500);
@@ -121,17 +121,17 @@ app.get('/batchFailure', function(req, res) {
     });
 });
 
-app.get('/callSequence', function(req, res) {
-  var key = 'foo';
-  var value = 'bar';
-  client.set(key, value, function(err) {
+app.get('/callSequence', (req, res) => {
+  const key = 'foo';
+  const value = 'bar';
+  client.set(key, value, err => {
     if (err) {
       log('Set with key %s, value %s failed', key, value, err);
       res.sendStatus(500);
       return;
     }
 
-    client.get(key, function(err2, result) {
+    client.get(key, (err2, result) => {
       if (err2) {
         log('get with key %s failed', key, err2);
         res.sendStatus(500);
@@ -143,12 +143,12 @@ app.get('/callSequence', function(req, res) {
   });
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/database/redis/controls.js
+++ b/packages/collector/test/tracing/database/redis/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/database/sequelize/app.js
+++ b/packages/collector/test/tracing/database/sequelize/app.js
@@ -11,8 +11,8 @@ require('../../../../')({
   }
 });
 
-var Sequelize = require('sequelize');
-var sequelize = new Sequelize(process.env.POSTGRES_DB, process.env.POSTGRES_USER, process.env.POSTGRES_PASSWORD, {
+const Sequelize = require('sequelize');
+const sequelize = new Sequelize(process.env.POSTGRES_DB, process.env.POSTGRES_USER, process.env.POSTGRES_PASSWORD, {
   host: process.env.POSTGRES_HOST,
   dialect: 'postgres',
   operatorsAliases: false,
@@ -24,21 +24,21 @@ var sequelize = new Sequelize(process.env.POSTGRES_DB, process.env.POSTGRES_USER
   }
 });
 
-var express = require('express');
-var morgan = require('morgan');
-var bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
+const bodyParser = require('body-parser');
 
-var app = express();
-var logPrefix = 'Express/Postgres/Sequelize App (' + process.pid + '):\t';
-var ready = false;
+const app = express();
+const logPrefix = `Express/Postgres/Sequelize App (${process.pid}):\t`;
+let ready = false;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   if (ready) {
     res.sendStatus(200);
   } else {
@@ -46,22 +46,22 @@ app.get('/', function(req, res) {
   }
 });
 
-var Regent = sequelize.define('regent', {
+const Regent = sequelize.define('regent', {
   firstName: Sequelize.STRING,
   lastName: Sequelize.STRING
 });
 
-Regent.sync({ force: true }).then(function() {
-  return Regent.create({
+Regent.sync({ force: true }).then(() =>
+  Regent.create({
     firstName: 'Irene',
     lastName: 'Sarantapechaina'
-  }).then(function() {
+  }).then(() => {
     ready = true;
-  });
-});
+  })
+);
 
-app.get('/regents', function(req, res) {
-  var where = req.query ? req.query : {};
+app.get('/regents', (req, res) => {
+  const where = req.query ? req.query : {};
   // Regent.findOne({ attributes: ['firstName', 'lastName'], where: where })
   //   .then(function(regent) {
   //     res.send([regent.get()]);
@@ -69,21 +69,17 @@ app.get('/regents', function(req, res) {
   //   .catch(function(err) {
   //     res.status(500).send(err);
   //   });
-  Regent.findAll({ attributes: ['firstName', 'lastName'], where: where })
-    .then(function(regents) {
-      res.send(
-        regents.map(function(regent) {
-          return regent.get();
-        })
-      );
+  Regent.findAll({ attributes: ['firstName', 'lastName'], where })
+    .then(regents => {
+      res.send(regents.map(regent => regent.get()));
     })
-    .catch(function(err) {
+    .catch(err => {
       res.status(500).send(err);
     });
 });
 
-app.post('/regents', function(req, res) {
-  return Regent.findOrCreate({
+app.post('/regents', (req, res) =>
+  Regent.findOrCreate({
     where: {
       firstName: req.body.firstName,
       lastName: req.body.lastName
@@ -93,20 +89,20 @@ app.post('/regents', function(req, res) {
       lastName: req.body.lastName
     }
   })
-    .then(function() {
+    .then(() => {
       res.sendStatus(201);
     })
-    .catch(function(err) {
+    .catch(err => {
       res.status(500).send(err);
-    });
-});
+    })
+);
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/disabled_test.js
+++ b/packages/collector/test/tracing/disabled_test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var expect = require('chai').expect;
-var Promise = require('bluebird');
+const expect = require('chai').expect;
+const Promise = require('bluebird');
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../config');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../config');
 
 /**
  * Tests behaviour when the Instana Node.js collector is active but tracing is disabled.
@@ -14,8 +14,8 @@ describe('disabled tracing', function() {
     return;
   }
 
-  var agentStubControls = require('../apps/agentStubControls');
-  var expressControls = require('../apps/expressControls');
+  const agentStubControls = require('../apps/agentStubControls');
+  const expressControls = require('../apps/expressControls');
 
   this.timeout(config.getTestTimeout());
 
@@ -24,24 +24,19 @@ describe('disabled tracing', function() {
     enableTracing: false
   });
 
-  beforeEach(function() {
-    return agentStubControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid());
-  });
+  beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(expressControls.getPid()));
 
-  it('must not send any spans to the agent', function() {
-    return expressControls
+  it('must not send any spans to the agent', () =>
+    expressControls
       .sendRequest({
         method: 'POST',
         path: '/checkout',
         responseStatus: 201
       })
-      .then(function() {
-        return Promise.delay(500);
-      })
-      .then(function() {
-        return agentStubControls.getSpans().then(function(spans) {
+      .then(() => Promise.delay(500))
+      .then(() =>
+        agentStubControls.getSpans().then(spans => {
           expect(spans).to.have.lengthOf(0);
-        });
-      });
-  });
+        })
+      ));
 });

--- a/packages/collector/test/tracing/frameworks/express/app.js
+++ b/packages/collector/test/tracing/frameworks/express/app.js
@@ -10,30 +10,30 @@ require('../../../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express HTTP: Server (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express HTTP: Server (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
 app.get('/blub', sendRoute);
 
-var subRoutes = express.Router();
+const subRoutes = express.Router();
 subRoutes.get('/bar/:id', sendRoute);
 app.use('/sub', subRoutes);
 
-var subSubRoutes = express.Router();
+const subSubRoutes = express.Router();
 subSubRoutes.get('/bar/:id', sendRoute);
 subRoutes.use('/sub', subSubRoutes);
 
@@ -41,12 +41,12 @@ function sendRoute(req, res) {
   res.send(req.baseUrl + req.route.path);
 }
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/frameworks/express/controls.js
+++ b/packages/collector/test/tracing/frameworks/express/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/frameworks/express/test.js
+++ b/packages/collector/test/tracing/frameworks/express/test.js
@@ -1,53 +1,52 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/express', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../../../apps/agentStubControls');
-  var Controls = require('./controls');
+  const agentControls = require('../../../apps/agentStubControls');
+  const Controls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var controls = new Controls({
-    agentControls: agentControls
+  const controls = new Controls({
+    agentControls
   });
   controls.registerTestHooks();
 
-  describe('express.js path templates', function() {
+  describe('express.js path templates', () => {
     check('/blub', '/blub');
     check('/sub/bar/42', '/sub/bar/:id');
     check('/sub/sub/bar/42', '/sub/sub/bar/:id');
 
     function check(actualPath, expectedTemplate) {
-      it('must report express path templates for actual path: ' + actualPath, function() {
-        return controls
+      it(`must report express path templates for actual path: ${actualPath}`, () =>
+        controls
           .sendRequest({
             method: 'GET',
             path: actualPath
           })
-          .then(function() {
-            return utils.retry(function() {
-              return agentControls.getSpans().then(function(spans) {
-                utils.expectOneMatching(spans, function(span) {
+          .then(() =>
+            utils.retry(() =>
+              agentControls.getSpans().then(spans => {
+                utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.server');
                   expect(span.k).to.equal(constants.ENTRY);
                   expect(span.data.http.path_tpl).to.equal(expectedTemplate);
                 });
-              });
-            });
-          });
-      });
+              })
+            )
+          ));
     }
   });
 });

--- a/packages/collector/test/tracing/frameworks/express_uncaught_errors/app.js
+++ b/packages/collector/test/tracing/frameworks/express_uncaught_errors/app.js
@@ -10,44 +10,44 @@ require('../../../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express uncaughtErrors App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express uncaughtErrors App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
 // eslint-disable-next-line
-app.get('/customErrorHandler', function(req, res) {
+app.get('/customErrorHandler', (req, res) => {
   throw new Error('To be caught by custom error handler');
 });
 
 // eslint-disable-next-line
-app.use(function(err, req, res, next) {
+app.use((err, req, res, next) => {
   res.sendStatus(400);
 });
 
 // eslint-disable-next-line
-app.get('/defaultErrorHandler', function(req, res) {
+app.get('/defaultErrorHandler', (req, res) => {
   throw new Error('To be caught by default error handler');
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/frameworks/express_uncaught_errors/controls.js
+++ b/packages/collector/test/tracing/frameworks/express_uncaught_errors/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/frameworks/express_uncaught_errors/test.js
+++ b/packages/collector/test/tracing/frameworks/express_uncaught_errors/test.js
@@ -1,43 +1,43 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/express with uncaught errors', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../../../apps/agentStubControls');
-  var ExpressUncaughtErrorsControls = require('./controls');
+  const agentControls = require('../../../apps/agentStubControls');
+  const ExpressUncaughtErrorsControls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var expressUncaughtErrorsControls = new ExpressUncaughtErrorsControls({
-    agentControls: agentControls
+  const expressUncaughtErrorsControls = new ExpressUncaughtErrorsControls({
+    agentControls
   });
   expressUncaughtErrorsControls.registerTestHooks();
 
-  it('must record result of default express uncaught error function', function() {
-    return expressUncaughtErrorsControls
+  it('must record result of default express uncaught error function', () =>
+    expressUncaughtErrorsControls
       .sendRequest({
         method: 'GET',
         path: '/defaultErrorHandler',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.statusCode).to.equal(500);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.f.e).to.equal(String(expressUncaughtErrorsControls.getPid()));
@@ -46,25 +46,24 @@ describe('tracing/express with uncaught errors', function() {
               expect(span.ec).to.equal(1);
               expect(span.data.http.error).to.match(/To be caught by default error handler/);
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must record result of custom express uncaught error function', function() {
-    return expressUncaughtErrorsControls
+  it('must record result of custom express uncaught error function', () =>
+    expressUncaughtErrorsControls
       .sendRequest({
         method: 'GET',
         path: '/customErrorHandler',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.statusCode).to.equal(400);
 
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.f.e).to.equal(String(expressUncaughtErrorsControls.getPid()));
@@ -73,8 +72,7 @@ describe('tracing/express with uncaught errors', function() {
               expect(span.ec).to.equal(0);
               expect(span.data.http.error).to.match(/To be caught by custom error handler/);
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 });

--- a/packages/collector/test/tracing/frameworks/fastify/app.js
+++ b/packages/collector/test/tracing/frameworks/fastify/app.js
@@ -10,10 +10,10 @@ require('../../../../')({
   }
 });
 
-var fastify = require('fastify');
+const fastify = require('fastify');
 
-var app = fastify();
-var logPrefix = 'Fastify (' + process.pid + '):\t';
+const app = fastify();
+const logPrefix = `Fastify (${process.pid}):\t`;
 
 app.get('/', ok);
 
@@ -72,7 +72,7 @@ const start = async () => {
 start();
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/frameworks/fastify/controls.js
+++ b/packages/collector/test/tracing/frameworks/fastify/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/frameworks/koa/app.js
+++ b/packages/collector/test/tracing/frameworks/koa/app.js
@@ -16,12 +16,12 @@ const Router = require('koa-router');
 const bodyParser = require('koa-bodyparser');
 const morgan = require('koa-morgan');
 const port = process.env.APP_PORT || 3000;
-const logPrefix = 'Koa Server: (' + process.pid + '):\t';
+const logPrefix = `Koa Server: (${process.pid}):\t`;
 
 const app = new Koa();
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser());
@@ -53,15 +53,15 @@ router.use('/sub1', subRouter.routes(), subRouter.allowedMethods());
 app.use(router.routes()).use(router.allowedMethods());
 
 function respondWithRoute(ctx) {
-  ctx.body = ctx.url + ' (' + ctx._matchedRoute + ')';
+  ctx.body = `${ctx.url} (${ctx._matchedRoute})`;
 }
 
 app.listen(port, () => {
-  log('Listening on port: ' + port);
+  log(`Listening on port: ${port}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/frameworks/koa/controls.js
+++ b/packages/collector/test/tracing/frameworks/koa/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/index_test.js
+++ b/packages/collector/test/tracing/index_test.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var tracing = require('@instana/core').tracing;
+const tracing = require('@instana/core').tracing;
 
-describe('tracing', function() {
-  describe('supportedVersion', function() {
-    it('must support various Node.js versions', function() {
+describe('tracing', () => {
+  describe('supportedVersion', () => {
+    it('must support various Node.js versions', () => {
       expect(tracing.supportedVersion('4.5.0')).to.equal(true);
       expect(tracing.supportedVersion('4.5.1')).to.equal(true);
       expect(tracing.supportedVersion('4.6.0')).to.equal(true);
@@ -40,7 +40,7 @@ describe('tracing', function() {
       expect(tracing.supportedVersion('15.0.0')).to.equal(true);
     });
 
-    it('must report various Node.js versions as not supported', function() {
+    it('must report various Node.js versions as not supported', () => {
       expect(tracing.supportedVersion('1.15.0')).to.equal(false);
       expect(tracing.supportedVersion('2.15.0')).to.equal(false);
       expect(tracing.supportedVersion('3.15.0')).to.equal(false);

--- a/packages/collector/test/tracing/logger/bunyan/app-instana-creates-bunyan-logger.js
+++ b/packages/collector/test/tracing/logger/bunyan/app-instana-creates-bunyan-logger.js
@@ -2,50 +2,50 @@
 
 'use strict';
 
-var agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_PORT;
 
-var instana = require('../../../..');
+const instana = require('../../../..');
 instana({
-  agentPort: agentPort,
+  agentPort,
   level: 'warn',
   tracing: {
     enabled: process.env.TRACING_ENABLED === 'true',
     forceTransmissionStartingAt: 1
   }
 });
-var instanaLogger;
-instanaLogger = require('../../../../src/logger').getLogger('test-module-name', function(newLogger) {
+let instanaLogger;
+instanaLogger = require('../../../../src/logger').getLogger('test-module-name', newLogger => {
   instanaLogger = newLogger;
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express / Bunyan App [Instana creates Bunyan logger] (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express / Bunyan App [Instana creates Bunyan logger] (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/trigger', function(req, res) {
+app.get('/trigger', (req, res) => {
   instanaLogger.error('An error logged by Instana - this must not be traced');
   res.sendStatus(200);
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/logger/bunyan/app-instana-receives-bunyan-logger.js
+++ b/packages/collector/test/tracing/logger/bunyan/app-instana-receives-bunyan-logger.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_PORT;
 
-var instana = require('../../../..');
+const instana = require('../../../..');
 instana({
-  agentPort: agentPort,
+  agentPort,
   logger: require('bunyan').createLogger({ name: 'app-logger' }),
   level: 'warn',
   tracing: {
@@ -14,39 +14,39 @@ instana({
     forceTransmissionStartingAt: 1
   }
 });
-var instanaLogger;
-instanaLogger = require('../../../../src/logger').getLogger('test-module-name', function(newLogger) {
+let instanaLogger;
+instanaLogger = require('../../../../src/logger').getLogger('test-module-name', newLogger => {
   instanaLogger = newLogger;
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express / Bunyan App [Instana receives Bunyan logger] (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express / Bunyan App [Instana receives Bunyan logger] (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/trigger', function(req, res) {
+app.get('/trigger', (req, res) => {
   instanaLogger.error('An error logged by Instana - this must not be traced');
   res.sendStatus(200);
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/logger/bunyan/app-instana-receives-non-bunyan-logger.js
+++ b/packages/collector/test/tracing/logger/bunyan/app-instana-receives-non-bunyan-logger.js
@@ -2,9 +2,9 @@
 
 'use strict';
 
-var agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_PORT;
 
-var dummyLogger = {
+const dummyLogger = {
   debug: function() {
     // omit debug calls to not pollute test logs
   },
@@ -13,9 +13,9 @@ var dummyLogger = {
   error: console.error
 };
 
-var instana = require('../../../..');
+const instana = require('../../../..');
 instana({
-  agentPort: agentPort,
+  agentPort,
   logger: dummyLogger,
   level: 'warn',
   tracing: {
@@ -23,39 +23,39 @@ instana({
     forceTransmissionStartingAt: 1
   }
 });
-var instanaLogger;
-instanaLogger = require('../../../../src/logger').getLogger('test-module-name', function(newLogger) {
+let instanaLogger;
+instanaLogger = require('../../../../src/logger').getLogger('test-module-name', newLogger => {
   instanaLogger = newLogger;
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express / Bunyan App [Instana receives non-Bunyan logger] (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express / Bunyan App [Instana receives non-Bunyan logger] (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/trigger', function(req, res) {
+app.get('/trigger', (req, res) => {
   instanaLogger.error('An error logged by Instana - this must not be traced');
   res.sendStatus(200);
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/logger/bunyan/app.js
+++ b/packages/collector/test/tracing/logger/bunyan/app.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_PORT;
 
-var instana = require('../../../..');
+const instana = require('../../../..');
 instana({
-  agentPort: agentPort,
+  agentPort,
   level: 'warn',
   tracing: {
     enabled: process.env.TRACING_ENABLED === 'true',
@@ -14,85 +14,85 @@ instana({
   }
 });
 
-var request = require('request-promise');
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const request = require('request-promise');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var bunyan = require('bunyan');
-var logger = bunyan.createLogger({ name: 'test-logger' });
+const bunyan = require('bunyan');
+const logger = bunyan.createLogger({ name: 'test-logger' });
 
-var app = express();
-var logPrefix = 'Express / Bunyan App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express / Bunyan App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/info', function(req, res) {
+app.get('/info', (req, res) => {
   logger.info('Info message - must not be traced.');
   finish(res);
 });
 
-app.get('/warn', function(req, res) {
+app.get('/warn', (req, res) => {
   logger.warn('Warn message - should be traced.');
   finish(res);
 });
 
-app.get('/error', function(req, res) {
+app.get('/error', (req, res) => {
   logger.error('Error message - should be traced.');
   finish(res);
 });
 
-app.get('/fatal', function(req, res) {
+app.get('/fatal', (req, res) => {
   logger.fatal('Fatal message - should be traced.');
   finish(res);
 });
 
-app.get('/error-object-only', function(req, res) {
+app.get('/error-object-only', (req, res) => {
   logger.error(new Error('This is an error.'));
   finish(res);
 });
 
-app.get('/error-random-object-only', function(req, res) {
+app.get('/error-random-object-only', (req, res) => {
   logger.error({ foo: { bar: 'baz' } });
   finish(res);
 });
 
-app.get('/error-object-and-string', function(req, res) {
+app.get('/error-object-and-string', (req, res) => {
   logger.error(new Error('This is an error.'), 'Error message - should be traced.');
   finish(res);
 });
 
-app.get('/error-random-object-and-string', function(req, res) {
+app.get('/error-random-object-and-string', (req, res) => {
   logger.error({ foo: { bar: 'baz' } }, 'Error message - should be traced.');
   finish(res);
 });
 
-app.get('/child-error', function(req, res) {
-  var child = logger.child({ a: 'property' });
+app.get('/child-error', (req, res) => {
+  const child = logger.child({ a: 'property' });
   child.error('Child logger error message - should be traced.');
   finish(res);
 });
 
 function finish(res) {
-  request('http://127.0.0.1:' + agentPort).then(function() {
+  request(`http://127.0.0.1:${agentPort}`).then(() => {
     res.sendStatus(200);
   });
 }
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/logger/bunyan/controls.js
+++ b/packages/collector/test/tracing/logger/bunyan/controls.js
@@ -2,21 +2,21 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../../../utils');
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
-var upstreamPort = require('../../../apps/expressControls').appPort;
-var appPort = (exports.appPort = 3215);
+const utils = require('../../../utils');
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
+const upstreamPort = require('../../../apps/expressControls').appPort;
+const appPort = (exports.appPort = 3215);
 
-var appProcess;
+let appProcess;
 
-exports.registerTestHooks = function(opts) {
+exports.registerTestHooks = opts => {
   opts = opts || {};
-  var appName = 'app.js';
+  let appName = 'app.js';
   if (opts.instanaLoggingMode) {
     switch (opts.instanaLoggingMode) {
       case 'instana-creates-bunyan-logger':
@@ -29,11 +29,11 @@ exports.registerTestHooks = function(opts) {
         appName = 'app-instana-receives-non-bunyan-logger.js';
         break;
       default:
-        throw new Error('Unknown instanaLoggingMode: ' + opts.instanaLoggingMode);
+        throw new Error(`Unknown instanaLoggingMode: ${opts.instanaLoggingMode}`);
     }
   }
-  beforeEach(function() {
-    var env = Object.create(process.env);
+  beforeEach(() => {
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.UPSTREAM_PORT = upstreamPort;
@@ -42,33 +42,29 @@ exports.registerTestHooks = function(opts) {
 
     appProcess = spawn('node', [path.join(__dirname, appName)], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     appProcess.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return appProcess.pid;
-};
+exports.getPid = () => appProcess.pid;
 
-exports.trigger = function(level) {
-  return request('http://127.0.0.1:' + appPort + '/' + level);
-};
+exports.trigger = level => request(`http://127.0.0.1:${appPort}/${level}`);

--- a/packages/collector/test/tracing/logger/pino/app.js
+++ b/packages/collector/test/tracing/logger/pino/app.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_PORT;
 
-var instana = require('../../../..');
+const instana = require('../../../..');
 instana({
-  agentPort: agentPort,
+  agentPort,
   level: 'warn',
   tracing: {
     enabled: process.env.TRACING_ENABLED === 'true',
@@ -14,154 +14,154 @@ instana({
   }
 });
 
-var request = require('request-promise');
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const request = require('request-promise');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var pinoOptions = {
+const pinoOptions = {
   customLevels: {
     customInfo: 31,
     customError: 51
   }
 };
-var pino = require('pino');
-var plainVanillaPino = pino(pinoOptions);
-var expressPino = require('express-pino-logger')(pinoOptions);
+const pino = require('pino');
+const plainVanillaPino = pino(pinoOptions);
+const expressPino = require('express-pino-logger')(pinoOptions);
 
-var app = express();
-var logPrefix = 'Express / Pino App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express / Pino App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(expressPino);
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/info', function(req, res) {
+app.get('/info', (req, res) => {
   plainVanillaPino.info('Info message - must not be traced.');
   finish(res);
 });
 
-app.get('/warn', function(req, res) {
+app.get('/warn', (req, res) => {
   plainVanillaPino.warn('Warn message - should be traced.');
   finish(res);
 });
 
-app.get('/error', function(req, res) {
+app.get('/error', (req, res) => {
   plainVanillaPino.error('Error message - should be traced.');
   finish(res);
 });
 
-app.get('/fatal', function(req, res) {
+app.get('/fatal', (req, res) => {
   plainVanillaPino.fatal('Fatal message - should be traced.');
   finish(res);
 });
 
-app.get('/custom-info', function(req, res) {
+app.get('/custom-info', (req, res) => {
   plainVanillaPino.customInfo('Custom info level message - should not be traced.');
   finish(res);
 });
 
-app.get('/custom-error', function(req, res) {
+app.get('/custom-error', (req, res) => {
   plainVanillaPino.customError('Custom error level message - should be traced.');
   finish(res);
 });
 
-app.get('/error-object-only', function(req, res) {
+app.get('/error-object-only', (req, res) => {
   plainVanillaPino.error(new Error('This is an error.'));
   finish(res);
 });
 
-app.get('/error-random-object-only', function(req, res) {
+app.get('/error-random-object-only', (req, res) => {
   plainVanillaPino.error({ foo: { bar: 'baz' } });
   finish(res);
 });
 
-app.get('/error-object-and-string', function(req, res) {
+app.get('/error-object-and-string', (req, res) => {
   plainVanillaPino.error(new Error('This is an error.'), 'Error message - should be traced.');
   finish(res);
 });
 
-app.get('/error-random-object-and-string', function(req, res) {
+app.get('/error-random-object-and-string', (req, res) => {
   plainVanillaPino.error({ foo: { bar: 'baz' } }, 'Error message - should be traced.');
   finish(res);
 });
 
-app.get('/child-error', function(req, res) {
-  var child = plainVanillaPino.child({ a: 'property' });
+app.get('/child-error', (req, res) => {
+  const child = plainVanillaPino.child({ a: 'property' });
   child.error('Child logger error message - should be traced.');
   finish(res);
 });
 
-app.get('/express-pino-info', function(req, res) {
+app.get('/express-pino-info', (req, res) => {
   req.log.info('Info message - must not be traced.');
   finish(res);
 });
 
-app.get('/express-pino-warn', function(req, res) {
+app.get('/express-pino-warn', (req, res) => {
   req.log.warn('Warn message - should be traced.');
   finish(res);
 });
 
-app.get('/express-pino-error', function(req, res) {
+app.get('/express-pino-error', (req, res) => {
   req.log.error('Error message - should be traced.');
   finish(res);
 });
 
-app.get('/express-pino-fatal', function(req, res) {
+app.get('/express-pino-fatal', (req, res) => {
   req.log.fatal('Fatal message - should be traced.');
   finish(res);
 });
 
-app.get('/express-pino-custom-info', function(req, res) {
+app.get('/express-pino-custom-info', (req, res) => {
   req.log.customInfo('Custom info level message - should not be traced.');
   finish(res);
 });
 
-app.get('/express-pino-custom-error', function(req, res) {
+app.get('/express-pino-custom-error', (req, res) => {
   req.log.customError('Custom error level message - should be traced.');
   finish(res);
 });
 
-app.get('/express-pino-error-object-only', function(req, res) {
+app.get('/express-pino-error-object-only', (req, res) => {
   req.log.error(new Error('This is an error.'));
   finish(res);
 });
 
-app.get('/express-pino-error-random-object-only', function(req, res) {
+app.get('/express-pino-error-random-object-only', (req, res) => {
   req.log.error({ foo: { bar: 'baz' } });
   finish(res);
 });
 
-app.get('/express-pino-error-object-and-string', function(req, res) {
+app.get('/express-pino-error-object-and-string', (req, res) => {
   req.log.error(new Error('This is an error.'), 'Error message - should be traced.');
   finish(res);
 });
 
-app.get('/express-pino-error-random-object-and-string', function(req, res) {
+app.get('/express-pino-error-random-object-and-string', (req, res) => {
   req.log.error({ foo: { bar: 'baz' } }, 'Error message - should be traced.');
   finish(res);
 });
 
 function finish(res) {
-  request('http://127.0.0.1:' + agentPort).then(function() {
+  request(`http://127.0.0.1:${agentPort}`).then(() => {
     res.sendStatus(200);
   });
 }
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/logger/pino/controls.js
+++ b/packages/collector/test/tracing/logger/pino/controls.js
@@ -2,22 +2,22 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../../../utils');
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
-var upstreamPort = require('../../../apps/expressControls').appPort;
-var appPort = (exports.appPort = 3215);
+const utils = require('../../../utils');
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
+const upstreamPort = require('../../../apps/expressControls').appPort;
+const appPort = (exports.appPort = 3215);
 
-var appProcess;
+let appProcess;
 
-exports.registerTestHooks = function(opts) {
+exports.registerTestHooks = opts => {
   opts = opts || {};
-  beforeEach(function() {
-    var env = Object.create(process.env);
+  beforeEach(() => {
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.UPSTREAM_PORT = upstreamPort;
@@ -26,34 +26,32 @@ exports.registerTestHooks = function(opts) {
 
     appProcess = spawn('node', [path.join(__dirname, 'app.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     appProcess.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return appProcess.pid;
-};
+exports.getPid = () => appProcess.pid;
 
-exports.trigger = function(level, useExpressPino) {
-  var pathSegment = (useExpressPino ? '/express-pino-' : '/') + level;
-  return request('http://127.0.0.1:' + appPort + pathSegment);
+exports.trigger = (level, useExpressPino) => {
+  const pathSegment = (useExpressPino ? '/express-pino-' : '/') + level;
+  return request(`http://127.0.0.1:${appPort}${pathSegment}`);
 };

--- a/packages/collector/test/tracing/logger/winston/app.js
+++ b/packages/collector/test/tracing/logger/winston/app.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_PORT;
 
-var instana = require('../../../..');
+const instana = require('../../../..');
 instana({
-  agentPort: agentPort,
+  agentPort,
   level: 'warn',
   tracing: {
     enabled: process.env.TRACING_ENABLED === 'true',
@@ -14,105 +14,105 @@ instana({
   }
 });
 
-var request = require('request-promise');
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const request = require('request-promise');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var winston = require('winston');
+const winston = require('winston');
 winston.add(new winston.transports.Console({ level: 'info' }));
 
-var logger = winston.createLogger({
+const logger = winston.createLogger({
   level: 'info',
   format: winston.format.json(),
   transports: [new winston.transports.Console({ level: 'info' })]
 });
 
-var app = express();
-var logPrefix = 'Express / Winston App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express / Winston App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/info', function(req, res) {
+app.get('/info', (req, res) => {
   logger.info('Info message - must not be traced.');
   finish(res);
 });
 
-app.get('/warn', function(req, res) {
+app.get('/warn', (req, res) => {
   logger.warn('Warn message - should be traced.');
   finish(res);
 });
 
-app.get('/error', function(req, res) {
+app.get('/error', (req, res) => {
   logger.error('Error message - should be traced.');
   finish(res);
 });
 
-app.get('/log-info', function(req, res) {
+app.get('/log-info', (req, res) => {
   logger.log('info', 'Info message - must not be traced.');
   finish(res);
 });
 
-app.get('/log-warn', function(req, res) {
+app.get('/log-warn', (req, res) => {
   logger.log('warn', 'Warn message - should be traced.');
   finish(res);
 });
 
-app.get('/log-error', function(req, res) {
+app.get('/log-error', (req, res) => {
   logger.log('error', 'Error message - should be traced.');
   finish(res);
 });
 
-app.get('/global-info', function(req, res) {
+app.get('/global-info', (req, res) => {
   winston.info('Info message - must not be traced.');
   finish(res);
 });
 
-app.get('/global-warn', function(req, res) {
+app.get('/global-warn', (req, res) => {
   winston.warn('Warn message - should be traced.');
   finish(res);
 });
 
-app.get('/global-error', function(req, res) {
+app.get('/global-error', (req, res) => {
   winston.error('Error message - should be traced.');
   finish(res);
 });
 
-app.get('/global-log-info', function(req, res) {
+app.get('/global-log-info', (req, res) => {
   winston.log('info', 'Info message - must not be traced.');
   finish(res);
 });
 
-app.get('/global-log-warn', function(req, res) {
+app.get('/global-log-warn', (req, res) => {
   winston.log('warn', 'Warn message - should be traced.');
   finish(res);
 });
 
-app.get('/global-log-error', function(req, res) {
+app.get('/global-log-error', (req, res) => {
   winston.log('error', 'Error message - should be traced.');
   finish(res);
 });
 
 function finish(res) {
-  request('http://127.0.0.1:' + agentPort).then(function() {
+  request(`http://127.0.0.1:${agentPort}`).then(() => {
     res.sendStatus(200);
   });
 }
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/messaging/amqp/consumerControls.js
+++ b/packages/collector/test/tracing/messaging/amqp/consumerControls.js
@@ -2,36 +2,34 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var Promise = require('bluebird');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const Promise = require('bluebird');
+const path = require('path');
 
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
 
-var app;
+let app;
 
-exports.registerTestHooks = function(opts) {
-  beforeEach(function() {
+exports.registerTestHooks = opts => {
+  beforeEach(() => {
     opts = opts || {};
 
-    var env = Object.create(process.env);
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.TRACING_ENABLED = opts.enableTracing !== false;
 
-    app = spawn('node', [path.join(__dirname, 'consumer' + opts.apiType + '.js')], {
+    app = spawn('node', [path.join(__dirname, `consumer${opts.apiType}.js`)], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return Promise.delay(1500);
   });
 
-  afterEach(function() {
+  afterEach(() => {
     app.kill();
   });
 };
 
-exports.getPid = function() {
-  return app.pid;
-};
+exports.getPid = () => app.pid;

--- a/packages/collector/test/tracing/messaging/amqp/publisherControls.js
+++ b/packages/collector/test/tracing/messaging/amqp/publisherControls.js
@@ -2,99 +2,93 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../../../utils');
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
-var appPort = (exports.appPort = 3216);
+const utils = require('../../../utils');
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
+const appPort = (exports.appPort = 3216);
 
-var app;
+let app;
 
-exports.registerTestHooks = function(opts) {
-  beforeEach(function() {
+exports.registerTestHooks = opts => {
+  beforeEach(() => {
     opts = opts || {};
 
-    var env = Object.create(process.env);
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.TRACING_ENABLED = opts.enableTracing !== false;
 
-    app = spawn('node', [path.join(__dirname, 'publisher' + opts.apiType + '.js')], {
+    app = spawn('node', [path.join(__dirname, `publisher${opts.apiType}.js`)], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     app.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return app.pid;
-};
+exports.getPid = () => app.pid;
 
-exports.sendToQueue = function(message) {
-  return request({
+exports.sendToQueue = message =>
+  request({
     method: 'POST',
-    url: 'http://127.0.0.1:' + appPort + '/send-to-queue',
+    url: `http://127.0.0.1:${appPort}/send-to-queue`,
     json: true,
     simple: true,
     body: {
-      message: message
+      message
     }
   });
-};
 
-exports.publish = function(message) {
-  return request({
+exports.publish = message =>
+  request({
     method: 'POST',
-    url: 'http://127.0.0.1:' + appPort + '/publish',
+    url: `http://127.0.0.1:${appPort}/publish`,
     json: true,
     simple: true,
     body: {
-      message: message
+      message
     }
   });
-};
 
-exports.sendToGetQueue = function(message) {
-  return request({
+exports.sendToGetQueue = message =>
+  request({
     method: 'POST',
-    url: 'http://127.0.0.1:' + appPort + '/send-to-get-queue',
+    url: `http://127.0.0.1:${appPort}/send-to-get-queue`,
     json: true,
     simple: true,
     body: {
-      message: message
+      message
     }
   });
-};
 
-exports.sendToConfirmQueue = function(message) {
-  return request({
+exports.sendToConfirmQueue = message =>
+  request({
     method: 'POST',
-    url: 'http://127.0.0.1:' + appPort + '/send-to-confirm-queue',
+    url: `http://127.0.0.1:${appPort}/send-to-confirm-queue`,
     json: true,
     simple: true,
     body: {
-      message: message
+      message
     }
   });
-};

--- a/packages/collector/test/tracing/messaging/amqp/publisherPromises.js
+++ b/packages/collector/test/tracing/messaging/amqp/publisherPromises.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-var agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_PORT;
 
 require('../../../../')({
-  agentPort: agentPort,
+  agentPort,
   level: 'warn',
   tracing: {
     enabled: process.env.TRACING_ENABLED === 'true',
@@ -13,57 +13,53 @@ require('../../../../')({
   }
 });
 
-var amqp = require('amqplib');
-var exchange = require('./amqpUtil').exchange;
-var queueName = require('./amqpUtil').queueName;
-var queueNameGet = require('./amqpUtil').queueNameGet;
-var queueNameConfirm = require('./amqpUtil').queueNameConfirm;
-var connection;
-var channel;
-var confirmChannel;
+const amqp = require('amqplib');
+const exchange = require('./amqpUtil').exchange;
+const queueName = require('./amqpUtil').queueName;
+const queueNameGet = require('./amqpUtil').queueNameGet;
+const queueNameConfirm = require('./amqpUtil').queueNameConfirm;
+let connection;
+let channel;
+let confirmChannel;
 
-var request = require('request-promise');
-var bodyParser = require('body-parser');
-var express = require('express');
-var app = express();
+const request = require('request-promise');
+const bodyParser = require('body-parser');
+const express = require('express');
+const app = express();
 
 // promise based amqp publisher
 amqp
   .connect('amqp://localhost')
-  .then(function(_connection) {
+  .then(_connection => {
     connection = _connection;
     return connection.createChannel();
   })
-  .then(function(_channel) {
+  .then(_channel => {
     channel = _channel;
     return channel.assertExchange(exchange, 'fanout', { durable: false });
   })
-  .then(function() {
+  .then(() =>
     // stand alone queue (for sendToQueue)
-    return channel.assertQueue(queueName, { durable: false });
-  })
-  .then(function() {
+    channel.assertQueue(queueName, { durable: false })
+  )
+  .then(() =>
     // stand alone queue (for get)
-    return channel.assertQueue(queueNameGet, { durable: false, noAck: true });
-  })
-  .then(function() {
-    return channel.purgeQueue(queueNameGet);
-  })
-  .then(function() {
-    return connection.createConfirmChannel();
-  })
-  .then(function(_confirmChannel) {
+    channel.assertQueue(queueNameGet, { durable: false, noAck: true })
+  )
+  .then(() => channel.purgeQueue(queueNameGet))
+  .then(() => connection.createConfirmChannel())
+  .then(_confirmChannel => {
     confirmChannel = _confirmChannel;
     return confirmChannel.assertQueue(queueNameConfirm, { durable: false });
   })
-  .then(function() {
+  .then(() => {
     log('amqp connection established');
   })
   .catch(console.warn);
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   if (channel && confirmChannel) {
     res.send('OK');
   } else {
@@ -71,78 +67,78 @@ app.get('/', function(req, res) {
   }
 });
 
-app.post('/publish', function(req, res) {
+app.post('/publish', (req, res) => {
   // sendToQueue, publish et al. do not return a promise because they do not necessarily wait for any confirmation from
   // RabbitMQ - see https://github.com/squaremo/amqp.node/issues/89#issuecomment-62632326
   channel.publish(exchange, '', Buffer.from(req.body.message));
 
-  request('http://127.0.0.1:' + agentPort)
-    .then(function() {
+  request(`http://127.0.0.1:${agentPort}`)
+    .then(() => {
       res.status(201).send('OK');
     })
-    .catch(function(err) {
+    .catch(err => {
       log(err);
       res.sendStatus(500);
     });
 });
 
-app.post('/send-to-queue', function(req, res) {
+app.post('/send-to-queue', (req, res) => {
   // sendToQueue, publish et al. do not return a promise because they do not necessarily wait for any confirmation from
   // RabbitMQ - see https://github.com/squaremo/amqp.node/issues/89#issuecomment-62632326
   channel.sendToQueue(queueName, Buffer.from(req.body.message));
 
-  request('http://127.0.0.1:' + agentPort)
-    .then(function() {
+  request(`http://127.0.0.1:${agentPort}`)
+    .then(() => {
       res.status(201).send('OK');
     })
-    .catch(function(err) {
+    .catch(err => {
       log(err);
       res.sendStatus(500);
     });
 });
 
-app.post('/send-to-get-queue', function(req, res) {
+app.post('/send-to-get-queue', (req, res) => {
   // sendToQueue, publish et al. do not return a promise because they do not necessarily wait for any confirmation from
   // RabbitMQ - see https://github.com/squaremo/amqp.node/issues/89#issuecomment-62632326
   log('sending to', queueNameGet);
   channel.sendToQueue(queueNameGet, Buffer.from(req.body.message));
 
-  request('http://127.0.0.1:' + agentPort)
-    .then(function() {
+  request(`http://127.0.0.1:${agentPort}`)
+    .then(() => {
       res.status(201).send('OK');
     })
-    .catch(function(err) {
+    .catch(err => {
       log(err);
       res.sendStatus(500);
     });
 });
 
-app.post('/send-to-confirm-queue', function(req, res) {
+app.post('/send-to-confirm-queue', (req, res) => {
   // Even with a ConfirmChannel and even in the promise API case, sendToQueue/publish do not return a promise, but only
   // accept a callback, see
   // http://www.squaremobius.net/amqp.node/channel_api.html#confirmchannel_sendToQueue
-  confirmChannel.sendToQueue(queueNameConfirm, Buffer.from(req.body.message), {}, function(err, ok) {
+  confirmChannel.sendToQueue(queueNameConfirm, Buffer.from(req.body.message), {}, (err, ok) => {
     if (err) {
       log(err || !ok);
       return res.sendStatus(500);
     }
-    request('http://127.0.0.1:' + agentPort)
-      .then(function() {
+    request(`http://127.0.0.1:${agentPort}`)
+      .then(() => {
         res.status(201).send('OK');
       })
-      .catch(function(err2) {
+      .catch(err2 => {
         log(err2);
         res.sendStatus(500);
       });
   });
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
-  args[0] = 'Express RabbitMQ Publisher/Promises (' + process.pid + '):\t' + args[0];
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `Express RabbitMQ Publisher/Promises (${process.pid}):\t${args[0]}`;
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/messaging/amqp/test.js
+++ b/packages/collector/test/tracing/messaging/amqp/test.js
@@ -2,21 +2,21 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var utils = require('../../../utils');
-var exchange = require('./amqpUtil').exchange;
-var queueName = require('./amqpUtil').queueName;
-var queueNameGet = require('./amqpUtil').queueNameGet;
-var queueNameConfirm = require('./amqpUtil').queueNameConfirm;
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const utils = require('../../../utils');
+const exchange = require('./amqpUtil').exchange;
+const queueName = require('./amqpUtil').queueName;
+const queueNameGet = require('./amqpUtil').queueNameGet;
+const queueNameConfirm = require('./amqpUtil').queueNameConfirm;
 
-var publisherControls;
-var consumerControls;
-var agentStubControls;
+let publisherControls;
+let consumerControls;
+let agentStubControls;
 
-describe('tracing/amqp', function() {
+describe('tracing/amqp', () => {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
@@ -27,7 +27,7 @@ describe('tracing/amqp', function() {
 
   agentStubControls.registerTestHooks();
 
-  ['Promises', 'Callbacks'].forEach(function(apiType) {
+  ['Promises', 'Callbacks'].forEach(apiType => {
     describe(apiType, function() {
       registerTests.call(this, apiType);
     });
@@ -36,24 +36,24 @@ describe('tracing/amqp', function() {
 
 function registerTests(apiType) {
   publisherControls.registerTestHooks({
-    apiType: apiType
+    apiType
   });
   consumerControls.registerTestHooks({
-    apiType: apiType
+    apiType
   });
 
-  beforeEach(function() {
-    return Promise.all([
+  beforeEach(() =>
+    Promise.all([
       agentStubControls.waitUntilAppIsCompletelyInitialized(consumerControls.getPid()),
       agentStubControls.waitUntilAppIsCompletelyInitialized(publisherControls.getPid())
-    ]);
-  });
+    ])
+  );
 
-  it('must record an exit span for sendToQueue', function() {
-    return publisherControls.sendToQueue('Ohai!').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var entrySpan = utils.expectOneMatching(spans, function(span) {
+  it('must record an exit span for sendToQueue', () =>
+    publisherControls.sendToQueue('Ohai!').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const entrySpan = utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.server');
             expect(span.f.e).to.equal(String(publisherControls.getPid()));
             expect(span.f.h).to.equal('agent-stub-uuid');
@@ -61,7 +61,7 @@ function registerTests(apiType) {
             expect(span.error).to.equal(false);
           });
 
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
             expect(span.k).to.equal(constants.EXIT);
@@ -77,22 +77,21 @@ function registerTests(apiType) {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
             expect(span.k).to.equal(constants.EXIT);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 
-  it('must record an exit span for publish', function() {
-    return publisherControls.publish('Ohai!').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var entrySpan = utils.expectOneMatching(spans, function(span) {
+  it('must record an exit span for publish', () =>
+    publisherControls.publish('Ohai!').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const entrySpan = utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.server');
             expect(span.f.e).to.equal(String(publisherControls.getPid()));
             expect(span.f.h).to.equal('agent-stub-uuid');
@@ -100,7 +99,7 @@ function registerTests(apiType) {
             expect(span.error).to.equal(false);
           });
 
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
             expect(span.k).to.equal(constants.EXIT);
@@ -115,27 +114,26 @@ function registerTests(apiType) {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
             expect(span.k).to.equal(constants.EXIT);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 
-  it('must record an entry span for consume without exchange', function() {
-    return publisherControls.sendToQueue('Ohai').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var rabbitMqExit = utils.expectOneMatching(spans, function(span) {
+  it('must record an entry span for consume without exchange', () =>
+    publisherControls.sendToQueue('Ohai').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const rabbitMqExit = utils.expectOneMatching(spans, span => {
             expect(span.k).to.equal(constants.EXIT);
             expect(span.n).to.equal('rabbitmq');
           });
 
-          var rabbitMqEntry = utils.expectOneMatching(spans, function(span) {
+          const rabbitMqEntry = utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqExit.s);
             expect(span.n).to.equal('rabbitmq');
@@ -151,27 +149,26 @@ function registerTests(apiType) {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqEntry.s);
             expect(span.k).to.equal(constants.EXIT);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 
-  it('must record an entry span for consume with exchange', function() {
-    return publisherControls.publish('Ohai').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var rabbitMqExit = utils.expectOneMatching(spans, function(span) {
+  it('must record an entry span for consume with exchange', () =>
+    publisherControls.publish('Ohai').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const rabbitMqExit = utils.expectOneMatching(spans, span => {
             expect(span.k).to.equal(constants.EXIT);
             expect(span.n).to.equal('rabbitmq');
           });
 
-          var rabbitMqEntry = utils.expectOneMatching(spans, function(span) {
+          const rabbitMqEntry = utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqExit.s);
             expect(span.n).to.equal('rabbitmq');
@@ -187,27 +184,26 @@ function registerTests(apiType) {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqEntry.s);
             expect(span.k).to.equal(constants.EXIT);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 
-  it('must record an entry span for channel#get', function() {
-    return publisherControls.sendToGetQueue('Ohai').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var rabbitMqExit = utils.expectOneMatching(spans, function(span) {
+  it('must record an entry span for channel#get', () =>
+    publisherControls.sendToGetQueue('Ohai').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const rabbitMqExit = utils.expectOneMatching(spans, span => {
             expect(span.k).to.equal(constants.EXIT);
             expect(span.n).to.equal('rabbitmq');
           });
 
-          var rabbitMqEntry = utils.expectOneMatching(spans, function(span) {
+          const rabbitMqEntry = utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqExit.s);
             expect(span.n).to.equal('rabbitmq');
@@ -223,22 +219,21 @@ function registerTests(apiType) {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqEntry.s);
             expect(span.k).to.equal(constants.EXIT);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 
-  it('must record an exit span for ConfirmChannel#sendToQueue', function() {
-    return publisherControls.sendToConfirmQueue('Ohai!').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var entrySpan = utils.expectOneMatching(spans, function(span) {
+  it('must record an exit span for ConfirmChannel#sendToQueue', () =>
+    publisherControls.sendToConfirmQueue('Ohai!').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const entrySpan = utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.server');
             expect(span.f.e).to.equal(String(publisherControls.getPid()));
             expect(span.f.h).to.equal('agent-stub-uuid');
@@ -246,7 +241,7 @@ function registerTests(apiType) {
             expect(span.error).to.equal(false);
           });
 
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
             expect(span.k).to.equal(constants.EXIT);
@@ -262,27 +257,26 @@ function registerTests(apiType) {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
             expect(span.k).to.equal(constants.EXIT);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 
-  it('must record an entry span for ConfirmChannel.consume', function() {
-    return publisherControls.sendToConfirmQueue('Ohai').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var rabbitMqExit = utils.expectOneMatching(spans, function(span) {
+  it('must record an entry span for ConfirmChannel.consume', () =>
+    publisherControls.sendToConfirmQueue('Ohai').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const rabbitMqExit = utils.expectOneMatching(spans, span => {
             expect(span.k).to.equal(constants.EXIT);
             expect(span.n).to.equal('rabbitmq');
           });
 
-          var rabbitMqEntry = utils.expectOneMatching(spans, function(span) {
+          const rabbitMqEntry = utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqExit.s);
             expect(span.n).to.equal('rabbitmq');
@@ -297,14 +291,13 @@ function registerTests(apiType) {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(rabbitMqExit.t);
             expect(span.p).to.equal(rabbitMqEntry.s);
             expect(span.k).to.equal(constants.EXIT);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 }

--- a/packages/collector/test/tracing/messaging/kafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/kafka/consumer.js
@@ -1,9 +1,11 @@
 /* eslint-disable */
 
-var agentPort = process.env.AGENT_PORT;
+'use strict';
 
-var instana = require('../../../../')({
-  agentPort: agentPort,
+const agentPort = process.env.AGENT_PORT;
+
+const instana = require('../../../../')({
+  agentPort,
   level: 'warn',
   tracing: {
     enabled: process.env.TRACING_ENABLED === 'true',
@@ -11,16 +13,16 @@ var instana = require('../../../../')({
   }
 });
 
-var request = require('request-promise');
-var kafka = require('kafka-node');
-var uuid = require('uuid/v4');
+const request = require('request-promise');
+const kafka = require('kafka-node');
+const uuid = require('uuid/v4');
 
-var client = new kafka.Client(process.env.ZOOKEEPER + '/');
-client.on('error', function(error) {
+const client = new kafka.Client(`${process.env.ZOOKEEPER}/`);
+client.on('error', error => {
   log('Got a client error: %s', error);
 });
 
-var consumer;
+let consumer;
 if (process.env.CONSUMER_TYPE === 'plain') {
   log('Using Consumer');
   consumer = new kafka.Consumer(
@@ -61,13 +63,13 @@ if (process.env.CONSUMER_TYPE === 'plain') {
   );
 }
 
-consumer.on('error', function(err) {
+consumer.on('error', err => {
   log('Error occured in consumer:', err);
-  var span = instana.currentSpan();
+  const span = instana.currentSpan();
   span.disableAutoEnd();
   // simulating asynchronous follow up steps with setTimeout and request-promise
-  setTimeout(function() {
-    request('http://127.0.0.1:' + agentPort).finally(function() {
+  setTimeout(() => {
+    request(`http://127.0.0.1:${agentPort}`).finally(() => {
       span.end(1);
     });
   }, 100);
@@ -75,18 +77,18 @@ consumer.on('error', function(err) {
 
 consumer.on('message', function() {
   log('Got message in Kafka consumer', arguments);
-  var span = instana.currentSpan();
+  const span = instana.currentSpan();
   span.disableAutoEnd();
   // simulating asynchronous follow up steps with setTimeout and request-promise
-  setTimeout(function() {
-    request('http://127.0.0.1:' + agentPort).finally(function() {
+  setTimeout(() => {
+    request(`http://127.0.0.1:${agentPort}`).finally(() => {
       span.end();
     });
   }, 100);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
-  args[0] = 'Express Kafka Producer App (' + process.pid + '):\t' + args[0];
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `Express Kafka Producer App (${process.pid}):\t${args[0]}`;
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/messaging/kafka/consumerControls.js
+++ b/packages/collector/test/tracing/messaging/kafka/consumerControls.js
@@ -2,37 +2,35 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var Promise = require('bluebird');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const Promise = require('bluebird');
+const path = require('path');
 
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
 
-var app;
+let app;
 
-exports.registerTestHooks = function(opts) {
-  beforeEach(function() {
+exports.registerTestHooks = opts => {
+  beforeEach(() => {
     opts = opts || {};
 
-    var env = Object.create(process.env);
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.TRACING_ENABLED = opts.enableTracing !== false;
     env.CONSUMER_TYPE = opts.consumerType;
 
     app = spawn('node', [path.join(__dirname, 'consumer.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return Promise.delay(1500);
   });
 
-  afterEach(function() {
+  afterEach(() => {
     app.kill();
   });
 };
 
-exports.getPid = function() {
-  return app.pid;
-};
+exports.getPid = () => app.pid;

--- a/packages/collector/test/tracing/messaging/kafka/producerControls.js
+++ b/packages/collector/test/tracing/messaging/kafka/producerControls.js
@@ -2,64 +2,61 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../../../utils');
-var config = require('../../../config');
-var agentPort = require('../../../apps/agentStubControls').agentPort;
-var appPort = (exports.appPort = 3216);
+const utils = require('../../../utils');
+const config = require('../../../config');
+const agentPort = require('../../../apps/agentStubControls').agentPort;
+const appPort = (exports.appPort = 3216);
 
-var app;
+let app;
 
-exports.registerTestHooks = function(opts) {
-  beforeEach(function() {
+exports.registerTestHooks = opts => {
+  beforeEach(() => {
     opts = opts || {};
 
-    var env = Object.create(process.env);
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.TRACING_ENABLED = opts.enableTracing !== false;
 
     app = spawn('node', [path.join(__dirname, 'producer.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     app.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return app.pid;
-};
+exports.getPid = () => app.pid;
 
-exports.send = function(key, message) {
-  return request({
+exports.send = (key, message) =>
+  request({
     method: 'POST',
-    url: 'http://127.0.0.1:' + appPort + '/send-message',
+    url: `http://127.0.0.1:${appPort}/send-message`,
     json: true,
     simple: true,
     body: {
-      key: key,
-      message: message
+      key,
+      message
     }
   });
-};

--- a/packages/collector/test/tracing/messaging/kafka/test.js
+++ b/packages/collector/test/tracing/messaging/kafka/test.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/kafka', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var expressKafkaProducerControls = require('./producerControls');
-  var kafkaConsumerControls = require('./consumerControls');
-  var agentStubControls = require('../../../apps/agentStubControls');
+  const expressKafkaProducerControls = require('./producerControls');
+  const kafkaConsumerControls = require('./consumerControls');
+  const agentStubControls = require('../../../apps/agentStubControls');
 
   // Too many moving parts with Kafka involved. Increase the default timeout.
   // This is especially important since the Kafka client has an
@@ -24,15 +24,13 @@ describe('tracing/kafka', function() {
   agentStubControls.registerTestHooks();
   expressKafkaProducerControls.registerTestHooks();
 
-  beforeEach(function() {
-    return agentStubControls.waitUntilAppIsCompletelyInitialized(expressKafkaProducerControls.getPid());
-  });
+  beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(expressKafkaProducerControls.getPid()));
 
-  it('must record trace publish spans', function() {
-    return expressKafkaProducerControls.send('someKey', 'someMessage').then(function() {
-      return utils.retry(function() {
-        return agentStubControls.getSpans().then(function(spans) {
-          var entrySpan = utils.expectOneMatching(spans, function(span) {
+  it('must record trace publish spans', () =>
+    expressKafkaProducerControls.send('someKey', 'someMessage').then(() =>
+      utils.retry(() =>
+        agentStubControls.getSpans().then(spans => {
+          const entrySpan = utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.server');
             expect(span.f.e).to.equal(String(expressKafkaProducerControls.getPid()));
             expect(span.f.h).to.equal('agent-stub-uuid');
@@ -40,7 +38,7 @@ describe('tracing/kafka', function() {
             expect(span.error).to.equal(false);
           });
 
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
             expect(span.n).to.equal('kafka');
@@ -54,38 +52,35 @@ describe('tracing/kafka', function() {
           });
 
           // verify that subsequent calls are correctly traced
-          utils.expectOneMatching(spans, function(span) {
+          utils.expectOneMatching(spans, span => {
             expect(span.n).to.equal('node.http.client');
             expect(span.t).to.equal(entrySpan.t);
             expect(span.p).to.equal(entrySpan.s);
           });
-        });
-      });
-    });
-  });
+        })
+      )
+    ));
 
-  ['consumerGroup', 'plain', 'highLevel'].forEach(function(consumerType) {
-    describe('consuming via: ' + consumerType, function() {
+  ['consumerGroup', 'plain', 'highLevel'].forEach(consumerType => {
+    describe(`consuming via: ${consumerType}`, () => {
       kafkaConsumerControls.registerTestHooks({
-        consumerType: consumerType
+        consumerType
       });
 
-      beforeEach(function() {
-        return agentStubControls.waitUntilAppIsCompletelyInitialized(kafkaConsumerControls.getPid());
-      });
+      beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(kafkaConsumerControls.getPid()));
 
-      it('must record kafka consumer spans via:' + consumerType, function() {
-        return utils.retry(function() {
-          return expressKafkaProducerControls.send('someKey', 'someMessage').then(function() {
-            return agentStubControls.getSpans().then(function(spans) {
-              var entrySpan = utils.expectOneMatching(spans, function(span) {
+      it(`must record kafka consumer spans via:${consumerType}`, () =>
+        utils.retry(() =>
+          expressKafkaProducerControls.send('someKey', 'someMessage').then(() =>
+            agentStubControls.getSpans().then(spans => {
+              const entrySpan = utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.server');
                 expect(span.f.e).to.equal(String(expressKafkaProducerControls.getPid()));
                 expect(span.f.h).to.equal('agent-stub-uuid');
                 expect(span.async).to.equal(false);
                 expect(span.error).to.equal(false);
               });
-              utils.expectOneMatching(spans, function(span) {
+              utils.expectOneMatching(spans, span => {
                 expect(span.t).to.equal(entrySpan.t);
                 expect(span.p).to.equal(entrySpan.s);
                 expect(span.n).to.equal('kafka');
@@ -103,7 +98,7 @@ describe('tracing/kafka', function() {
               // Node.js/kafka. See
               // https://github.com/SOHU-Co/kafka-node/issues/763
               // So for now, span.p is undefined (new root span) and span.t is not equal to entrySpan.t.
-              var kafkaConsumeEntry = utils.expectOneMatching(spans, function(span) {
+              const kafkaConsumeEntry = utils.expectOneMatching(spans, span => {
                 expect(span.p).to.equal(undefined);
                 expect(span.n).to.equal('kafka');
                 expect(span.k).to.equal(constants.ENTRY);
@@ -116,15 +111,14 @@ describe('tracing/kafka', function() {
                 expect(span.data.kafka.service).to.equal('test');
               });
               // verify that subsequent calls are correctly traced
-              utils.expectOneMatching(spans, function(span) {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.client');
                 expect(span.t).to.equal(kafkaConsumeEntry.t);
                 expect(span.p).to.equal(kafkaConsumeEntry.s);
               });
-            });
-          });
-        });
-      });
+            })
+          )
+        ));
     });
   });
 });

--- a/packages/collector/test/tracing/open_tracing/app.js
+++ b/packages/collector/test/tracing/open_tracing/app.js
@@ -1,6 +1,8 @@
 /* eslint-disable */
 
-var instana = require('../../../');
+'use strict';
+
+const instana = require('../../../');
 instana({
   agentPort: process.env.AGENT_PORT,
   level: 'warn',
@@ -12,45 +14,45 @@ instana({
   }
 });
 
-var opentracing = require('opentracing');
-var express = require('express');
-var app = express();
+const opentracing = require('opentracing');
+const express = require('express');
+const app = express();
 
 opentracing.initGlobalTracer(instana.opentracing.createTracer());
-var tracer = opentracing.globalTracer();
+const tracer = opentracing.globalTracer();
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.send('OK');
 });
 
-app.get('/withOpentracing', function(req, res) {
+app.get('/withOpentracing', (req, res) => {
   log('########################## Start span!');
-  var serviceSpan = tracer.startSpan('service');
+  const serviceSpan = tracer.startSpan('service');
   log('########################## Started span:', serviceSpan);
   serviceSpan.setTag(opentracing.Tags.SPAN_KIND, opentracing.Tags.SPAN_KIND_RPC_SERVER);
-  var authSpan = tracer.startSpan('auth', { childOf: serviceSpan });
+  const authSpan = tracer.startSpan('auth', { childOf: serviceSpan });
   authSpan.finish();
   serviceSpan.finish();
   res.send('OK');
 });
 
-app.get('/withOpentracingConnectedToInstanaTrace', function(req, res) {
-  var spanContext = instana.opentracing.getCurrentlyActiveInstanaSpanContext();
-  var serviceSpan = tracer.startSpan('service', { childOf: spanContext });
+app.get('/withOpentracingConnectedToInstanaTrace', (req, res) => {
+  const spanContext = instana.opentracing.getCurrentlyActiveInstanaSpanContext();
+  const serviceSpan = tracer.startSpan('service', { childOf: spanContext });
   serviceSpan.finish();
   res.send('OK');
 });
 
-app.get('/getCurrentlyActiveInstanaSpanContext', function(req, res) {
+app.get('/getCurrentlyActiveInstanaSpanContext', (req, res) => {
   res.json(instana.opentracing.getCurrentlyActiveInstanaSpanContext());
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
-  args[0] = 'Express OT App (' + process.pid + '):\t' + args[0];
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `Express OT App (${process.pid}):\t${args[0]}`;
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/open_tracing/controls.js
+++ b/packages/collector/test/tracing/open_tracing/controls.js
@@ -2,22 +2,22 @@
 
 'use strict';
 
-var spawn = require('child_process').spawn;
-var request = require('request-promise');
-var path = require('path');
+const spawn = require('child_process').spawn;
+const request = require('request-promise');
+const path = require('path');
 
-var utils = require('../../utils');
-var config = require('../../config');
-var agentPort = require('../../apps/agentStubControls').agentPort;
-var appPort = (exports.appPort = 3215);
+const utils = require('../../utils');
+const config = require('../../config');
+const agentPort = require('../../apps/agentStubControls').agentPort;
+const appPort = (exports.appPort = 3215);
 
-var expressOpentracingApp;
+let expressOpentracingApp;
 
-exports.registerTestHooks = function(opts) {
-  beforeEach(function() {
+exports.registerTestHooks = opts => {
+  beforeEach(() => {
     opts = opts || {};
 
-    var env = Object.create(process.env);
+    const env = Object.create(process.env);
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.TRACING_ENABLED = opts.enableTracing !== false;
@@ -25,36 +25,33 @@ exports.registerTestHooks = function(opts) {
 
     expressOpentracingApp = spawn('node', [path.join(__dirname, 'app.js')], {
       stdio: config.getAppStdio(),
-      env: env
+      env
     });
 
     return waitUntilServerIsUp();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     expressOpentracingApp.kill();
   });
 };
 
 function waitUntilServerIsUp() {
-  return utils.retry(function() {
-    return request({
+  return utils.retry(() =>
+    request({
       method: 'GET',
-      url: 'http://127.0.0.1:' + appPort,
+      url: `http://127.0.0.1:${appPort}`,
       headers: {
         'X-INSTANA-L': '0'
       }
-    });
-  });
+    })
+  );
 }
 
-exports.getPid = function() {
-  return expressOpentracingApp.pid;
-};
+exports.getPid = () => expressOpentracingApp.pid;
 
-exports.sendRequest = function(opts) {
-  return request({
+exports.sendRequest = opts =>
+  request({
     method: opts.method,
-    url: 'http://127.0.0.1:' + appPort + opts.path
+    url: `http://127.0.0.1:${appPort}${opts.path}`
   });
-};

--- a/packages/collector/test/tracing/protocols/grpc/clientControls.js
+++ b/packages/collector/test/tracing/protocols/grpc/clientControls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'client.js');
   opts.port = 3216;
   AbstractControls.call(this, opts);

--- a/packages/collector/test/tracing/protocols/grpc/serverControls.js
+++ b/packages/collector/test/tracing/protocols/grpc/serverControls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'server.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/protocols/grpc/test.js
+++ b/packages/collector/test/tracing/protocols/grpc/test.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var expect = require('chai').expect;
-var Promise = require('bluebird');
-var semver = require('semver');
+const expect = require('chai').expect;
+const Promise = require('bluebird');
+const semver = require('semver');
 
-var constants = require('@instana/core').tracing.constants;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
-var agentControls;
-var ClientControls;
-var ServerControls;
-var serverControls;
-var clientControls;
+let agentControls;
+let ClientControls;
+let ServerControls;
+let serverControls;
+let clientControls;
 
 describe('tracing/grpc', function() {
   if (!semver.satisfies(process.versions.node, '>=8.2.1')) {
@@ -25,8 +25,8 @@ describe('tracing/grpc', function() {
 
   this.timeout(config.getTestTimeout());
 
-  ['dynamic', 'static'].forEach(function(codeGenMode) {
-    [false, true].forEach(function(withMetadata) {
+  ['dynamic', 'static'].forEach(codeGenMode => {
+    [false, true].forEach(withMetadata => {
       [false, true].forEach(function(withOptions) {
         registerSuite.bind(this)(codeGenMode, withMetadata, withOptions);
       });
@@ -34,15 +34,15 @@ describe('tracing/grpc', function() {
   });
   // registerSuite.bind(this)('dynamic', false, false);
 
-  describe('suppressed', function() {
+  describe('suppressed', () => {
     agentControls.registerTestHooks();
-    serverControls = new ServerControls({ agentControls: agentControls });
+    serverControls = new ServerControls({ agentControls });
     serverControls.registerTestHooks();
-    clientControls = new ClientControls({ agentControls: agentControls });
+    clientControls = new ClientControls({ agentControls });
     clientControls.registerTestHooks();
 
-    it('should not trace when suppressed', function() {
-      return clientControls
+    it('should not trace when suppressed', () =>
+      clientControls
         .sendRequest({
           method: 'POST',
           path: '/unary-call',
@@ -50,107 +50,87 @@ describe('tracing/grpc', function() {
             'X-INSTANA-L': '0'
           }
         })
-        .then(function(response) {
+        .then(response => {
           expect(response.reply).to.equal('received: request');
           return Promise.delay(config.getTestTimeout() / 4);
         })
-        .then(function() {
-          return agentControls.getSpans().then(function(spans) {
+        .then(() =>
+          agentControls.getSpans().then(spans => {
             expect(spans).to.have.lengthOf(0);
-          });
-        });
-    });
+          })
+        ));
   });
 });
 
 function registerSuite(codeGenMode, withMetadata, withOptions) {
-  describe(
-    'codegen: ' + codeGenMode + ', with metadata: ' + withMetadata + ', with options: ' + withOptions,
-    function() {
-      var env = {};
-      if (codeGenMode === 'static') {
-        env.GRPC_STATIC = true;
-      }
-      if (withMetadata) {
-        env.GRPC_WITH_METADATA = true;
-      }
-      if (withOptions) {
-        env.GRPC_WITH_OPTIONS = true;
-      }
-      agentControls.registerTestHooks();
-      serverControls = new ServerControls({
-        agentControls: agentControls,
-        env: env
-      });
-      serverControls.registerTestHooks();
-      clientControls = new ClientControls({
-        agentControls: agentControls,
-        env: env
-      });
-      clientControls.registerTestHooks();
-
-      it('must trace an unary call', function() {
-        var expectedReply = 'received: request' + (withMetadata ? ' & test-content' : '');
-        return runTest('/unary-call', expectedReply);
-      });
-
-      it('must cancel an unary call', function() {
-        return runTest('/unary-call', null, true, false);
-      });
-
-      it('must mark unary call as erroneous', function() {
-        return runTest('/unary-call', null, false, true);
-      });
-
-      it('must trace server-side streaming', function() {
-        var expectedReply = withMetadata
-          ? ['received: request & test-content', 'streaming', 'more', 'data']
-          : ['received: request', 'streaming', 'more', 'data'];
-        return runTest('/server-stream', expectedReply);
-      });
-
-      it('must cancel server-side streaming', function() {
-        return runTest('/server-stream', null, true, false);
-      });
-
-      it('must mark server-side streaming as erroneous', function() {
-        return runTest('/server-stream', null, false, true);
-      });
-
-      it('must trace client-side streaming', function() {
-        var expectedReply = 'first; second; third';
-        return runTest('/client-stream', expectedReply);
-      });
-
-      it('must cancel client-side streaming', function() {
-        return runTest('/client-stream', null, true, false);
-      });
-
-      it('must mark client-side streaming as erroneous', function() {
-        return runTest('/client-stream', null, false, true);
-      });
-
-      it('must trace bidi streaming', function() {
-        var expectedReply = withMetadata
-          ? [
-              'received: first & test-content',
-              'received: second & test-content',
-              'received: third & test-content',
-              'STOP'
-            ]
-          : ['received: first', 'received: second', 'received: third', 'STOP'];
-        return runTest('/bidi-stream', expectedReply);
-      });
-
-      it('must cancel bidi streaming', function() {
-        return runTest('/bidi-stream', null, true, false);
-      });
-
-      it('must mark bidi streaming as erroneous', function() {
-        return runTest('/bidi-stream', null, false, true);
-      });
+  describe(`codegen: ${codeGenMode}, with metadata: ${withMetadata}, with options: ${withOptions}`, () => {
+    const env = {};
+    if (codeGenMode === 'static') {
+      env.GRPC_STATIC = true;
     }
-  );
+    if (withMetadata) {
+      env.GRPC_WITH_METADATA = true;
+    }
+    if (withOptions) {
+      env.GRPC_WITH_OPTIONS = true;
+    }
+    agentControls.registerTestHooks();
+    serverControls = new ServerControls({
+      agentControls,
+      env
+    });
+    serverControls.registerTestHooks();
+    clientControls = new ClientControls({
+      agentControls,
+      env
+    });
+    clientControls.registerTestHooks();
+
+    it('must trace an unary call', () => {
+      const expectedReply = `received: request${withMetadata ? ' & test-content' : ''}`;
+      return runTest('/unary-call', expectedReply);
+    });
+
+    it('must cancel an unary call', () => runTest('/unary-call', null, true, false));
+
+    it('must mark unary call as erroneous', () => runTest('/unary-call', null, false, true));
+
+    it('must trace server-side streaming', () => {
+      const expectedReply = withMetadata
+        ? ['received: request & test-content', 'streaming', 'more', 'data']
+        : ['received: request', 'streaming', 'more', 'data'];
+      return runTest('/server-stream', expectedReply);
+    });
+
+    it('must cancel server-side streaming', () => runTest('/server-stream', null, true, false));
+
+    it('must mark server-side streaming as erroneous', () => runTest('/server-stream', null, false, true));
+
+    it('must trace client-side streaming', () => {
+      const expectedReply = 'first; second; third';
+      return runTest('/client-stream', expectedReply);
+    });
+
+    it('must cancel client-side streaming', () => runTest('/client-stream', null, true, false));
+
+    it('must mark client-side streaming as erroneous', () => runTest('/client-stream', null, false, true));
+
+    it('must trace bidi streaming', () => {
+      const expectedReply = withMetadata
+        ? [
+            'received: first & test-content',
+            'received: second & test-content',
+            'received: third & test-content',
+            'STOP'
+          ]
+        : ['received: first', 'received: second', 'received: third', 'STOP'];
+      return runTest('/bidi-stream', expectedReply);
+    });
+
+    it('must cancel bidi streaming', () => runTest('/bidi-stream', null, true, false));
+
+    it('must mark bidi streaming as erroneous', () => runTest('/bidi-stream', null, false, true));
+  });
 
   function runTest(url, expectedReply, cancel, erroneous) {
     return clientControls
@@ -158,7 +138,7 @@ function registerSuite(codeGenMode, withMetadata, withOptions) {
         method: 'POST',
         path: url + createQueryParams(cancel, erroneous)
       })
-      .then(function(response) {
+      .then(response => {
         if (!erroneous && !cancel) {
           expect(response.reply).to.deep.equal(expectedReply);
         }
@@ -177,23 +157,26 @@ function registerSuite(codeGenMode, withMetadata, withOptions) {
   }
 
   function waitForTrace(url, cancel, erroneous) {
-    return utils.retry(function() {
-      return agentControls.getSpans().then(function(spans) {
+    return utils.retry(() =>
+      agentControls.getSpans().then(spans => {
         checkTrace(spans, url, cancel, erroneous);
-      });
-    });
+      })
+    );
   }
 
   function checkTrace(spans, url, cancel, erroneous) {
-    var httpEntry = utils.expectOneMatching(spans, checkHttpEntry.bind(null, url));
-    var grpcExit = utils.expectOneMatching(spans, checkGrpcClientSpan.bind(null, httpEntry, url, cancel, erroneous));
+    const httpEntry = utils.expectOneMatching(spans, checkHttpEntry.bind(null, url));
+    const grpcExit = utils.expectOneMatching(spans, checkGrpcClientSpan.bind(null, httpEntry, url, cancel, erroneous));
     // Except for server-streaming and bidi-streaming, we cancel the call immediately on the client, so it usually never
     // reaches the server (depends on the timing). Therefore we also do not expect any GRPC server spans to exist. For
     // server-streaming and bidi-streaming we have a communcation channel from the server to the client so that the
     // server can signal to the client when to cancel the call after it has already reached the server, such a channel
     // does not exist for unary call and client side streaming.
     if (!cancel || url === '/server-stream' || url === '/bidi-stream') {
-      var grpcEntry = utils.expectOneMatching(spans, checkGrpcServerSpan.bind(null, grpcExit, url, cancel, erroneous));
+      const grpcEntry = utils.expectOneMatching(
+        spans,
+        checkGrpcServerSpan.bind(null, grpcExit, url, cancel, erroneous)
+      );
       utils.expectOneMatching(spans, checkLogSpanDuringGrpcEntry.bind(null, grpcEntry, url, erroneous));
     }
     // Would be nice to also check for the log span from the interceptor but will actually never be created because at
@@ -287,7 +270,7 @@ function registerSuite(codeGenMode, withMetadata, withOptions) {
       case '/bidi-stream':
         return 'instana.node.grpc.test.TestService/StartBidiStreaming';
       default:
-        throw new Error('Unknown URL: ' + url);
+        throw new Error(`Unknown URL: ${url}`);
     }
   }
 }

--- a/packages/collector/test/tracing/protocols/grpc/versionUnderTest.js
+++ b/packages/collector/test/tracing/protocols/grpc/versionUnderTest.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var semver = require('semver');
+const semver = require('semver');
 
 module.exports = exports = function determineGrpcPackageVersionUnderTest() {
   if (process.env.GRPC_PACKAGE_VERSION) {

--- a/packages/collector/test/tracing/protocols/http_client/clientControls.js
+++ b/packages/collector/test/tracing/protocols/http_client/clientControls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'clientApp.js');
   opts.port = 3216;
   AbstractControls.call(this, opts);

--- a/packages/collector/test/tracing/protocols/http_client/serverApp.js
+++ b/packages/collector/test/tracing/protocols/http_client/serverApp.js
@@ -10,22 +10,22 @@ require('../../../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var fs = require('fs');
-var morgan = require('morgan');
-var path = require('path');
+const bodyParser = require('body-parser');
+const express = require('express');
+const fs = require('fs');
+const morgan = require('morgan');
+const path = require('path');
 
-var app = express();
-var logPrefix = 'Express HTTP client: Server (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express HTTP client: Server (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.set('Foobar', '42');
   res.sendStatus(200);
 });
@@ -37,19 +37,19 @@ app.get('/', function(req, res) {
   '/get-url-opts',
   '/get-only-url',
   '/get-only-opts'
-].forEach(function(p) {
-  app.get(p, function(req, res) {
+].forEach(p => {
+  app.get(p, (req, res) => {
     res.sendStatus(200);
   });
 });
 
-app.get('/timeout', function(req, res) {
-  setTimeout(function() {
+app.get('/timeout', (req, res) => {
+  setTimeout(() => {
     res.sendStatus(200);
   }, 10000);
 });
 
-app.put('/continue', function(req, res) {
+app.put('/continue', (req, res) => {
   // Node http server will automatically send 100 Continue when it receives a request with an "Expect: 100-continue"
   // header present, unless we override the 'checkContinue' listener. For our test case, the default behaviour is just
   // fine.
@@ -57,7 +57,7 @@ app.put('/continue', function(req, res) {
 });
 
 if (process.env.USE_HTTPS === 'true') {
-  var sslDir = path.join(__dirname, '..', '..', '..', 'apps', 'ssl');
+  const sslDir = path.join(__dirname, '..', '..', '..', 'apps', 'ssl');
   require('https')
     .createServer(
       {
@@ -66,17 +66,17 @@ if (process.env.USE_HTTPS === 'true') {
       },
       app
     )
-    .listen(process.env.APP_PORT, function() {
-      log('Listening (HTTPS!) on port: ' + process.env.APP_PORT);
+    .listen(process.env.APP_PORT, () => {
+      log(`Listening (HTTPS!) on port: ${process.env.APP_PORT}`);
     });
 } else {
-  app.listen(process.env.APP_PORT, function() {
-    log('Listening on port: ' + process.env.APP_PORT);
+  app.listen(process.env.APP_PORT, () => {
+    log(`Listening on port: ${process.env.APP_PORT}`);
   });
 }
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/protocols/http_client/serverControls.js
+++ b/packages/collector/test/tracing/protocols/http_client/serverControls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'serverApp.js');
   opts.port = 3217;
   AbstractControls.call(this, opts);

--- a/packages/collector/test/tracing/protocols/http_client/test.js
+++ b/packages/collector/test/tracing/protocols/http_client/test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var expect = require('chai').expect;
-var semver = require('semver');
+const expect = require('chai').expect;
+const semver = require('semver');
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
-var agentControls;
-var ClientControls;
-var ServerControls;
+let agentControls;
+let ClientControls;
+let ServerControls;
 
 describe('tracing/http client', function() {
   if (!supportedVersion(process.versions.node)) {
@@ -37,16 +37,16 @@ describe('tracing/http client', function() {
 });
 
 function registerTests(useHttps) {
-  var serverControls = new ServerControls({
-    agentControls: agentControls,
+  const serverControls = new ServerControls({
+    agentControls,
     env: {
       USE_HTTPS: useHttps
     }
   });
   serverControls.registerTestHooks();
 
-  var clientControls = new ClientControls({
-    agentControls: agentControls,
+  const clientControls = new ClientControls({
+    agentControls,
     env: {
       SERVER_PORT: serverControls.port,
       USE_HTTPS: useHttps
@@ -63,10 +63,10 @@ function registerTests(useHttps) {
   //
   // This following tests cover all variants.
 
-  [false, true].forEach(function(urlObject) {
-    [false, true].forEach(function(withQuery) {
-      var urlParam = urlObject ? 'urlObject' : 'urlString';
-      it('must trace request(' + urlParam + ', options, cb) with query: ' + withQuery, function() {
+  [false, true].forEach(urlObject => {
+    [false, true].forEach(withQuery => {
+      const urlParam = urlObject ? 'urlObject' : 'urlString';
+      it(`must trace request(${urlParam}, options, cb) with query: ${withQuery}`, () => {
         if (semver.lt(process.versions.node, '10.9.0')) {
           // The (url, options[, callback]) API only exists since Node 10.9.0:
           return;
@@ -77,33 +77,33 @@ function registerTests(useHttps) {
             method: 'GET',
             path: constructPath('/request-url-and-options', urlObject, withQuery)
           })
-          .then(function() {
-            return utils.retry(function() {
-              return agentControls.getSpans().then(function(spans) {
-                var clientSpan = utils.expectOneMatching(spans, function(span) {
+          .then(() =>
+            utils.retry(() =>
+              agentControls.getSpans().then(spans => {
+                const clientSpan = utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.client');
                   expect(span.k).to.equal(constants.EXIT);
                   expect(span.data.http.url).to.match(/\/request-url-opts/);
                   checkQuery(span, withQuery);
                 });
-                utils.expectOneMatching(spans, function(span) {
+                utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.server');
                   expect(span.k).to.equal(constants.ENTRY);
                   expect(span.data.http.url).to.match(/\/request-url-opts/);
                   expect(span.t).to.equal(clientSpan.t);
                   expect(span.p).to.equal(clientSpan.s);
                 });
-              });
-            });
-          });
+              })
+            )
+          );
       });
     });
   });
 
-  [false, true].forEach(function(urlObject) {
-    [false, true].forEach(function(withQuery) {
-      var urlParam = urlObject ? 'urlObject' : 'urlString';
-      it('must trace request(' + urlParam + ', cb) with query: ' + withQuery, function() {
+  [false, true].forEach(urlObject => {
+    [false, true].forEach(withQuery => {
+      const urlParam = urlObject ? 'urlObject' : 'urlString';
+      it(`must trace request(${urlParam}, cb) with query: ${withQuery}`, () => {
         if (urlObject && semver.lt(process.versions.node, '7.5.0')) {
           // WHATWG URL objects can only be passed since 7.5.0
           return;
@@ -118,74 +118,73 @@ function registerTests(useHttps) {
             method: 'GET',
             path: constructPath('/request-url-only', urlObject, withQuery)
           })
-          .then(function() {
-            return utils.retry(function() {
-              return agentControls.getSpans().then(function(spans) {
-                var clientSpan = utils.expectOneMatching(spans, function(span) {
+          .then(() =>
+            utils.retry(() =>
+              agentControls.getSpans().then(spans => {
+                const clientSpan = utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.client');
                   expect(span.k).to.equal(constants.EXIT);
                   expect(span.data.http.url).to.match(/\/request-only-url/);
                   checkQuery(span, withQuery);
                 });
-                utils.expectOneMatching(spans, function(span) {
+                utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.server');
                   expect(span.k).to.equal(constants.ENTRY);
                   expect(span.data.http.url).to.match(/\/request-only-url/);
                   expect(span.t).to.equal(clientSpan.t);
                   expect(span.p).to.equal(clientSpan.s);
                 });
-              });
-            });
-          });
+              })
+            )
+          );
       });
     });
   });
 
-  [false, true].forEach(function(withQuery) {
-    it('must trace request(options, cb) with query: ' + withQuery, function() {
-      return clientControls
+  [false, true].forEach(withQuery => {
+    it(`must trace request(options, cb) with query: ${withQuery}`, () =>
+      clientControls
         .sendRequest({
           method: 'GET',
           path: constructPath('/request-options-only', false, withQuery)
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentControls.getSpans().then(function(spans) {
-              var clientSpan = utils.expectOneMatching(spans, function(span) {
+        .then(() =>
+          utils.retry(() =>
+            agentControls.getSpans().then(spans => {
+              const clientSpan = utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.client');
                 expect(span.k).to.equal(constants.EXIT);
                 expect(span.data.http.url).to.match(/\/request-only-opts/);
                 checkQuery(span, withQuery);
               });
-              utils.expectOneMatching(spans, function(span) {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.server');
                 expect(span.k).to.equal(constants.ENTRY);
                 expect(span.data.http.url).to.match(/\/request-only-opts/);
                 expect(span.t).to.equal(clientSpan.t);
                 expect(span.p).to.equal(clientSpan.s);
               });
-            });
-          });
-        });
-    });
+            })
+          )
+        ));
   });
 
-  it('must capture sync exceptions', function() {
-    return clientControls
+  it('must capture sync exceptions', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/request-malformed-url'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var entrySpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const entrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/request-malformed-url/);
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
@@ -195,7 +194,7 @@ function registerTests(useHttps) {
               expect(span.p).to.equal(entrySpan.s);
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/request-only-opts/);
@@ -203,44 +202,42 @@ function registerTests(useHttps) {
               expect(span.t).to.equal(entrySpan.t);
               expect(span.p).to.equal(entrySpan.s);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  [false, true].forEach(function(withQuery) {
-    it('must trace request(options, cb) with { headers: null } with query: ' + withQuery, function() {
-      return clientControls
+  [false, true].forEach(withQuery => {
+    it(`must trace request(options, cb) with { headers: null } with query: ${withQuery}`, () =>
+      clientControls
         .sendRequest({
           method: 'GET',
           path: constructPath('/request-options-only-null-headers', false, withQuery)
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentControls.getSpans().then(function(spans) {
-              var clientSpan = utils.expectOneMatching(spans, function(span) {
+        .then(() =>
+          utils.retry(() =>
+            agentControls.getSpans().then(spans => {
+              const clientSpan = utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.client');
                 expect(span.k).to.equal(constants.EXIT);
                 expect(span.data.http.url).to.match(/\/request-only-opts/);
                 checkQuery(span, withQuery);
               });
-              utils.expectOneMatching(spans, function(span) {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.server');
                 expect(span.k).to.equal(constants.ENTRY);
                 expect(span.data.http.url).to.match(/\/request-only-opts/);
                 expect(span.t).to.equal(clientSpan.t);
                 expect(span.p).to.equal(clientSpan.s);
               });
-            });
-          });
-        });
-    });
+            })
+          )
+        ));
   });
 
-  [false, true].forEach(function(urlObject) {
-    [false, true].forEach(function(withQuery) {
-      var urlParam = urlObject ? 'urlObject' : 'urlString';
-      it('must trace get(' + urlParam + ', options, cb) with query: ' + withQuery, function() {
+  [false, true].forEach(urlObject => {
+    [false, true].forEach(withQuery => {
+      const urlParam = urlObject ? 'urlObject' : 'urlString';
+      it(`must trace get(${urlParam}, options, cb) with query: ${withQuery}`, () => {
         if (semver.lt(process.versions.node, '10.9.0')) {
           // The (url, options[, callback]) API only exists since Node 10.9.0.
           return;
@@ -250,33 +247,33 @@ function registerTests(useHttps) {
             method: 'GET',
             path: constructPath('/get-url-and-options', urlObject, withQuery)
           })
-          .then(function() {
-            return utils.retry(function() {
-              return agentControls.getSpans().then(function(spans) {
-                var clientSpan = utils.expectOneMatching(spans, function(span) {
+          .then(() =>
+            utils.retry(() =>
+              agentControls.getSpans().then(spans => {
+                const clientSpan = utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.client');
                   expect(span.k).to.equal(constants.EXIT);
                   expect(span.data.http.url).to.match(/\/get-url-opts/);
                   checkQuery(span, withQuery);
                 });
-                utils.expectOneMatching(spans, function(span) {
+                utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.server');
                   expect(span.k).to.equal(constants.ENTRY);
                   expect(span.data.http.url).to.match(/\/get-url-opts/);
                   expect(span.t).to.equal(clientSpan.t);
                   expect(span.p).to.equal(clientSpan.s);
                 });
-              });
-            });
-          });
+              })
+            )
+          );
       });
     });
   });
 
-  [false, true].forEach(function(urlObject) {
-    [false, true].forEach(function(withQuery) {
-      var urlParam = urlObject ? 'urlObject' : 'urlString';
-      it('must trace get(' + urlParam + ', cb) with query: ' + withQuery, function() {
+  [false, true].forEach(urlObject => {
+    [false, true].forEach(withQuery => {
+      const urlParam = urlObject ? 'urlObject' : 'urlString';
+      it(`must trace get(${urlParam}, cb) with query: ${withQuery}`, () => {
         if (urlObject && semver.lt(process.versions.node, '7.5.0')) {
           // WHATWG URL objects can only be passed since 7.5.0
           return;
@@ -291,185 +288,178 @@ function registerTests(useHttps) {
             method: 'GET',
             path: constructPath('/get-url-only', urlObject, withQuery)
           })
-          .then(function() {
-            return utils.retry(function() {
-              return agentControls.getSpans().then(function(spans) {
-                var clientSpan = utils.expectOneMatching(spans, function(span) {
+          .then(() =>
+            utils.retry(() =>
+              agentControls.getSpans().then(spans => {
+                const clientSpan = utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.client');
                   expect(span.k).to.equal(constants.EXIT);
                   expect(span.data.http.url).to.match(/\/get-only-url/);
                   checkQuery(span, withQuery);
                 });
-                utils.expectOneMatching(spans, function(span) {
+                utils.expectOneMatching(spans, span => {
                   expect(span.n).to.equal('node.http.server');
                   expect(span.k).to.equal(constants.ENTRY);
                   expect(span.data.http.url).to.match(/\/get-only-url/);
                   expect(span.t).to.equal(clientSpan.t);
                   expect(span.p).to.equal(clientSpan.s);
                 });
-              });
-            });
-          });
+              })
+            )
+          );
       });
     });
   });
 
-  [false, true].forEach(function(withQuery) {
-    it('must trace get(options, cb) with query: ' + withQuery, function() {
-      return clientControls
+  [false, true].forEach(withQuery => {
+    it(`must trace get(options, cb) with query: ${withQuery}`, () =>
+      clientControls
         .sendRequest({
           method: 'GET',
           path: constructPath('/get-options-only', false, withQuery)
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentControls.getSpans().then(function(spans) {
-              var clientSpan = utils.expectOneMatching(spans, function(span) {
+        .then(() =>
+          utils.retry(() =>
+            agentControls.getSpans().then(spans => {
+              const clientSpan = utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.client');
                 expect(span.k).to.equal(constants.EXIT);
                 expect(span.data.http.url).to.match(/\/get-only-opts/);
                 checkQuery(span, withQuery);
               });
-              utils.expectOneMatching(spans, function(span) {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.server');
                 expect(span.k).to.equal(constants.ENTRY);
                 expect(span.data.http.url).to.match(/\/get-only-opts/);
                 expect(span.t).to.equal(clientSpan.t);
                 expect(span.p).to.equal(clientSpan.s);
               });
-            });
-          });
-        });
-    });
+            })
+          )
+        ));
   });
 
-  it('must trace calls that fail due to connection refusal', function() {
-    return serverControls
+  it('must trace calls that fail due to connection refusal', () =>
+    serverControls
       .kill()
-      .then(function() {
-        return clientControls.sendRequest({
+      .then(() =>
+        clientControls.sendRequest({
           method: 'GET',
           path: '/timeout',
           simple: false
-        });
-      })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+        })
+      )
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
               expect(span.data.http.error).to.match(/ECONNREFUSED/);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace calls that fail due to timeouts', function() {
-    return clientControls
+  it('must trace calls that fail due to timeouts', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/timeout',
         simple: false
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
               expect(span.data.http.error).to.match(/Timeout/);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace aborted calls', function() {
-    return clientControls
+  it('must trace aborted calls', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/abort',
         simple: false
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
               expect(span.data.http.error).to.match(/aborted/);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must not record custom headers', function() {
+  it('must not record custom headers', () =>
     // only http entries are supposed to capture headers, not http exits
-    return clientControls
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.header).to.not.exist;
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must record calls with an "Expect: 100-continue" header', function() {
-    return clientControls
+  it('must record calls with an "Expect: 100-continue" header', () =>
+    clientControls
       .sendRequest({
         method: 'put',
         path: '/expect-continue'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.method).to.equal('PUT');
               expect(span.data.http.status).to.equal(200);
               expect(span.data.http.url).to.match(/\/continue/);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
   // This test is always skipped on CI, it is meant to be only activated for manual execution because it needs three
   // additional environment variables that provide access to an S3 bucket. The env vars that need to be set are:
   // AWS_ACCESS_KEY_ID,
   // AWS_SECRET_ACCESS_KEY and
   // AWS_S3_BUCKET_NAME.
-  it.skip('must upload to S3', function() {
-    return clientControls.sendRequest({
+  it.skip('must upload to S3', () =>
+    clientControls.sendRequest({
       method: 'POST',
       path: '/upload-s3'
-    });
-  });
+    }));
 }
 
 function constructPath(basePath, urlObject, withQuery) {
   if (urlObject && withQuery) {
-    return basePath + '?urlObject=true&withQuery=true';
+    return `${basePath}?urlObject=true&withQuery=true`;
   } else if (urlObject) {
-    return basePath + '?urlObject=true';
+    return `${basePath}?urlObject=true`;
   } else if (withQuery) {
-    return basePath + '?withQuery=true';
+    return `${basePath}?withQuery=true`;
   } else {
     return basePath;
   }

--- a/packages/collector/test/tracing/protocols/http_server/app.js
+++ b/packages/collector/test/tracing/protocols/http_server/app.js
@@ -10,25 +10,25 @@ require('../../../../')({
   }
 });
 
-var logPrefix = 'HTTP: Server (' + process.pid + '):\t';
+const logPrefix = `HTTP: Server (${process.pid}):\t`;
 
-var http = require('http');
-var port = process.env.APP_PORT || 3000;
-var app = new http.Server();
+const http = require('http');
+const port = process.env.APP_PORT || 3000;
+const app = new http.Server();
 
-app.on('request', function(req, res) {
+app.on('request', (req, res) => {
   if (process.env.WITH_STDOUT) {
-    log(req.method + ' ' + req.url);
+    log(`${req.method} ${req.url}`);
   }
   res.end();
 });
 
-app.listen(port, function() {
-  log('Listening on port: ' + port);
+app.listen(port, () => {
+  log(`Listening on port: ${port}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/protocols/http_server/controls.js
+++ b/packages/collector/test/tracing/protocols/http_server/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../AbstractControls');
+const AbstractControls = require('../../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/protocols/http_server/http_test.js
+++ b/packages/collector/test/tracing/protocols/http_server/http_test.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/http server', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../../../apps/agentStubControls');
-  var Controls = require('./controls');
+  const agentControls = require('../../../apps/agentStubControls');
+  const Controls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
@@ -22,13 +22,13 @@ describe('tracing/http server', function() {
     secretsList: ['secret', 'Enigma', 'CIPHER']
   });
 
-  var controls = new Controls({
-    agentControls: agentControls
+  const controls = new Controls({
+    agentControls
   });
   controls.registerTestHooks();
 
-  it('must report additional headers when requested', function() {
-    var userAgent = 'medivhTheTeleporter';
+  it('must report additional headers when requested', () => {
+    const userAgent = 'medivhTheTeleporter';
     return controls
       .sendRequest({
         method: 'GET',
@@ -37,35 +37,34 @@ describe('tracing/http server', function() {
           'User-Agent': userAgent
         }
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.header['user-agent']).to.equal(userAgent);
             });
-          });
-        });
-      });
+          })
+        )
+      );
   });
 
-  it('must remove secrets from query parameters', function() {
-    return controls
+  it('must remove secrets from query parameters', () =>
+    controls
       .sendRequest({
         method: 'GET',
         path: '/?param1=value1&TheSecreT=classified&param2=value2&enIgmAtic=occult&param3=value4&cipher=veiled'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.params).to.equal('param1=value1&param2=value2&param3=value4');
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 });

--- a/packages/collector/test/tracing/protocols/http_server/https_test.js
+++ b/packages/collector/test/tracing/protocols/http_server/https_test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var constants = require('@instana/core').tracing.constants;
-var config = require('../../../config');
-var utils = require('../../../utils');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const constants = require('@instana/core').tracing.constants;
+const config = require('../../../config');
+const utils = require('../../../utils');
 
 describe('tracing/https server', function() {
   if (!supportedVersion(process.versions.node)) {
@@ -14,32 +14,30 @@ describe('tracing/https server', function() {
 
   this.timeout(config.getTestTimeout());
 
-  var agentControls = require('../../../apps/agentStubControls');
-  var controls = require('../../../apps/expressControls');
+  const agentControls = require('../../../apps/agentStubControls');
+  const controls = require('../../../apps/expressControls');
 
   agentControls.registerTestHooks();
   controls.registerTestHooks({
     useHttps: true
   });
 
-  beforeEach(function() {
-    return agentControls.waitUntilAppIsCompletelyInitialized(controls.getPid());
-  });
+  beforeEach(() => agentControls.waitUntilAppIsCompletelyInitialized(controls.getPid()));
 
-  it('must trace incoming HTTPS calls', function() {
-    return controls
+  it('must trace incoming HTTPS calls', () =>
+    controls
       .sendRequest({
         method: 'POST',
         path: '/checkout',
         responseStatus: 201,
         useHttps: true
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
             expect(spans.length).to.equal(1);
 
-            var span = spans[0];
+            const span = spans[0];
             expect(span.n).to.equal('node.http.server');
             expect(span.k).to.equal(constants.ENTRY);
             expect(span.async).to.equal(false);
@@ -49,13 +47,12 @@ describe('tracing/https server', function() {
             expect(span.data.http.url).to.equal('/checkout');
             expect(span.data.http.status).to.equal(201);
             expect(span.data.http.host).to.equal('127.0.0.1:3211');
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must continue incoming trace', function() {
-    return controls
+  it('must continue incoming trace', () =>
+    controls
       .sendRequest({
         method: 'POST',
         path: '/checkout',
@@ -67,21 +64,20 @@ describe('tracing/https server', function() {
           'X-INSTANA-L': '1'
         }
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
             expect(spans.length).to.equal(1);
 
-            var span = spans[0];
+            const span = spans[0];
             expect(span.t).to.equal('84e588b697868fee');
             expect(span.p).to.equal('5e734f51bce69eca');
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must continue incoming trace with 128bit traceIds', function() {
-    return controls
+  it('must continue incoming trace with 128bit traceIds', () =>
+    controls
       .sendRequest({
         method: 'POST',
         path: '/checkout',
@@ -93,16 +89,15 @@ describe('tracing/https server', function() {
           'X-INSTANA-L': '1'
         }
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
             expect(spans.length).to.equal(1);
 
-            var span = spans[0];
+            const span = spans[0];
             expect(span.t).to.equal('6636f38f0f3dd0996636f38f0f3dd099');
             expect(span.p).to.equal('fb2bb293ac206c05');
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 });

--- a/packages/collector/test/tracing/require_hook/app.js
+++ b/packages/collector/test/tracing/require_hook/app.js
@@ -10,36 +10,36 @@ require('../../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'requireHook App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `requireHook App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/requireRequestPromiseMultipleTimes', function(req, res) {
+app.get('/requireRequestPromiseMultipleTimes', (req, res) => {
   require('request');
   require('request-promise'); // executes stealthy-require
   require('request-promise-native'); // executes stealthy-require
   res.sendStatus(200);
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/require_hook/controls.js
+++ b/packages/collector/test/tracing/require_hook/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../AbstractControls');
+const AbstractControls = require('../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/require_hook/test.js
+++ b/packages/collector/test/tracing/require_hook/test.js
@@ -1,45 +1,44 @@
 'use strict';
 
-var expect = require('chai').expect;
-var semver = require('semver');
+const expect = require('chai').expect;
+const semver = require('semver');
 
-var config = require('../../config');
-var utils = require('../../utils');
+const config = require('../../config');
+const utils = require('../../utils');
 
 describe('tracing/requireHook', function() {
   if (semver.lt(process.versions.node, '8.0.0')) {
     return;
   }
 
-  var agentControls = require('../../apps/agentStubControls');
-  var Controls = require('./controls');
+  const agentControls = require('../../apps/agentStubControls');
+  const Controls = require('./controls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var controls = new Controls({
-    agentControls: agentControls
+  const controls = new Controls({
+    agentControls
   });
   controls.registerTestHooks();
 
-  describe('stealthy require', function() {
-    it('must not apply caching when not necessary / or when something is fishy', function() {
-      return controls
+  describe('stealthy require', () => {
+    it('must not apply caching when not necessary / or when something is fishy', () =>
+      controls
         .sendRequest({
           method: 'GET',
           path: '/requireRequestPromiseMultipleTimes'
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentControls.getSpans().then(function(spans) {
-              utils.expectOneMatching(spans, function(span) {
+        .then(() =>
+          utils.retry(() =>
+            agentControls.getSpans().then(spans => {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.server');
                 expect(span.data.http.status).to.equal(200);
               });
-            });
-          });
-        });
-    });
+            })
+          )
+        ));
   });
 });

--- a/packages/collector/test/tracing/sdk/controls.js
+++ b/packages/collector/test/tracing/sdk/controls.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-var path = require('path');
-var util = require('util');
+const path = require('path');
+const util = require('util');
 
-var AbstractControls = require('../AbstractControls');
+const AbstractControls = require('../AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   AbstractControls.call(this, opts);
 });

--- a/packages/collector/test/tracing/sdk/dummyEmitter.js
+++ b/packages/collector/test/tracing/sdk/dummyEmitter.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var EventEmitter = require('events');
-var util = require('util');
+const EventEmitter = require('events');
+const util = require('util');
 
 function DummyEmitter() {
   EventEmitter.call(this);
@@ -9,8 +9,8 @@ function DummyEmitter() {
 util.inherits(DummyEmitter, EventEmitter);
 
 DummyEmitter.prototype.start = function start() {
-  var that = this;
-  this.intervalHandle = setInterval(function() {
+  const that = this;
+  this.intervalHandle = setInterval(() => {
     that.emit('tick');
   }, 100);
   this.intervalHandle.unref();

--- a/packages/collector/test/tracing/stackTraces_test.js
+++ b/packages/collector/test/tracing/stackTraces_test.js
@@ -1,103 +1,96 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../config');
-var utils = require('../utils');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../config');
+const utils = require('../utils');
 
 describe('tracing/stackTraces', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentStubControls = require('../apps/agentStubControls');
-  var expressProxyControls = require('../apps/expressProxyControls');
+  const agentStubControls = require('../apps/agentStubControls');
+  const expressProxyControls = require('../apps/expressProxyControls');
 
   this.timeout(config.getTestTimeout());
 
   agentStubControls.registerTestHooks();
 
-  describe('with stack trace lenght of 0', function() {
+  describe('with stack trace lenght of 0', () => {
     expressProxyControls.registerTestHooks({
       stackTraceLength: 0
     });
 
-    beforeEach(function() {
-      return agentStubControls.waitUntilAppIsCompletelyInitialized(expressProxyControls.getPid());
-    });
+    beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(expressProxyControls.getPid()));
 
-    it('must not add stack traces to the spans', function() {
-      return expressProxyControls
+    it('must not add stack traces to the spans', () =>
+      expressProxyControls
         .sendRequest({
           method: 'POST',
           path: '/checkout',
           responseStatus: 201
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentStubControls.getSpans().then(function(spans) {
-              utils.expectOneMatching(spans, function(span) {
+        .then(() =>
+          utils.retry(() =>
+            agentStubControls.getSpans().then(spans => {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.server');
                 expect(span.stack).to.have.lengthOf(0);
               });
 
-              utils.expectOneMatching(spans, function(span) {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.client');
                 expect(span.stack).to.have.lengthOf(0);
               });
-            });
-          });
-        });
-    });
+            })
+          )
+        ));
   });
 
-  describe('with enabled stack traces', function() {
+  describe('with enabled stack traces', () => {
     expressProxyControls.registerTestHooks({
       stackTraceLength: 10
     });
 
-    beforeEach(function() {
-      return agentStubControls.waitUntilAppIsCompletelyInitialized(expressProxyControls.getPid());
-    });
+    beforeEach(() => agentStubControls.waitUntilAppIsCompletelyInitialized(expressProxyControls.getPid()));
 
-    it('must not add stack traces to entry spans', function() {
-      return expressProxyControls
+    it('must not add stack traces to entry spans', () =>
+      expressProxyControls
         .sendRequest({
           method: 'POST',
           path: '/checkout',
           responseStatus: 201
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentStubControls.getSpans().then(function(spans) {
-              utils.expectOneMatching(spans, function(span) {
+        .then(() =>
+          utils.retry(() =>
+            agentStubControls.getSpans().then(spans => {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.server');
                 expect(span.stack).to.have.lengthOf(0);
               });
-            });
-          });
-        });
-    });
+            })
+          )
+        ));
 
-    it('must add stack traces to exit spans', function() {
-      return expressProxyControls
+    it('must add stack traces to exit spans', () =>
+      expressProxyControls
         .sendRequest({
           method: 'POST',
           path: '/checkout',
           responseStatus: 201
         })
-        .then(function() {
-          return utils.retry(function() {
-            return agentStubControls.getSpans().then(function(spans) {
-              utils.expectOneMatching(spans, function(span) {
+        .then(() =>
+          utils.retry(() =>
+            agentStubControls.getSpans().then(spans => {
+              utils.expectOneMatching(spans, span => {
                 expect(span.n).to.equal('node.http.client');
                 expect(span.stack[0].m).to.equal('Request.Request.start [as start]');
                 expect(span.stack[0].c).to.match(/request\.js$/i);
               });
-            });
-          });
-        });
-    });
+            })
+          )
+        ));
   });
 });

--- a/packages/collector/test/uncaught/apps/controls.js
+++ b/packages/collector/test/uncaught/apps/controls.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var spawnSync = require('child_process').spawnSync;
-var path = require('path');
+const spawnSync = require('child_process').spawnSync;
+const path = require('path');
 
 exports.order = function() {
   return spawnProcess('order.js');
@@ -24,7 +24,7 @@ exports.asyncRethrowWhenOtherHandlersArePresent = function() {
 };
 
 function spawnProcess(fileName) {
-  var appPath = path.join(__dirname, fileName);
+  const appPath = path.join(__dirname, fileName);
   return spawnSync('node', [appPath], {
     timeout: 1000
   });

--- a/packages/collector/test/uncaught/apps/order.js
+++ b/packages/collector/test/uncaught/apps/order.js
@@ -5,11 +5,11 @@
 // Handlers are called in the same order they are registered.
 // See https://nodejs.org/api/events.html#events_emitter_emit_eventname_args
 
-process.on('uncaughtException', function() {
+process.on('uncaughtException', () => {
   console.log('HANDLER 1');
 });
 
-process.on('uncaughtException', function() {
+process.on('uncaughtException', () => {
   console.log('HANDLER 2');
 });
 

--- a/packages/collector/test/uncaught/apps/rethrow.js
+++ b/packages/collector/test/uncaught/apps/rethrow.js
@@ -6,7 +6,7 @@
 // uncaughtException handler terminates the process with an exit code != 1.
 // The orginal stack trace is preserved.
 
-process.on('uncaughtException', function(err) {
+process.on('uncaughtException', err => {
   throw err;
 });
 

--- a/packages/collector/test/uncaught/apps/server.js
+++ b/packages/collector/test/uncaught/apps/server.js
@@ -4,8 +4,8 @@
 
 // Deliberately not using Express.js here to avoid conflicts with Express.js' error handling.
 
-var instana = require('../../..');
-var config = {
+const instana = require('../../..');
+const config = {
   agentPort: process.env.AGENT_PORT,
   level: 'warn'
   // not using "forceTransmissionStartingAt: 1" as usual here to verify that the uncaught exception handler actually
@@ -20,10 +20,10 @@ if (process.env.ENABLE_REPORT_UNHANDLED_REJECTIONS) {
 
 instana(config);
 
-var http = require('http');
-var port = process.env.APP_PORT;
+const http = require('http');
+const port = process.env.APP_PORT;
 
-var requestHandler = function(request, response) {
+const requestHandler = (request, response) => {
   if (request.url === '/') {
     return success(response);
   } else if (request.url === '/other') {
@@ -39,34 +39,34 @@ var requestHandler = function(request, response) {
 };
 
 function success(response) {
-  setTimeout(function() {
+  setTimeout(() => {
     response.end("Everything's peachy.");
   }, 100);
 }
 
 function uncaughtError() {
-  process.nextTick(function() {
+  process.nextTick(() => {
     throw new Error('Boom');
   });
 }
 
 function uncaughtPromiseRejection(response) {
-  process.nextTick(function() {
+  process.nextTick(() => {
     Promise.reject(new Error('Unhandled Promise Rejection'));
-    process.nextTick(function() {
+    process.nextTick(() => {
       response.end('Rejected.');
     });
   });
 }
 
-var server = http.createServer(requestHandler);
+const server = http.createServer(requestHandler);
 
-server.listen(port, function(err) {
+server.listen(port, err => {
   if (err) {
     // eslint-disable-next-line no-console
     return console.log('something bad happened', err);
   }
 
   // eslint-disable-next-line no-console
-  console.log('server is listening on ' + port);
+  console.log(`server is listening on ${port}`);
 });

--- a/packages/collector/test/uncaught/apps/serverControls.js
+++ b/packages/collector/test/uncaught/apps/serverControls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../tracing/AbstractControls');
+const AbstractControls = require('../../tracing/AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'server.js');
   this.dontKillInAfterHook = opts.dontKillInAfterHook !== false;
   AbstractControls.call(this, opts);

--- a/packages/collector/test/uncaught/assumptions_test.js
+++ b/packages/collector/test/uncaught/assumptions_test.js
@@ -1,49 +1,49 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var controls = require('./apps/controls');
+const controls = require('./apps/controls');
 
 /**
  * This test suite does not test Instana code but verifies assumptions around process.on('uncaughtException') across
  * all supported Node.js versions.
  */
-describe('uncaught exceptions assumptions - ', function() {
-  describe('synchronous non-throwing uncaught exceptions handler', function() {
-    it('executes handlers in order', function() {
-      var result = controls.order();
+describe('uncaught exceptions assumptions - ', () => {
+  describe('synchronous non-throwing uncaught exceptions handler', () => {
+    it('executes handlers in order', () => {
+      const result = controls.order();
       expect(result.status).to.equal(0);
-      var stdOut = result.stdout.toString('utf-8');
-      var stdErr = result.stderr.toString('utf-8');
+      const stdOut = result.stdout.toString('utf-8');
+      const stdErr = result.stderr.toString('utf-8');
       expect(stdOut).to.match(/HANDLER 1\s*HANDLER 2\s*Bye, bye/);
       expect(stdErr).to.be.empty;
     });
   });
 
-  describe('synchronous rethrowing uncaught exceptions handler', function() {
-    it('terminates the process', function() {
-      var result = controls.rethrow();
+  describe('synchronous rethrowing uncaught exceptions handler', () => {
+    it('terminates the process', () => {
+      const result = controls.rethrow();
       expect(result.status).to.equal(7);
     });
 
-    it('keeps the original stack trace', function() {
-      var result = controls.rethrow();
+    it('keeps the original stack trace', () => {
+      const result = controls.rethrow();
       // Actually, it will be 7, see
       // https://nodejs.org/api/process.html#process_exit_codes
       expect(result.status).to.not.equal(1);
-      var stdOut = result.stdout.toString('utf-8');
-      var stdErr = result.stderr.toString('utf-8');
+      const stdOut = result.stdout.toString('utf-8');
+      const stdErr = result.stderr.toString('utf-8');
       expect(stdOut).to.be.empty;
       expect(stdErr).to.contain('Error: Boom');
       expect(stdErr).to.contain('_onTimeout');
       expect(stdErr).to.contain('test/uncaught/apps/rethrow.js');
     });
 
-    it('executes handlers registered before rethrowing handler, but not handlers registered after that', function() {
-      var result = controls.rethrowWhenOtherHandlersArePresent();
+    it('executes handlers registered before rethrowing handler, but not handlers registered after that', () => {
+      const result = controls.rethrowWhenOtherHandlersArePresent();
       expect(result.status).to.not.equal(0);
-      var stdOut = result.stdout.toString('utf-8');
-      var stdErr = result.stderr.toString('utf-8');
+      const stdOut = result.stdout.toString('utf-8');
+      const stdErr = result.stderr.toString('utf-8');
       expect(stdOut).to.match(/HANDLER 1\s*HANDLER 2\s*HANDLER 3/);
       expect(stdErr).to.not.be.empty;
       expect(stdErr).to.contain('Error: Boom');

--- a/packages/collector/test/uncaught/disabled_test.js
+++ b/packages/collector/test/uncaught/disabled_test.js
@@ -1,77 +1,75 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
-var assert = chai.assert;
-var Promise = require('bluebird');
+const chai = require('chai');
+const expect = chai.expect;
+const assert = chai.assert;
+const Promise = require('bluebird');
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../config');
-var utils = require('../utils');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../config');
+const utils = require('../utils');
 
 describe('uncaught exception reporting disabled', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../apps/agentStubControls');
-  var ServerControls = require('./apps/serverControls');
+  const agentControls = require('../apps/agentStubControls');
+  const ServerControls = require('./apps/serverControls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var serverControls = new ServerControls({
-    agentControls: agentControls
+  const serverControls = new ServerControls({
+    agentControls
   });
   serverControls.registerTestHooks();
 
-  it('will not finish the current span', function() {
-    return serverControls
+  it('will not finish the current span', () =>
+    serverControls
       .sendRequest({
         method: 'GET',
         path: '/boom',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         assert.fail(response, 'no response', 'Unexpected response, server should have crashed');
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err.name).to.equal('RequestError');
         expect(err.message).to.equal('Error: socket hang up');
 
-        return Promise.delay(1000).then(function() {
-          return utils.retry(function() {
-            return agentControls.getSpans().then(function(spans) {
+        return Promise.delay(1000).then(() =>
+          utils.retry(() =>
+            agentControls.getSpans().then(spans => {
               expect(spans).to.have.lengthOf(0);
-            });
-          });
-        });
-      });
-  });
+            })
+          )
+        );
+      }));
 
-  it('must not report the uncaught exception as an issue', function() {
-    return serverControls
+  it('must not report the uncaught exception as an issue', () =>
+    serverControls
       .sendRequest({
         method: 'GET',
         path: '/boom',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         assert.fail(response, 'no response', 'Unexpected response, server should have crashed');
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err.name).to.equal('RequestError');
         expect(err.message).to.equal('Error: socket hang up');
-        return Promise.delay(1000).then(function() {
-          return utils.retry(function() {
-            return agentControls.getEvents().then(function(events) {
+        return Promise.delay(1000).then(() =>
+          utils.retry(() =>
+            agentControls.getEvents().then(events => {
               expect(events).to.have.lengthOf(0);
-            });
-          });
-        });
-      });
-  });
+            })
+          )
+        );
+      }));
 });

--- a/packages/collector/test/uncaught/uncaught_exceptions_test.js
+++ b/packages/collector/test/uncaught/uncaught_exceptions_test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var semver = require('semver');
-var chai = require('chai');
-var expect = chai.expect;
-var assert = chai.assert;
+const semver = require('semver');
+const chai = require('chai');
+const expect = chai.expect;
+const assert = chai.assert;
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../config');
-var utils = require('../utils');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../config');
+const utils = require('../utils');
 
 describe('uncaught exceptions', function() {
   if (!supportedVersion(process.versions.node)) {
@@ -18,15 +18,15 @@ describe('uncaught exceptions', function() {
     return;
   }
 
-  var agentControls = require('../apps/agentStubControls');
-  var ServerControls = require('./apps/serverControls');
+  const agentControls = require('../apps/agentStubControls');
+  const ServerControls = require('./apps/serverControls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var serverControls = new ServerControls({
-    agentControls: agentControls,
+  const serverControls = new ServerControls({
+    agentControls,
     env: {
       ENABLE_REPORT_UNCAUGHT_EXCEPTION: true,
       ENABLE_REPORT_UNHANDLED_REJECTIONS: false
@@ -34,23 +34,23 @@ describe('uncaught exceptions', function() {
   });
   serverControls.registerTestHooks();
 
-  it('must finish the current span and mark it as an error', function() {
-    return serverControls
+  it('must finish the current span and mark it as an error', () =>
+    serverControls
       .sendRequest({
         method: 'GET',
         path: '/boom',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         assert.fail(response, 'no response', 'Unexpected response, server should have crashed.');
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err.name).to.equal('RequestError');
         expect(err.message).to.equal('Error: socket hang up');
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.f.e).to.equal(String(serverControls.getPid()));
               expect(span.f.h).to.equal('agent-stub-uuid');
@@ -58,28 +58,27 @@ describe('uncaught exceptions', function() {
               expect(span.ec).to.equal(1);
               expect(JSON.stringify(span.stack)).to.contain('test/uncaught/apps/server.js');
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must be reported as an issue', function() {
-    return serverControls
+  it('must be reported as an issue', () =>
+    serverControls
       .sendRequest({
         method: 'GET',
         path: '/boom',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         assert.fail(response, 'no response', 'Unexpected response, server should have crashed.');
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err.name).to.equal('RequestError');
         expect(err.message).to.equal('Error: socket hang up');
-        return utils.retry(function() {
-          return agentControls.getEvents().then(function(events) {
-            utils.expectOneMatching(events, function(event) {
+        return utils.retry(() =>
+          agentControls.getEvents().then(events => {
+            utils.expectOneMatching(events, event => {
               expect(event.title).to.equal('A Node.js process terminated abnormally due to an uncaught exception.');
               expect(event.text).to.contain('Boom');
               expect(event.plugin).to.equal('com.instana.forge.infrastructure.runtime.nodejs.NodeJsRuntimePlatform');
@@ -88,15 +87,14 @@ describe('uncaught exceptions', function() {
               expect(event.duration).to.equal(1);
               expect(event.severity).to.equal(10);
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must block the dying process until termination', function() {
-    var serverAcceptedAnotherResponse = false;
-    var errorFromSecondHttpRequest = null;
-    var triggerUncaughtException = serverControls.sendRequest({
+  it('must block the dying process until termination', () => {
+    let serverAcceptedAnotherResponse = false;
+    let errorFromSecondHttpRequest = null;
+    const triggerUncaughtException = serverControls.sendRequest({
       method: 'GET',
       path: '/boom',
       simple: false,
@@ -109,37 +107,35 @@ describe('uncaught exceptions', function() {
         path: '/other',
         simple: false
       })
-      .then(function() {
+      .then(() => {
         serverAcceptedAnotherResponse = true;
       })
-      .catch(function(_errorFromSecondHttpRequest) {
+      .catch(_errorFromSecondHttpRequest => {
         errorFromSecondHttpRequest = _errorFromSecondHttpRequest;
       });
 
     return triggerUncaughtException
-      .then(function(response) {
+      .then(response => {
         assert.fail(response, 'no response', 'Unexpected response, server should have crashed.');
       })
-      .catch(function(err) {
+      .catch(err => {
         expect(err.name).to.equal('RequestError');
         expect(err.message).to.equal('Error: socket hang up');
 
         // Wait until the event has arrived and make sure that the other HTTP request has not been accepted/processed
         // in the meantime.
-        return utils.retry(function() {
-          return agentControls.getEvents().then(function(events) {
-            expect(
-              serverAcceptedAnotherResponse,
-              "Unexpected response, server shouldn't have accepted another call."
-            ).to.be.false;
+        return utils.retry(() =>
+          agentControls.getEvents().then(events => {
+            expect(serverAcceptedAnotherResponse, "Unexpected response, server shouldn't have accepted another call.")
+              .to.be.false;
             expect(errorFromSecondHttpRequest).to.exist;
             expect(errorFromSecondHttpRequest.message).to.equal('Error: read ECONNRESET');
-            utils.expectOneMatching(events, function(event) {
+            utils.expectOneMatching(events, event => {
               expect(event.title).to.equal('A Node.js process terminated abnormally due to an uncaught exception.');
               expect(event.text).to.contain('Boom');
             });
-          });
-        });
+          })
+        );
       });
   });
 });

--- a/packages/collector/test/uncaught/unhandled_promise_rejections_test.js
+++ b/packages/collector/test/uncaught/unhandled_promise_rejections_test.js
@@ -1,26 +1,26 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
-var config = require('../config');
-var utils = require('../utils');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../config');
+const utils = require('../utils');
 
 describe('unhandled promise rejections', function() {
   if (!supportedVersion(process.versions.node)) {
     return;
   }
 
-  var agentControls = require('../apps/agentStubControls');
-  var ServerControls = require('./apps/serverControls');
+  const agentControls = require('../apps/agentStubControls');
+  const ServerControls = require('./apps/serverControls');
 
   this.timeout(config.getTestTimeout());
 
   agentControls.registerTestHooks();
 
-  var serverControls = new ServerControls({
-    agentControls: agentControls,
+  const serverControls = new ServerControls({
+    agentControls,
     dontKillInAfterHook: false,
     env: {
       ENABLE_REPORT_UNCAUGHT_EXCEPTION: false,
@@ -29,19 +29,19 @@ describe('unhandled promise rejections', function() {
   });
   serverControls.registerTestHooks();
 
-  it('must not interfere with tracing', function() {
-    return serverControls
+  it('must not interfere with tracing', () =>
+    serverControls
       .sendRequest({
         method: 'GET',
         path: '/reject',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.body).to.equal('Rejected.');
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+        return utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.f.e).to.equal(String(serverControls.getPid()));
               expect(span.f.h).to.equal('agent-stub-uuid');
@@ -49,24 +49,23 @@ describe('unhandled promise rejections', function() {
               expect(span.ec).to.equal(0);
               expect(span.stack).to.be.empty;
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 
-  it('must be reported as an issue', function() {
-    return serverControls
+  it('must be reported as an issue', () =>
+    serverControls
       .sendRequest({
         method: 'GET',
         path: '/reject',
         simple: false,
         resolveWithFullResponse: true
       })
-      .then(function(response) {
+      .then(response => {
         expect(response.body).to.equal('Rejected.');
-        return utils.retry(function() {
-          return agentControls.getEvents().then(function(events) {
-            utils.expectOneMatching(events, function(event) {
+        return utils.retry(() =>
+          agentControls.getEvents().then(events => {
+            utils.expectOneMatching(events, event => {
               expect(event.title).to.equal('An unhandled promise rejection occured in a Node.js process.');
               expect(event.text).to.contain('Unhandled Promise Rejection');
               expect(event.plugin).to.equal('com.instana.forge.infrastructure.runtime.nodejs.NodeJsRuntimePlatform');
@@ -75,8 +74,7 @@ describe('unhandled promise rejections', function() {
               expect(event.duration).to.equal(1);
               expect(event.severity).to.equal(5);
             });
-          });
-        });
-      });
-  });
+          })
+        );
+      }));
 });

--- a/packages/collector/test/util/normalizeConfig_test.js
+++ b/packages/collector/test/util/normalizeConfig_test.js
@@ -3,11 +3,11 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var normalizeConfig = require('../../src/util/normalizeConfig');
+const normalizeConfig = require('../../src/util/normalizeConfig');
 
-describe('util.normalizeConfig', function() {
+describe('util.normalizeConfig', () => {
   beforeEach(resetEnv);
   afterEach(resetEnv);
 
@@ -17,14 +17,14 @@ describe('util.normalizeConfig', function() {
     delete process.env['INSTANA_AGENT_NAME'];
   }
 
-  it('should apply all defaults', function() {
+  it('should apply all defaults', () => {
     checkDefaults(normalizeConfig());
     checkDefaults(normalizeConfig({}));
     checkDefaults(normalizeConfig({ unknowConfigOption: 13 }));
   });
 
-  it('should accept custom agent connection configuration', function() {
-    var config = normalizeConfig({
+  it('should accept custom agent connection configuration', () => {
+    const config = normalizeConfig({
       agentHost: 'LOKAL_HORST',
       agentPort: 1207,
       agentName: 'Joe'
@@ -34,19 +34,19 @@ describe('util.normalizeConfig', function() {
     expect(config.agentName).to.equal('Joe');
   });
 
-  it('should accept custom agent connection configuration from environment', function() {
+  it('should accept custom agent connection configuration from environment', () => {
     process.env['INSTANA_AGENT_HOST'] = 'yadayada';
     process.env['INSTANA_AGENT_PORT'] = '1357';
     process.env['INSTANA_AGENT_NAME'] = 'Cthulhu';
-    var config = normalizeConfig();
+    const config = normalizeConfig();
     expect(config.agentHost).to.equal('yadayada');
     expect(config.agentPort).to.equal(1357);
     expect(config.agentPort).to.be.a('number');
     expect(config.agentName).to.equal('Cthulhu');
   });
 
-  it('should custom stack trace length', function() {
-    var config = normalizeConfig({
+  it('should custom stack trace length', () => {
+    const config = normalizeConfig({
       tracing: {
         stackTraceLength: 7
       }
@@ -54,16 +54,16 @@ describe('util.normalizeConfig', function() {
     expect(config.tracing.stackTraceLength).to.equal(7);
   });
 
-  it('should enable reporting uncaught exceptions', function() {
-    var config = normalizeConfig({
+  it('should enable reporting uncaught exceptions', () => {
+    const config = normalizeConfig({
       reportUncaughtException: true
     });
     expect(config.reportUncaughtException).to.be.true;
     expect(config.reportUnhandledPromiseRejections).to.be.true;
   });
 
-  it('should enable uncaught exceptions but disable unhandled promises', function() {
-    var config = normalizeConfig({
+  it('should enable uncaught exceptions but disable unhandled promises', () => {
+    const config = normalizeConfig({
       reportUncaughtException: true,
       reportUnhandledPromiseRejections: false
     });
@@ -71,8 +71,8 @@ describe('util.normalizeConfig', function() {
     expect(config.reportUnhandledPromiseRejections).to.be.false;
   });
 
-  it('should enable disable unhandled promises only', function() {
-    var config = normalizeConfig({
+  it('should enable disable unhandled promises only', () => {
+    const config = normalizeConfig({
       reportUnhandledPromiseRejections: true
     });
     expect(config.reportUncaughtException).to.be.false;

--- a/packages/collector/test/utils.js
+++ b/packages/collector/test/utils.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-var Promise = require('bluebird');
-var fail = require('chai').assert.fail;
+const Promise = require('bluebird');
+const fail = require('chai').assert.fail;
 
-var config = require('./config');
+const config = require('./config');
 
 exports.retry = function retry(fn, time, until) {
   if (time == null) {
@@ -22,9 +22,7 @@ exports.retry = function retry(fn, time, until) {
 
   return Promise.delay(time / 20)
     .then(fn)
-    .catch(function() {
-      return retry(fn, time, until);
-    });
+    .catch(() => retry(fn, time, until));
 };
 
 exports.expectOneMatching = function expectOneMatching(arr, fn) {
@@ -32,10 +30,10 @@ exports.expectOneMatching = function expectOneMatching(arr, fn) {
     fail('Could not find an item which matches all the criteria. Got 0 items.');
   }
 
-  var error;
+  let error;
 
-  for (var i = 0; i < arr.length; i++) {
-    var item = arr[i];
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
 
     try {
       fn(item);
@@ -47,27 +45,22 @@ exports.expectOneMatching = function expectOneMatching(arr, fn) {
 
   if (error) {
     fail(
-      'Could not find an item which matches all the criteria. Got ' +
-        arr.length +
-        ' items. Last error: ' +
-        error.message +
-        '. All Items:\n' +
-        JSON.stringify(arr, 0, 2) +
-        '. Error stack trace: ' +
-        error.stack
+      `Could not find an item which matches all the criteria. Got ${arr.length} items. Last error: ${
+        error.message
+      }. All Items:\n${JSON.stringify(arr, 0, 2)}. Error stack trace: ${error.stack}`
     );
   }
 };
 
 exports.getSpansByName = function getSpansByName(arr, name) {
-  var result = [];
+  const result = [];
 
   if (!arr || arr.length === 0) {
     return result;
   }
 
-  for (var i = 0; i < arr.length; i++) {
-    var item = arr[i];
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
     if (item.n === name) {
       result.push(item);
     }

--- a/packages/core/test/config.js
+++ b/packages/core/test/config.js
@@ -1,13 +1,13 @@
 'use strict';
 
-exports.getAppStdio = function() {
+exports.getAppStdio = () => {
   if (process.env.WITH_STDOUT || process.env.CI) {
     return [process.stdin, process.stdout, process.stderr, 'ipc'];
   }
   return [process.stdin, 'ignore', process.stderr, 'ipc'];
 };
 
-exports.getTestTimeout = function() {
+exports.getTestTimeout = () => {
   if (process.env.CI) {
     return 30000;
   }

--- a/packages/core/test/metrics/activeRequests_test.js
+++ b/packages/core/test/metrics/activeRequests_test.js
@@ -2,20 +2,20 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var fs = require('fs');
+const expect = require('chai').expect;
+const fs = require('fs');
 
-var activeRequests = require('../../src/metrics/activeRequests');
+const activeRequests = require('../../src/metrics/activeRequests');
 
-describe('metrics.activeRequests', function() {
-  it('should export active requests count', function() {
+describe('metrics.activeRequests', () => {
+  it('should export active requests count', () => {
     expect(activeRequests.currentPayload).to.equal(process._getActiveRequests().length);
   });
 
-  it('should update requests count for a fs.open', function() {
-    var activeRequestBefore = activeRequests.currentPayload;
-    for (var i = 0; i < 13; i++) {
-      fs.open(__filename, 'r', function() {});
+  it('should update requests count for a fs.open', () => {
+    const activeRequestBefore = activeRequests.currentPayload;
+    for (let i = 0; i < 13; i++) {
+      fs.open(__filename, 'r', () => {});
     }
     expect(activeRequests.currentPayload).to.equal(activeRequestBefore + 13);
   });

--- a/packages/core/test/metrics/dependencies_test.js
+++ b/packages/core/test/metrics/dependencies_test.js
@@ -2,20 +2,20 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var utils = require('../utils');
-var dependencies = require('../../src/metrics/dependencies');
+const utils = require('../utils');
+const dependencies = require('../../src/metrics/dependencies');
 
-describe('metrics.dependencies', function() {
-  it('should export a dependencies payload prefix', function() {
+describe('metrics.dependencies', () => {
+  it('should export a dependencies payload prefix', () => {
     expect(dependencies.payloadPrefix).to.equal('dependencies');
   });
 
-  it('should provide the set of depencies with versions', function() {
+  it('should provide the set of depencies with versions', () => {
     dependencies.activate();
 
-    return utils.retry(function() {
+    return utils.retry(() => {
       // Testing against Mocha dependencies as mocha is the main module when running the tests and dependencies are
       // evaluated as the content of the node_modules directory relative to the main module.
       expect(dependencies.currentPayload.debug).to.equal('3.1.0');

--- a/packages/core/test/metrics/directDependencies_test.js
+++ b/packages/core/test/metrics/directDependencies_test.js
@@ -2,29 +2,29 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var utils = require('../utils');
-var directDependencies = require('../../src/metrics/directDependencies');
+const utils = require('../utils');
+const directDependencies = require('../../src/metrics/directDependencies');
 
-describe('metrics.directDependencies', function() {
-  it('should use the correct payload prefix', function() {
+describe('metrics.directDependencies', () => {
+  it('should use the correct payload prefix', () => {
     expect(directDependencies.payloadPrefix).to.equal('directDependencies');
   });
 
-  it('should export a well formed empty payload right away', function() {
+  it('should export a well formed empty payload right away', () => {
     expect(directDependencies.currentPayload.dependencies).to.exist;
     expect(directDependencies.currentPayload.peerDependencies).to.exist;
     expect(directDependencies.currentPayload.optionalDependencies).to.exist;
   });
 
-  it('should provide the set of depencies with versions', function() {
+  it('should provide the set of depencies with versions', () => {
     directDependencies.activate();
 
-    return utils.retry(function() {
+    return utils.retry(() => {
       // Testing against Mocha dependencies as mocha is the main module when running the tests and dependencies are
       // evaluated as the content of the node_modules directory relative to the main module.
-      var deps = directDependencies.currentPayload.dependencies;
+      const deps = directDependencies.currentPayload.dependencies;
       expect(deps).to.exist;
       expect(deps.debug).to.equal('3.1.0');
       expect(deps['browser-stdout']).to.equal('1.3.1');

--- a/packages/core/test/metrics/heapSpaces_test.js
+++ b/packages/core/test/metrics/heapSpaces_test.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var proxyquire = require('proxyquire');
-var sinon = require('sinon');
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
 
-var doesV8ModuleExist;
+let doesV8ModuleExist;
 try {
   require('v8');
   doesV8ModuleExist = true;
@@ -14,28 +14,28 @@ try {
   doesV8ModuleExist = false;
 }
 
-describe('metrics.heapSpaces', function() {
-  var v8;
-  var heapSpaces;
+describe('metrics.heapSpaces', () => {
+  let v8;
+  let heapSpaces;
 
-  beforeEach(function() {
+  beforeEach(() => {
     v8 = {
       getHeapSpaceStatistics: sinon.stub()
     };
     heapSpaces = proxyquire('../../src/metrics/heapSpaces', {
-      v8: v8
+      v8
     });
   });
 
-  afterEach(function() {
+  afterEach(() => {
     heapSpaces.deactivate();
   });
 
-  it('should export a heapSpaces payload prefix', function() {
+  it('should export a heapSpaces payload prefix', () => {
     expect(heapSpaces.payloadPrefix).to.equal('heapSpaces');
   });
 
-  it('should not fail when the collector is activated in old Node versions', function() {
+  it('should not fail when the collector is activated in old Node versions', () => {
     delete v8.getHeapSpaceStatistics;
 
     heapSpaces.activate();
@@ -44,7 +44,7 @@ describe('metrics.heapSpaces', function() {
   });
 
   if (doesV8ModuleExist) {
-    it('should gather heap space data', function() {
+    it('should gather heap space data', () => {
       v8.getHeapSpaceStatistics.returns([
         {
           space_name: 'new_space',

--- a/packages/core/test/metrics/memory_test.js
+++ b/packages/core/test/metrics/memory_test.js
@@ -2,23 +2,23 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var utils = require('../utils');
-var memory = require('../../src/metrics/memory');
+const utils = require('../utils');
+const memory = require('../../src/metrics/memory');
 
-describe('metrics.memory', function() {
-  afterEach(function() {
+describe('metrics.memory', () => {
+  afterEach(() => {
     memory.deactivate();
   });
 
-  it('should export a memory payload prefix', function() {
+  it('should export a memory payload prefix', () => {
     expect(memory.payloadPrefix).to.equal('memory');
   });
 
-  it('should provide memory information', function() {
+  it('should provide memory information', () => {
     memory.activate();
-    var p = memory.currentPayload;
+    const p = memory.currentPayload;
     expect(p.rss).to.be.a('number');
     expect(p.heapTotal).to.be.a('number');
     expect(p.heapUsed).to.be.a('number');
@@ -26,18 +26,18 @@ describe('metrics.memory', function() {
 
   // Test is too fragile (especially for CI environments) and should only be used locally
   // to verify the behavior from time to time.
-  it.skip('should update memory information after 1s', function() {
+  it.skip('should update memory information after 1s', () => {
     memory.activate();
-    var previousPayload = memory.currentPayload;
+    const previousPayload = memory.currentPayload;
 
     // generate some garbage so that memory information changes
-    var garbage = [];
-    for (var i = 0; i < 100; i++) {
+    const garbage = [];
+    for (let i = 0; i < 100; i++) {
       garbage.push(new Date());
     }
 
-    return utils.retry(function() {
-      var newPayload = memory.currentPayload;
+    return utils.retry(() => {
+      const newPayload = memory.currentPayload;
       expect(newPayload.heapUsed).to.be.gt(previousPayload.heapUsed);
     });
   });

--- a/packages/core/test/metrics/name_test.js
+++ b/packages/core/test/metrics/name_test.js
@@ -2,20 +2,20 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var utils = require('../utils');
-var name = require('../../src/metrics/name');
+const utils = require('../utils');
+const name = require('../../src/metrics/name');
 
-describe('metrics.name', function() {
-  it('should export a name payload prefix', function() {
+describe('metrics.name', () => {
+  it('should export a name payload prefix', () => {
     expect(name.payloadPrefix).to.equal('name');
   });
 
-  it('should provide the main module name', function() {
+  it('should provide the main module name', () => {
     name.activate();
 
-    return utils.retry(function() {
+    return utils.retry(() => {
       // Mocha is used to execute the tests via the mocha executable.
       // As such mocha is the main module.
       expect(name.currentPayload).to.equal('mocha');

--- a/packages/core/test/metrics/startTime_test.js
+++ b/packages/core/test/metrics/startTime_test.js
@@ -2,30 +2,30 @@
 
 'use strict';
 
-var proxyquire = require('proxyquire');
-var expect = require('chai').expect;
-var sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const expect = require('chai').expect;
+const sinon = require('sinon');
 
-var originalUptime = process.uptime;
+const originalUptime = process.uptime;
 
-describe('metrics.startTime', function() {
-  var clock;
+describe('metrics.startTime', () => {
+  let clock;
 
-  beforeEach(function() {
+  beforeEach(() => {
     clock = sinon.useFakeTimers();
     process.uptime = sinon.stub();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     process.uptime = originalUptime;
     clock.restore();
   });
 
-  it('should report start time', function() {
+  it('should report start time', () => {
     process.uptime.returns(3); // seconds
     clock.tick(100000);
     // proxyquire to reset module state
-    var startTime = proxyquire('../../src/metrics/startTime', {});
+    const startTime = proxyquire('../../src/metrics/startTime', {});
     expect(startTime.currentPayload).to.equal(97000);
   });
 });

--- a/packages/core/test/secrets_test.js
+++ b/packages/core/test/secrets_test.js
@@ -2,296 +2,296 @@
 
 'use strict';
 
-var secrets = require('../src/secrets');
+const secrets = require('../src/secrets');
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-describe('secrets with matcher mode', function() {
-  describe('equals-ignore-case', function() {
-    var matcher;
+describe('secrets with matcher mode', () => {
+  describe('equals-ignore-case', () => {
+    let matcher;
 
-    beforeEach(function() {
+    beforeEach(() => {
       matcher = secrets.matchers['equals-ignore-case'](['secret-key', 'anotherKey', 'whatever']);
     });
 
-    it('should match full string', function() {
+    it('should match full string', () => {
       expect(matcher('secret-key')).to.be.true;
     });
 
-    it('should match case insensitive', function() {
+    it('should match case insensitive', () => {
       expect(matcher('sEcReT-kEy')).to.be.true;
     });
 
-    it('should match against all secrets insensitive', function() {
+    it('should match against all secrets insensitive', () => {
       expect(matcher('sEcReT-kEy')).to.be.true;
       expect(matcher('anotherkey')).to.be.true;
       expect(matcher('whatever')).to.be.true;
     });
 
-    it('should not match substring', function() {
+    it('should not match substring', () => {
       expect(matcher('XXXsecret-keyXXX')).to.be.false;
     });
 
-    it('should ignore null', function() {
+    it('should ignore null', () => {
       expect(matcher(null)).to.be.false;
     });
 
-    it('should ignore undefined', function() {
+    it('should ignore undefined', () => {
       expect(matcher(undefined)).to.be.false;
     });
 
-    it('should ignore wrong types', function() {
+    it('should ignore wrong types', () => {
       expect(matcher(1302)).to.be.false;
     });
 
-    it('should ignore borked secrets array', function() {
+    it('should ignore borked secrets array', () => {
       matcher = secrets.matchers['equals-ignore-case']('not an array');
       expect(matcher('anything')).to.be.false;
       expect(matcher('KEY')).to.be.true;
     });
 
-    it('should ignore secrets array with members of wrong type', function() {
+    it('should ignore secrets array with members of wrong type', () => {
       matcher = secrets.matchers['equals-ignore-case'](['secret', 13]);
       expect(matcher('secret')).to.be.true;
       expect(matcher(13)).to.be.false;
     });
   });
 
-  describe('equals', function() {
-    var matcher;
+  describe('equals', () => {
+    let matcher;
 
-    beforeEach(function() {
+    beforeEach(() => {
       matcher = secrets.matchers.equals(['secret-key', 'anotherKey', 'whatever']);
     });
 
-    it('should match full string', function() {
+    it('should match full string', () => {
       expect(matcher('secret-key')).to.be.true;
     });
 
-    it('should not match case insensitive', function() {
+    it('should not match case insensitive', () => {
       expect(matcher('sEcReT-kEy')).to.be.false;
     });
 
-    it('should match against all secrets', function() {
+    it('should match against all secrets', () => {
       expect(matcher('secret-key')).to.be.true;
       expect(matcher('anotherKey')).to.be.true;
       expect(matcher('whatever')).to.be.true;
     });
 
-    it('should not match substring', function() {
+    it('should not match substring', () => {
       expect(matcher('XXXsecret-keyXXX')).to.be.false;
     });
 
-    it('should ignore null', function() {
+    it('should ignore null', () => {
       expect(matcher(null)).to.be.false;
     });
 
-    it('should ignore undefined', function() {
+    it('should ignore undefined', () => {
       expect(matcher(undefined)).to.be.false;
     });
 
-    it('should ignore wrong types', function() {
+    it('should ignore wrong types', () => {
       expect(matcher(1302)).to.be.false;
     });
 
-    it('should ignore borked secrets array', function() {
+    it('should ignore borked secrets array', () => {
       matcher = secrets.matchers.equals('not an array');
       expect(matcher('anything')).to.be.false;
       expect(matcher('key')).to.be.true;
     });
 
-    it('should ignore secrets array with members of wrong type', function() {
+    it('should ignore secrets array with members of wrong type', () => {
       matcher = secrets.matchers.equals(['secret', 13]);
       expect(matcher('secret')).to.be.true;
       expect(matcher(13)).to.be.false;
     });
   });
 
-  describe('contains-ignore-case', function() {
-    var matcher;
+  describe('contains-ignore-case', () => {
+    let matcher;
 
-    beforeEach(function() {
+    beforeEach(() => {
       matcher = secrets.matchers['contains-ignore-case'](['secret-key', 'anotherKey', 'whatever']);
     });
 
-    it('should match full string', function() {
+    it('should match full string', () => {
       expect(matcher('secret-key')).to.be.true;
     });
 
-    it('should match substring', function() {
+    it('should match substring', () => {
       expect(matcher('XXXsecret-keyXXX')).to.be.true;
     });
 
-    it('should match substring case insensitive', function() {
+    it('should match substring case insensitive', () => {
       expect(matcher('XXXsEcReT-kEyXXX')).to.be.true;
     });
 
-    it('should match against all secrets', function() {
+    it('should match against all secrets', () => {
       expect(matcher('XXXsEcReT-kEyXXX')).to.be.true;
       expect(matcher('123anotherkey456')).to.be.true;
       expect(matcher('.-=whaTever=-.')).to.be.true;
     });
 
-    it('should ignore null', function() {
+    it('should ignore null', () => {
       expect(matcher(null)).to.be.false;
     });
 
-    it('should ignore undefined', function() {
+    it('should ignore undefined', () => {
       expect(matcher(undefined)).to.be.false;
     });
 
-    it('should ignore wrong types', function() {
+    it('should ignore wrong types', () => {
       expect(matcher(1302)).to.be.false;
     });
 
-    it('should ignore borked secrets array', function() {
+    it('should ignore borked secrets array', () => {
       matcher = secrets.matchers['contains-ignore-case']('not an array');
       expect(matcher('anything')).to.be.false;
       expect(matcher('...PASSWORD...')).to.be.true;
     });
 
-    it('should ignore secrets array with members of wrong type', function() {
+    it('should ignore secrets array with members of wrong type', () => {
       matcher = secrets.matchers['contains-ignore-case'](['secret', 13]);
       expect(matcher('XXXsEcRetZZZ')).to.be.true;
       expect(matcher(13)).to.be.false;
     });
   });
 
-  describe('contains', function() {
-    var matcher;
+  describe('contains', () => {
+    let matcher;
 
-    beforeEach(function() {
+    beforeEach(() => {
       matcher = secrets.matchers.contains(['secret-key', 'anotherKey', 'whatever']);
     });
 
-    it('should match full string', function() {
+    it('should match full string', () => {
       expect(matcher('secret-key')).to.be.true;
     });
 
-    it('should match substring', function() {
+    it('should match substring', () => {
       expect(matcher('XXXsecret-key___')).to.be.true;
     });
 
-    it('should not match case insensitive', function() {
+    it('should not match case insensitive', () => {
       expect(matcher('sEcReT-kEy')).to.be.false;
     });
 
-    it('should match against all secrets', function() {
+    it('should match against all secrets', () => {
       expect(matcher('secret-keyyyy')).to.be.true;
       expect(matcher('>>>anotherKey<<<')).to.be.true;
       expect(matcher('.-=whatever=-.')).to.be.true;
     });
 
-    it('should ignore null', function() {
+    it('should ignore null', () => {
       expect(matcher(null)).to.be.false;
     });
 
-    it('should ignore undefined', function() {
+    it('should ignore undefined', () => {
       expect(matcher(undefined)).to.be.false;
     });
 
-    it('should ignore wrong types', function() {
+    it('should ignore wrong types', () => {
       expect(matcher(1302)).to.be.false;
     });
 
-    it('should ignore borked secrets array', function() {
+    it('should ignore borked secrets array', () => {
       matcher = secrets.matchers.contains('not an array');
       expect(matcher('anything')).to.be.false;
       expect(matcher('__password__')).to.be.true;
     });
 
-    it('should ignore secrets array with members of wrong type', function() {
+    it('should ignore secrets array with members of wrong type', () => {
       matcher = secrets.matchers.contains(['secret', 13]);
       expect(matcher('secret')).to.be.true;
       expect(matcher(13)).to.be.false;
     });
   });
 
-  describe('regex', function() {
-    var matcher;
+  describe('regex', () => {
+    let matcher;
 
-    beforeEach(function() {
+    beforeEach(() => {
       matcher = secrets.matchers.regex(['abc.*xyz', '\\d{1,3}']);
     });
 
-    it('should match regex', function() {
+    it('should match regex', () => {
       expect(matcher('abcWHATEVERxyz')).to.be.true;
     });
 
-    it('should not match when no regex matches', function() {
+    it('should not match when no regex matches', () => {
       expect(matcher('efgXuvw')).to.be.false;
       expect(matcher('1234')).to.be.false;
     });
 
-    it('should not match case insensitive', function() {
+    it('should not match case insensitive', () => {
       expect(matcher('ABCWHATEVERXYZ')).to.be.false;
     });
 
-    it('should match against all secrets', function() {
+    it('should match against all secrets', () => {
       expect(matcher('abcWHATEVERxyz')).to.be.true;
       expect(matcher('123')).to.be.true;
       expect(matcher('9')).to.be.true;
     });
 
-    it('should not match when regex matches a substring', function() {
+    it('should not match when regex matches a substring', () => {
       expect(matcher('ZZZabcXXXxyzZZZ')).to.be.false;
     });
 
-    it('should handle regex string that starts with ^', function() {
+    it('should handle regex string that starts with ^', () => {
       matcher = secrets.matchers.regex(['^regex']);
       expect(matcher('regex')).to.be.true;
       expect(matcher('Xregex')).to.be.false;
       expect(matcher('regexX')).to.be.false;
     });
 
-    it('should handle regex string that ends with $', function() {
+    it('should handle regex string that ends with $', () => {
       matcher = secrets.matchers.regex(['regex$']);
       expect(matcher('regex')).to.be.true;
       expect(matcher('Xregex')).to.be.false;
       expect(matcher('regexX')).to.be.false;
     });
 
-    it('should handle regex string that starts with ^ and ends with $', function() {
+    it('should handle regex string that starts with ^ and ends with $', () => {
       matcher = secrets.matchers.regex(['^regex$']);
       expect(matcher('regex')).to.be.true;
       expect(matcher('Xregex')).to.be.false;
       expect(matcher('regexX')).to.be.false;
     });
 
-    it('should ignore null', function() {
+    it('should ignore null', () => {
       expect(matcher(null)).to.be.false;
     });
 
-    it('should ignore undefined', function() {
+    it('should ignore undefined', () => {
       expect(matcher(undefined)).to.be.false;
     });
 
-    it('should ignore wrong types', function() {
+    it('should ignore wrong types', () => {
       expect(matcher(1302)).to.be.false;
     });
 
-    it('should ignore borked secrets array', function() {
+    it('should ignore borked secrets array', () => {
       matcher = secrets.matchers.regex('not an array');
       expect(matcher('anything')).to.be.false;
       expect(matcher('key')).to.be.true; // default secret
       expect(matcher('pass')).to.be.true; // default secret
     });
 
-    it('should ignore secrets array with members of wrong type', function() {
+    it('should ignore secrets array with members of wrong type', () => {
       matcher = secrets.matchers.regex(['secret', 13]);
       expect(matcher('secret')).to.be.true;
       expect(matcher(13)).to.be.false;
     });
   });
 
-  describe('none', function() {
-    var matcher;
+  describe('none', () => {
+    let matcher;
 
-    beforeEach(function() {
+    beforeEach(() => {
       matcher = secrets.matchers.none(['secret-key', 'anotherKey', 'whatever']);
     });
 
-    it('should not match anything', function() {
+    it('should not match anything', () => {
       expect(matcher('secret-key')).to.be.false;
       expect(matcher('key')).to.be.false;
       expect(matcher('pass')).to.be.false;

--- a/packages/core/test/tracing/cls_test.js
+++ b/packages/core/test/tracing/cls_test.js
@@ -2,27 +2,27 @@
 
 'use strict';
 
-var proxyquire = require('proxyquire');
-var expect = require('chai').expect;
+const proxyquire = require('proxyquire');
+const expect = require('chai').expect;
 
-var constants = require('../../src/tracing/constants');
+const constants = require('../../src/tracing/constants');
 
-describe('tracing/cls', function() {
-  var cls;
+describe('tracing/cls', () => {
+  let cls;
 
-  beforeEach(function() {
+  beforeEach(() => {
     // reload to clear vars
     cls = proxyquire('../../src/tracing/cls', {});
     cls.init();
   });
 
-  it('must not have an active context initially', function() {
+  it('must not have an active context initially', () => {
     expect(cls.getCurrentSpan()).to.equal(undefined);
   });
 
-  it('must initialize a new valid span', function() {
-    cls.ns.run(function() {
-      var newSpan = cls.startSpan('cls-test-run', constants.EXIT);
+  it('must initialize a new valid span', () => {
+    cls.ns.run(() => {
+      const newSpan = cls.startSpan('cls-test-run', constants.EXIT);
       expect(newSpan).to.be.a('Object');
       expect(newSpan).to.have.property('t');
       expect(newSpan).to.have.property('s');
@@ -44,22 +44,22 @@ describe('tracing/cls', function() {
     });
   });
 
-  it('must not set span.f without process identity provider', function() {
-    cls.ns.run(function() {
-      var newSpan = cls.startSpan('cls-test-run', constants.EXIT);
+  it('must not set span.f without process identity provider', () => {
+    cls.ns.run(() => {
+      const newSpan = cls.startSpan('cls-test-run', constants.EXIT);
       expect(newSpan).to.not.have.property('f');
     });
   });
 
-  it('must not set span.f if process identity provider does not support getFrom', function() {
+  it('must not set span.f if process identity provider does not support getFrom', () => {
     cls.init({});
-    cls.ns.run(function() {
-      var newSpan = cls.startSpan('cls-test-run', constants.EXIT);
+    cls.ns.run(() => {
+      const newSpan = cls.startSpan('cls-test-run', constants.EXIT);
       expect(newSpan).to.not.have.property('f');
     });
   });
 
-  it('must use process identity provider', function() {
+  it('must use process identity provider', () => {
     cls.init({
       getFrom: function() {
         return {
@@ -68,8 +68,8 @@ describe('tracing/cls', function() {
         };
       }
     });
-    cls.ns.run(function() {
-      var newSpan = cls.startSpan('cls-test-run', constants.EXIT);
+    cls.ns.run(() => {
+      const newSpan = cls.startSpan('cls-test-run', constants.EXIT);
       expect(newSpan.f).to.deep.equal({
         e: String(process.pid),
         h: undefined
@@ -77,11 +77,11 @@ describe('tracing/cls', function() {
     });
   });
 
-  it('new spans must inherit from current span IDs', function() {
-    var parentSpan;
-    var newSpan;
+  it('new spans must inherit from current span IDs', () => {
+    let parentSpan;
+    let newSpan;
 
-    cls.ns.run(function() {
+    cls.ns.run(() => {
       parentSpan = cls.startSpan('Mr-Brady', constants.ENTRY);
       newSpan = cls.startSpan('Peter-Brady', constants.EXIT);
     });
@@ -89,8 +89,8 @@ describe('tracing/cls', function() {
     expect(newSpan.p).to.equal(parentSpan.s);
   });
 
-  it('must pass trace suppression configuration across spans', function() {
-    cls.ns.run(function() {
+  it('must pass trace suppression configuration across spans', () => {
+    cls.ns.run(() => {
       cls.setTracingLevel('0');
       expect(cls.tracingSuppressed()).to.equal(true);
       cls.startSpan('Antonio-Andolini', constants.ENTRY);
@@ -100,7 +100,7 @@ describe('tracing/cls', function() {
       cls.startSpan('Michael-Corleone', constants.EXIT);
       expect(cls.tracingSuppressed()).to.equal(true);
 
-      cls.ns.run(function() {
+      cls.ns.run(() => {
         cls.setTracingLevel('1');
         expect(cls.tracingSuppressed()).to.equal(false);
         cls.startSpan('Antonio-Andolini', constants.EXIT);
@@ -110,7 +110,7 @@ describe('tracing/cls', function() {
         cls.startSpan('Michael-Corleone', constants.EXIT);
         expect(cls.tracingSuppressed()).to.equal(false);
 
-        cls.ns.run(function() {
+        cls.ns.run(() => {
           cls.setTracingLevel('0');
           expect(cls.tracingSuppressed()).to.equal(true);
           cls.startSpan('Antonio-Andolini', constants.EXIT);
@@ -120,7 +120,7 @@ describe('tracing/cls', function() {
           cls.startSpan('Michael-Corleone', constants.EXIT);
           expect(cls.tracingSuppressed()).to.equal(true);
 
-          cls.ns.run(function() {
+          cls.ns.run(() => {
             expect(cls.tracingSuppressed()).to.equal(true);
             cls.startSpan('Antonio-Andolini', constants.EXIT);
             expect(cls.tracingSuppressed()).to.equal(true);
@@ -134,12 +134,12 @@ describe('tracing/cls', function() {
     });
   });
 
-  it('new spans must have direction set', function() {
-    var entrySpan;
-    var exitSpan;
-    var intermediateSpan;
+  it('new spans must have direction set', () => {
+    let entrySpan;
+    let exitSpan;
+    let intermediateSpan;
 
-    cls.ns.run(function() {
+    cls.ns.run(() => {
       entrySpan = cls.startSpan('node.http.server', constants.ENTRY);
       exitSpan = cls.startSpan('mongo', constants.EXIT);
       intermediateSpan = cls.startSpan('intermediate', constants.INTERMEDIATE);
@@ -161,12 +161,12 @@ describe('tracing/cls', function() {
     expect(constants.isIntermediateSpan(intermediateSpan)).to.equal(true);
   });
 
-  it('must clean up span data from contexts once the span is transmitted', function() {
-    cls.ns.run(function(context) {
+  it('must clean up span data from contexts once the span is transmitted', () => {
+    cls.ns.run(context => {
       expect(context[cls.currentRootSpanKey]).to.equal(undefined);
       expect(context[cls.currentSpanKey]).to.equal(undefined);
 
-      var span = cls.startSpan('node.http.server', constants.ENTRY);
+      const span = cls.startSpan('node.http.server', constants.ENTRY);
       expect(context[cls.currentRootSpanKey]).to.equal(span);
       expect(context[cls.currentSpanKey]).to.equal(span);
 

--- a/packages/core/test/tracing/open_tracing/Span_test.js
+++ b/packages/core/test/tracing/open_tracing/Span_test.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var opentracing = require('opentracing');
-var proxyquire = require('proxyquire');
-var expect = require('chai').expect;
-var sinon = require('sinon');
+const opentracing = require('opentracing');
+const proxyquire = require('proxyquire');
+const expect = require('chai').expect;
+const sinon = require('sinon');
 
-describe('tracing/opentracing/Span', function() {
+describe('tracing/opentracing/Span', () => {
   // we know that the actual Span implementation doesn't require access to the OT Tracer
   // instance, so we just pass null to fulfill the OT API contract.
-  var tracerInstance = null;
+  const tracerInstance = null;
 
-  var now;
-  var spanBuffer;
-  var Span;
+  let now;
+  let spanBuffer;
+  let Span;
 
-  beforeEach(function() {
+  beforeEach(() => {
     now = Date.now();
     spanBuffer = {
       addSpan: sinon.stub()
@@ -24,12 +24,12 @@ describe('tracing/opentracing/Span', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(() => {
     Span.init({}, null);
   });
 
-  it('must create new spans', function() {
-    var span = new Span(tracerInstance, 'rpc');
+  it('must create new spans', () => {
+    const span = new Span(tracerInstance, 'rpc');
     expect(span.span.t).to.be.a('string');
     expect(span.span.s).to.be.a('string');
     expect(span.span.s).to.equal(span.span.t);
@@ -54,18 +54,18 @@ describe('tracing/opentracing/Span', function() {
     });
   });
 
-  it('must not set span.f without process identity provider', function() {
-    var span = new Span(tracerInstance, 'rpc');
+  it('must not set span.f without process identity provider', () => {
+    const span = new Span(tracerInstance, 'rpc');
     expect(span.span).to.not.have.property('f');
   });
 
-  it('must not set span.f if process identity provider does not support getFrom', function() {
+  it('must not set span.f if process identity provider does not support getFrom', () => {
     Span.init({}, {});
-    var span = new Span(tracerInstance, 'rpc');
+    const span = new Span(tracerInstance, 'rpc');
     expect(span.span).to.not.have.property('f');
   });
 
-  it('must use process identity provider', function() {
+  it('must use process identity provider', () => {
     Span.init(
       {},
       {
@@ -77,78 +77,78 @@ describe('tracing/opentracing/Span', function() {
         }
       }
     );
-    var span = new Span(tracerInstance, 'rpc');
+    const span = new Span(tracerInstance, 'rpc');
     expect(span.span.f).to.deep.equal({
       e: String(process.pid),
       h: undefined
     });
   });
 
-  it('must be able to change operation name at a later point', function() {
-    var span = new Span(tracerInstance, 'rpc');
+  it('must be able to change operation name at a later point', () => {
+    const span = new Span(tracerInstance, 'rpc');
     span.setOperationName('http');
     expect(span.span.data.sdk.name).to.equal('http');
   });
 
-  describe('tags', function() {
-    it('must handle error tag differently', function() {
-      var span = new Span(tracerInstance, 'rpc');
+  describe('tags', () => {
+    it('must handle error tag differently', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.ERROR, true);
       expect(span.span.error).to.equal(true);
       expect(span.span.ec).to.equal(1);
     });
 
-    it('must support setting error to false', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must support setting error to false', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.ERROR, false);
       expect(span.span.error).to.equal(false);
       expect(span.span.ec).to.equal(0);
     });
 
-    it('must change direction to exit for client rpc kind', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must change direction to exit for client rpc kind', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.SPAN_KIND, opentracing.Tags.SPAN_KIND_RPC_CLIENT);
       expect(span.span.data.sdk.type).to.equal('exit');
     });
 
-    it('must change direction to entry for server rpc kind', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must change direction to entry for server rpc kind', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.SPAN_KIND, opentracing.Tags.SPAN_KIND_RPC_SERVER);
       expect(span.span.data.sdk.type).to.equal('entry');
     });
 
-    it('must change direction to exit for producer rpc kind', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must change direction to exit for producer rpc kind', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.SPAN_KIND, 'producer');
       expect(span.span.data.sdk.type).to.equal('exit');
     });
 
-    it('must change direction to entry for consumer rpc kind', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must change direction to entry for consumer rpc kind', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.SPAN_KIND, 'consumer');
       expect(span.span.data.sdk.type).to.equal('entry');
     });
 
-    it('must treat sampling priority changes specially', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must treat sampling priority changes specially', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.SAMPLING_PRIORITY, 0.5);
       expect(span.context().samplingPriority).to.equal(0.5);
     });
 
-    it('must set all other tags as user provided payload', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must set all other tags as user provided payload', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag('foo', 'bar');
       expect(span.span.data.sdk.custom.tags.foo).to.equal('bar');
     });
   });
 
-  describe('logs', function() {
-    it('must set logs without timestamp', function() {
-      var span = new Span(tracerInstance, 'rpc');
+  describe('logs', () => {
+    it('must set logs without timestamp', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.log({
         foo: 'bar'
       });
-      var keys = Object.keys(span.span.data.sdk.custom.logs);
+      const keys = Object.keys(span.span.data.sdk.custom.logs);
       expect(keys).to.have.lengthOf(1);
       expect(parseInt(keys[0], 0)).to.be.at.least(now);
       expect(span.span.data.sdk.custom.logs[keys[0]]).to.deep.equal({
@@ -156,15 +156,15 @@ describe('tracing/opentracing/Span', function() {
       });
     });
 
-    it('must set logs with user specified timestamp', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must set logs with user specified timestamp', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.log(
         {
           foo: 'bar'
         },
         5
       );
-      var keys = Object.keys(span.span.data.sdk.custom.logs);
+      const keys = Object.keys(span.span.data.sdk.custom.logs);
       expect(keys).to.have.lengthOf(1);
       expect(keys[0]).to.equal('5');
       expect(span.span.data.sdk.custom.logs[keys[0]]).to.deep.equal({
@@ -172,8 +172,8 @@ describe('tracing/opentracing/Span', function() {
       });
     });
 
-    it('must merge log entries with the same timestamp', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must merge log entries with the same timestamp', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.log(
         {
           foo: 'bar'
@@ -186,7 +186,7 @@ describe('tracing/opentracing/Span', function() {
         },
         5
       );
-      var keys = Object.keys(span.span.data.sdk.custom.logs);
+      const keys = Object.keys(span.span.data.sdk.custom.logs);
       expect(keys).to.have.lengthOf(1);
       expect(keys[0]).to.equal('5');
       expect(span.span.data.sdk.custom.logs[keys[0]]).to.deep.equal({
@@ -195,8 +195,8 @@ describe('tracing/opentracing/Span', function() {
       });
     });
 
-    it('must support log entries of varying timestamps', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must support log entries of varying timestamps', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.log(
         {
           foo: 'bar'
@@ -220,47 +220,47 @@ describe('tracing/opentracing/Span', function() {
     });
   });
 
-  describe('finish', function() {
-    it('must pass span to spanBuffer handler when finishing', function() {
-      var span = new Span(tracerInstance, 'rpc');
+  describe('finish', () => {
+    it('must pass span to spanBuffer handler when finishing', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.finish();
       expect(spanBuffer.addSpan.callCount).to.equal(1);
       expect(spanBuffer.addSpan.getCall(0).args[0]).to.equal(span.span);
     });
 
-    it('must pass span to spanBuffer handler when finishing with user defined end time', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must pass span to spanBuffer handler when finishing with user defined end time', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.finish(span.span.ts + 6);
       expect(spanBuffer.addSpan.callCount).to.equal(1);
       expect(spanBuffer.addSpan.getCall(0).args[0]).to.equal(span.span);
       expect(span.span.d).to.equal(6);
     });
 
-    it('must not transmit span when sampling priority is 0', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must not transmit span when sampling priority is 0', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.SAMPLING_PRIORITY, 0);
       span.finish();
       expect(spanBuffer.addSpan.callCount).to.equal(0);
     });
   });
 
-  describe('fields', function() {
-    it('must use start time from passed fields', function() {
-      var span = new Span(tracerInstance, 'rpc');
+  describe('fields', () => {
+    it('must use start time from passed fields', () => {
+      let span = new Span(tracerInstance, 'rpc');
       span = new Span(tracerInstance, 'rpc', {
         startTime: 5
       });
       expect(span.span.ts).to.equal(5);
     });
 
-    it('must use tags passed via fields', function() {
-      var tags = {};
+    it('must use tags passed via fields', () => {
+      const tags = {};
       tags[opentracing.Tags.SPAN_KIND] = opentracing.Tags.SPAN_KIND_RPC_CLIENT;
       tags[opentracing.Tags.ERROR] = true;
       tags.foo = 'bar';
 
-      var span = new Span(tracerInstance, 'rpc', {
-        tags: tags
+      const span = new Span(tracerInstance, 'rpc', {
+        tags
       });
 
       expect(span.span.data.sdk.custom.tags).to.deep.equal({
@@ -270,31 +270,31 @@ describe('tracing/opentracing/Span', function() {
       expect(span.span.data.sdk.type).to.equal('exit');
     });
 
-    it('must use operation name passed via fields when available', function() {
-      var span = new Span(tracerInstance, 'rpc', {
+    it('must use operation name passed via fields when available', () => {
+      const span = new Span(tracerInstance, 'rpc', {
         operationName: 'oauth'
       });
       expect(span.span.data.sdk.name).to.equal('oauth');
     });
   });
 
-  describe('baggage', function() {
-    it('must support set and get baggage items', function() {
-      var span = new Span(tracerInstance, 'rpc');
+  describe('baggage', () => {
+    it('must support set and get baggage items', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setBaggageItem('foo', 'bar');
       expect(span.getBaggageItem('foo')).to.equal('bar');
     });
 
-    it('must return undefined for unknown baggage items', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must return undefined for unknown baggage items', () => {
+      const span = new Span(tracerInstance, 'rpc');
       expect(span.getBaggageItem('foo')).to.equal(undefined);
     });
   });
 
-  describe('references', function() {
-    it('must set trace and parent ID based on child of reference', function() {
-      var span = new Span(tracerInstance, 'rpc');
-      var child = new Span(tracerInstance, 'oauth', {
+  describe('references', () => {
+    it('must set trace and parent ID based on child of reference', () => {
+      const span = new Span(tracerInstance, 'rpc');
+      const child = new Span(tracerInstance, 'oauth', {
         references: [opentracing.childOf(span)]
       });
       expect(child.span.t).to.equal(span.span.t);
@@ -302,30 +302,30 @@ describe('tracing/opentracing/Span', function() {
       expect(child.span.s).not.to.equal(span.span.s);
     });
 
-    it('must copy sampling priority from parent span', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must copy sampling priority from parent span', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setTag(opentracing.Tags.SAMPLING_PRIORITY, 0);
-      var child = new Span(tracerInstance, 'oauth', {
+      const child = new Span(tracerInstance, 'oauth', {
         references: [opentracing.childOf(span)]
       });
       child.finish();
       expect(spanBuffer.addSpan.callCount).to.equal(0);
     });
 
-    it('must copy baggage from parent span', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must copy baggage from parent span', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setBaggageItem('foo', 'bar');
-      var child = new Span(tracerInstance, 'oauth', {
+      const child = new Span(tracerInstance, 'oauth', {
         references: [opentracing.childOf(span)]
       });
       expect(span.getBaggageItem('foo')).to.equal('bar');
       expect(child.getBaggageItem('foo')).to.equal('bar');
     });
 
-    it('must actually copy baggage to keep future baggage mutations from propagating', function() {
-      var span = new Span(tracerInstance, 'rpc');
+    it('must actually copy baggage to keep future baggage mutations from propagating', () => {
+      const span = new Span(tracerInstance, 'rpc');
       span.setBaggageItem('foo', 'bar');
-      var child = new Span(tracerInstance, 'oauth', {
+      const child = new Span(tracerInstance, 'oauth', {
         references: [opentracing.childOf(span)]
       });
       child.setBaggageItem('foo', 'blub');
@@ -333,20 +333,20 @@ describe('tracing/opentracing/Span', function() {
       expect(child.getBaggageItem('foo')).to.equal('blub');
     });
 
-    it('must support child of span contexts with missing trace relation data', function() {
-      var span = new Span(tracerInstance, 'rpc');
-      var parentContext = span.context();
+    it('must support child of span contexts with missing trace relation data', () => {
+      const span = new Span(tracerInstance, 'rpc');
+      const parentContext = span.context();
       delete parentContext.t;
       delete parentContext.s;
-      var child = new Span(tracerInstance, 'oauth', {
+      const child = new Span(tracerInstance, 'oauth', {
         references: [opentracing.childOf(parentContext)]
       });
       expect(child.span.t).to.equal(child.span.s);
     });
 
-    it('must set trace and parent ID based on follows from of reference', function() {
-      var span = new Span(tracerInstance, 'rpc');
-      var child = new Span(tracerInstance, 'oauth', {
+    it('must set trace and parent ID based on follows from of reference', () => {
+      const span = new Span(tracerInstance, 'rpc');
+      const child = new Span(tracerInstance, 'oauth', {
         references: [opentracing.followsFrom(span)]
       });
       expect(child.span.t).to.equal(span.span.t);

--- a/packages/core/test/tracing/open_tracing/Tracer_test.js
+++ b/packages/core/test/tracing/open_tracing/Tracer_test.js
@@ -1,27 +1,27 @@
 'use strict';
 
-var opentracing = require('opentracing');
-var Tracer = require('../../../src/tracing/opentracing/Tracer');
-var expect = require('chai').expect;
+const opentracing = require('opentracing');
+const Tracer = require('../../../src/tracing/opentracing/Tracer');
+const expect = require('chai').expect;
 
-describe('tracing/opentracing/Tracer', function() {
-  var tracer;
-  var span;
+describe('tracing/opentracing/Tracer', () => {
+  let tracer;
+  let span;
 
-  beforeEach(function() {
+  beforeEach(() => {
     tracer = new Tracer(true);
     span = tracer.startSpan('rpc');
   });
 
-  describe('serialization formats', function() {
-    var carrier;
+  describe('serialization formats', () => {
+    let carrier;
 
-    beforeEach(function() {
+    beforeEach(() => {
       carrier = {};
     });
 
-    describe('inject', function() {
-      it('must inject text map context', function() {
+    describe('inject', () => {
+      it('must inject text map context', () => {
         tracer.inject(span, opentracing.FORMAT_TEXT_MAP, carrier);
         expect(carrier).to.deep.equal({
           'x-instana-t': span.span.t,
@@ -30,7 +30,7 @@ describe('tracing/opentracing/Tracer', function() {
         });
       });
 
-      it('must inject varying log levels', function() {
+      it('must inject varying log levels', () => {
         span.setTag(opentracing.Tags.SAMPLING_PRIORITY, 0.5);
         tracer.inject(span, opentracing.FORMAT_TEXT_MAP, carrier);
         expect(carrier).to.deep.equal({
@@ -40,8 +40,8 @@ describe('tracing/opentracing/Tracer', function() {
         });
       });
 
-      it('must respect span hierarchy', function() {
-        var child = tracer.startSpan('oauth', {
+      it('must respect span hierarchy', () => {
+        const child = tracer.startSpan('oauth', {
           childOf: span
         });
         tracer.inject(child, opentracing.FORMAT_TEXT_MAP, carrier);
@@ -52,7 +52,7 @@ describe('tracing/opentracing/Tracer', function() {
         });
       });
 
-      it('must include baggage items in serialized context', function() {
+      it('must include baggage items in serialized context', () => {
         span.setBaggageItem('foo', 'bar');
         tracer.inject(span, opentracing.FORMAT_TEXT_MAP, carrier);
         expect(carrier).to.deep.equal({
@@ -63,7 +63,7 @@ describe('tracing/opentracing/Tracer', function() {
         });
       });
 
-      it('must url encode values', function() {
+      it('must url encode values', () => {
         span.setBaggageItem('foo', 'bar & blub');
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, carrier);
         expect(carrier).to.deep.equal({
@@ -74,14 +74,14 @@ describe('tracing/opentracing/Tracer', function() {
         });
       });
 
-      it('must not fail when requesting unknown or unsupported serialization formats', function() {
+      it('must not fail when requesting unknown or unsupported serialization formats', () => {
         tracer.inject(span, opentracing.FORMAT_BINARY, carrier);
         expect(carrier).to.deep.equal({});
       });
     });
 
-    describe('extract', function() {
-      beforeEach(function() {
+    describe('extract', () => {
+      beforeEach(() => {
         carrier = {
           'x-instana-t': 'aTraceId',
           'x-instana-s': 'aSpanId',
@@ -90,8 +90,8 @@ describe('tracing/opentracing/Tracer', function() {
         };
       });
 
-      it('must extract carrier object into span context and use it for new span', function() {
-        var spanContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
+      it('must extract carrier object into span context and use it for new span', () => {
+        const spanContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
         expect(spanContext.samplingPriority).to.equal(0.5);
         span = tracer.startSpan('oauth', {
           childOf: spanContext
@@ -101,20 +101,20 @@ describe('tracing/opentracing/Tracer', function() {
         expect(span.getBaggageItem('foo')).to.equal('bar & blub');
       });
 
-      it('must return null for unsupported / unknown serialization formats', function() {
-        var spanContext = tracer.extract(opentracing.FORMAT_BINARY, carrier);
+      it('must return null for unsupported / unknown serialization formats', () => {
+        const spanContext = tracer.extract(opentracing.FORMAT_BINARY, carrier);
         expect(spanContext).to.equal(null);
       });
 
-      it('must translate failed sampling priority parsing to disabled tracing', function() {
+      it('must translate failed sampling priority parsing to disabled tracing', () => {
         carrier['x-instana-l'] = 'unsupportedValue';
-        var spanContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
+        const spanContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
         expect(spanContext.samplingPriority).to.equal(0);
       });
 
-      it('must translate partially available parent trace data as unavailable trace data', function() {
+      it('must translate partially available parent trace data as unavailable trace data', () => {
         delete carrier['x-instana-t'];
-        var spanContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
+        const spanContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
         expect(spanContext.t).to.equal(null);
         expect(spanContext.s).to.equal(null);
       });

--- a/packages/core/test/tracing/open_tracing/opentracingApi_test.js
+++ b/packages/core/test/tracing/open_tracing/opentracingApi_test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var instanaOpentracing = require('../../../src/tracing/opentracing');
-var apiCompatibilityChecks = require('opentracing/lib/test/api_compatibility').default;
+const instanaOpentracing = require('../../../src/tracing/opentracing');
+const apiCompatibilityChecks = require('opentracing/lib/test/api_compatibility').default;
 
-describe('tracing/opentracing/opentracingApi', function() {
+describe('tracing/opentracing/opentracingApi', () => {
   apiCompatibilityChecks(instanaOpentracing.createTracer, {
     checkBaggageValues: true
   });

--- a/packages/core/test/tracing/tracingUtil_test.js
+++ b/packages/core/test/tracing/tracingUtil_test.js
@@ -2,14 +2,14 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var fail = require('assert').fail;
+const expect = require('chai').expect;
+const fail = require('assert').fail;
 
-var config = require('../config');
+const config = require('../config');
 
-var tracingUtil = require('../../src/tracing/tracingUtil');
+const tracingUtil = require('../../src/tracing/tracingUtil');
 
-describe('tracing/tracingUtil', function() {
+describe('tracing/tracingUtil', () => {
   describe('generate random IDs', function() {
     this.timeout(config.getTestTimeout() * 10);
 
@@ -20,13 +20,13 @@ describe('tracing/tracingUtil', function() {
     // 128 bit IDs (yet). It can be removed once trace IDs are upped to 128 bit.
     testRandomIds('128 bit', tracingUtil.generateRandomId.bind(null, 32), 32);
 
-    var validIdRegex = /^[a-f0-9]+$/;
+    const validIdRegex = /^[a-f0-9]+$/;
 
     function testRandomIds(idType, genFn, expectedLength) {
-      it('must generate unique and wellformed ' + idType + ' IDs', function() {
-        var iterations = 20000;
-        var generatedIds = [];
-        for (var i = 0; i < iterations; i++) {
+      it(`must generate unique and wellformed ${idType} IDs`, () => {
+        const iterations = 20000;
+        const generatedIds = [];
+        for (let i = 0; i < iterations; i++) {
           generatedIds[i] = genFn();
           expect(generatedIds[i]).to.be.a('string');
           expect(generatedIds[i].length).to.equal(expectedLength);
@@ -34,24 +34,17 @@ describe('tracing/tracingUtil', function() {
         }
 
         // verify that the generated IDs are unique
-        for (i = 0; i < iterations; i++) {
-          for (var j = i + 1; j < iterations; j++) {
+        for (let i = 0; i < iterations; i++) {
+          for (let j = i + 1; j < iterations; j++) {
             // eslint-disable-next-line eqeqeq
             if (generatedIds[i] == generatedIds[j]) {
               fail(
                 // actual
                 generatedIds[j],
                 // expected
-                'an ID != ' + generatedIds[j],
+                `an ID != ${generatedIds[j]}`,
                 // message
-                'found a non-unique ID at indices ' +
-                  i +
-                  ' and ' +
-                  j +
-                  ': ' +
-                  generatedIds[i] +
-                  ' === ' +
-                  generatedIds[j]
+                `found a non-unique ID at indices ${i} and ${j}: ${generatedIds[i]} === ${generatedIds[j]}`
               );
             }
           }
@@ -64,39 +57,39 @@ describe('tracing/tracingUtil', function() {
     this.timeout(config.getTestTimeout() * 4);
 
     // generate one million IDs each (64 bit/16 chars, 128 bit/32 chars)
-    var iterations = 1000000;
-    var maxAcceptableDuration = process.env.CI ? 50000 : 10000;
+    const iterations = 1000000;
+    const maxAcceptableDuration = process.env.CI ? 50000 : 10000;
 
     microBenchmark(16);
     microBenchmark(32);
 
     function microBenchmark(length) {
-      it('with hex IDs that are ' + length + ' characters long', function() {
-        var start = Date.now();
-        for (var i = 0; i < iterations; i++) {
+      it(`with hex IDs that are ${length} characters long`, () => {
+        const start = Date.now();
+        for (let i = 0; i < iterations; i++) {
           tracingUtil.generateRandomSpanId(length);
         }
-        var duration = Date.now() - start;
+        const duration = Date.now() - start;
         expect(duration).to.be.lte(maxAcceptableDuration);
       });
     }
   });
 
-  describe('getErrorDetails', function() {
-    it('must not fail on null/undefined', function() {
+  describe('getErrorDetails', () => {
+    it('must not fail on null/undefined', () => {
       expect(tracingUtil.getErrorDetails(null)).to.equal(undefined);
       expect(tracingUtil.getErrorDetails(undefined)).to.equal(undefined);
     });
 
-    it('must use error stack when available', function() {
+    it('must use error stack when available', () => {
       expect(tracingUtil.getErrorDetails(new Error('Whhoooopppppss'))).to.match(/Whhoooopppppss/);
     });
 
-    it('must use error message when available', function() {
+    it('must use error message when available', () => {
       expect(tracingUtil.getErrorDetails({ message: 'Whhoooopppppss' })).to.match(/Whhoooopppppss/);
     });
 
-    it('must use the whole provided error when all else fails', function() {
+    it('must use the whole provided error when all else fails', () => {
       expect(tracingUtil.getErrorDetails('Whhoooopppppss')).to.match(/Whhoooopppppss/);
     });
   });

--- a/packages/core/test/util/atMostOnce_test.js
+++ b/packages/core/test/util/atMostOnce_test.js
@@ -2,20 +2,20 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var sinon = require('sinon');
+const expect = require('chai').expect;
+const sinon = require('sinon');
 
-var atMostOnce = require('../../src/util/atMostOnce');
+const atMostOnce = require('../../src/util/atMostOnce');
 
-describe('util.atMostOnce', function() {
-  var cb;
+describe('util.atMostOnce', () => {
+  let cb;
 
-  beforeEach(function() {
+  beforeEach(() => {
     cb = sinon.stub();
   });
 
-  it('should forward calls with parameters', function() {
-    var wrapped = atMostOnce('test', cb);
+  it('should forward calls with parameters', () => {
+    const wrapped = atMostOnce('test', cb);
     expect(cb.callCount).to.equal(0);
 
     wrapped('foo', true, 1);
@@ -26,8 +26,8 @@ describe('util.atMostOnce', function() {
     expect(cb.getCall(0).args[2]).to.equal(1);
   });
 
-  it('should not permit any successive calls', function() {
-    var wrapped = atMostOnce('test', cb);
+  it('should not permit any successive calls', () => {
+    const wrapped = atMostOnce('test', cb);
     wrapped('a');
 
     wrapped();

--- a/packages/core/test/util/compression_test.js
+++ b/packages/core/test/util/compression_test.js
@@ -2,59 +2,59 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var compression = require('../../src/util/compression');
+const expect = require('chai').expect;
+const compression = require('../../src/util/compression');
 
-describe('compression', function() {
-  it('should comparse primitive values', function() {
+describe('compression', () => {
+  it('should comparse primitive values', () => {
     expect(compression(42, 43)).to.deep.equal(43);
     expect(compression(true, false)).to.deep.equal(false);
   });
 
-  it('should copy new value if type changes', function() {
+  it('should copy new value if type changes', () => {
     expect(compression(42, true)).to.deep.equal(true);
     expect(compression(42, 'foobar')).to.deep.equal('foobar');
   });
 
-  describe('objects', function() {
-    it('should find new properties', function() {
+  describe('objects', () => {
+    it('should find new properties', () => {
       expect(compression({}, { a: 42 })).to.deep.equal({ a: 42 });
     });
 
-    it('should ignore unchanged properties', function() {
+    it('should ignore unchanged properties', () => {
       expect(compression({ a: 42 }, { a: 42 })).to.deep.equal({});
     });
 
-    it('should deep find new properties', function() {
+    it('should deep find new properties', () => {
       expect(compression({}, { a: { b: 7 } })).to.deep.equal({ a: { b: 7 } });
     });
 
-    it('should ignore unchanged properties', function() {
+    it('should ignore unchanged properties', () => {
       expect(compression({ a: { b: 7 } }, { a: { b: 7, c: 3 } })).to.deep.equal({ a: { c: 3 } });
     });
 
-    it('should mark all values as new', function() {
+    it('should mark all values as new', () => {
       expect(compression(undefined, { a: { b: 7, c: 3 } })).to.deep.equal({ a: { b: 7, c: 3 } });
     });
   });
 
-  describe('arrays', function() {
-    it('should report empty next array as empty arrays', function() {
+  describe('arrays', () => {
+    it('should report empty next array as empty arrays', () => {
       expect(compression({ data: [1, 2] }, { data: [] })).to.deep.equal({ data: [] });
     });
 
-    it('should report complete new array when the length differs', function() {
+    it('should report complete new array when the length differs', () => {
       expect(compression({ data: [1, 2] }, { data: [1, 2, 3] })).to.deep.equal({ data: [1, 2, 3] });
       expect(compression({ data: [1, 2, 3] }, { data: [1, 2] })).to.deep.equal({ data: [1, 2] });
     });
 
-    it('should report undefined when array is shallow unchanged', function() {
+    it('should report undefined when array is shallow unchanged', () => {
       expect(compression({ data: [1, 2, 3] }, { data: [1, 2, 3] })).to.deep.equal({});
       expect(compression({ data: [1] }, { data: [1] })).to.deep.equal({});
       expect(compression({ data: [] }, { data: [] })).to.deep.equal({});
     });
 
-    it('should resend the whole array when any of the values changes', function() {
+    it('should resend the whole array when any of the values changes', () => {
       expect(compression({ data: [1, 2, 3] }, { data: [1, 2, 4] })).to.deep.equal({ data: [1, 2, 4] });
     });
   });

--- a/packages/core/test/util/deepMerge_test.js
+++ b/packages/core/test/util/deepMerge_test.js
@@ -2,73 +2,73 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var deepMerge = require('../../src/util/deepMerge');
+const deepMerge = require('../../src/util/deepMerge');
 
-describe('util.deepMerge', function() {
-  it('should merge nulls to null', function() {
+describe('util.deepMerge', () => {
+  it('should merge nulls to null', () => {
     expect(deepMerge(null, null)).to.not.exist;
     expect(deepMerge(null, undefined)).to.not.exist;
     expect(deepMerge(undefined, null)).to.not.exist;
   });
 
-  it('should merge object and null', function() {
+  it('should merge object and null', () => {
     expect(deepMerge({ value: 13 }, null).value).to.equal(13);
     expect(deepMerge({ value: 13 }, undefined).value).to.equal(13);
     expect(deepMerge(null, { value: 13 }).value).to.equal(13);
     expect(deepMerge(undefined, { value: 13 }).value).to.equal(13);
   });
 
-  it('should merge two objects with different properties', function() {
-    var merged = deepMerge({ a: 13 }, { b: 2 });
+  it('should merge two objects with different properties', () => {
+    const merged = deepMerge({ a: 13 }, { b: 2 });
     expect(merged.a).to.equal(13);
     expect(merged.b).to.equal(2);
   });
 
-  it('source takes precedence in case of conflicts', function() {
-    var merged = deepMerge({ a: 13 }, { a: 2 });
+  it('source takes precedence in case of conflicts', () => {
+    const merged = deepMerge({ a: 13 }, { a: 2 });
     expect(merged.a).to.equal(2);
   });
 
-  it('source takes precedence in case of conflicts', function() {
-    var merged = deepMerge({ a: 13 }, { a: 2 });
+  it('source takes precedence in case of conflicts', () => {
+    const merged = deepMerge({ a: 13 }, { a: 2 });
     expect(merged.a).to.equal(2);
   });
 
-  it('merges recursively', function() {
-    var merged = deepMerge({ nested: { a: 13 } }, { nested: { b: 2 } });
+  it('merges recursively', () => {
+    const merged = deepMerge({ nested: { a: 13 } }, { nested: { b: 2 } });
     expect(merged.nested.a).to.equal(13);
     expect(merged.nested.b).to.equal(2);
   });
 
-  it('uses source property when target property does not exist', function() {
-    var merged = deepMerge({ nested: { a: 13 } }, { nested: { b: 2, c: 1234 } });
+  it('uses source property when target property does not exist', () => {
+    const merged = deepMerge({ nested: { a: 13 } }, { nested: { b: 2, c: 1234 } });
     expect(merged.nested.c).to.equal(1234);
   });
 
-  it('uses source property when target property is array', function() {
-    var merged = deepMerge({ nested: { value: [1, 2, 3] } }, { nested: { value: { deep: 'Ohai!' } } });
+  it('uses source property when target property is array', () => {
+    const merged = deepMerge({ nested: { value: [1, 2, 3] } }, { nested: { value: { deep: 'Ohai!' } } });
     expect(merged.nested.value.deep).to.equal('Ohai!');
   });
 
-  it('uses source property when source property is array', function() {
-    var merged = deepMerge({ nested: { value: { deep: 'Ohai!' } } }, { nested: { value: [1, 2, 3] } });
+  it('uses source property when source property is array', () => {
+    const merged = deepMerge({ nested: { value: { deep: 'Ohai!' } } }, { nested: { value: [1, 2, 3] } });
     expect(merged.nested.value).to.deep.equal([1, 2, 3]);
   });
 
-  it('uses source property when target property is not an object', function() {
-    var merged = deepMerge({ nested: { value: 'not an object' } }, { nested: { value: { deep: 'Ohai!' } } });
+  it('uses source property when target property is not an object', () => {
+    const merged = deepMerge({ nested: { value: 'not an object' } }, { nested: { value: { deep: 'Ohai!' } } });
     expect(merged.nested.value.deep).to.equal('Ohai!');
   });
 
-  it('uses source property when source property is not an object', function() {
-    var merged = deepMerge({ nested: { value: { deep: 'Ohai!' } } }, { nested: { value: 'not an object' } });
+  it('uses source property when source property is not an object', () => {
+    const merged = deepMerge({ nested: { value: { deep: 'Ohai!' } } }, { nested: { value: 'not an object' } });
     expect(merged.nested.value).to.equal('not an object');
   });
 
-  it('uses target property when source property is null', function() {
-    var merged = deepMerge({ nested: { value: { deep: 'Ohai!' } } }, { nested: { value: null } });
+  it('uses target property when source property is null', () => {
+    const merged = deepMerge({ nested: { value: { deep: 'Ohai!' } } }, { nested: { value: null } });
     expect(merged.nested.value.deep).to.equal('Ohai!');
   });
 });

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -3,11 +3,11 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var normalizeConfig = require('../../src/util/normalizeConfig');
+const normalizeConfig = require('../../src/util/normalizeConfig');
 
-describe('util.normalizeConfig', function() {
+describe('util.normalizeConfig', () => {
   beforeEach(resetEnv);
   afterEach(resetEnv);
 
@@ -18,31 +18,31 @@ describe('util.normalizeConfig', function() {
     delete process.env['INSTANA_STACK_TRACE_LENGTH'];
   }
 
-  it('should apply all defaults', function() {
+  it('should apply all defaults', () => {
     checkDefaults(normalizeConfig());
     checkDefaults(normalizeConfig({}));
     checkDefaults(normalizeConfig({ tracing: {}, metrics: {} }));
     checkDefaults(normalizeConfig({ unknowConfigOption: 13 }));
   });
 
-  it('should accept service name', function() {
-    var config = normalizeConfig({ serviceName: 'custom-service-name' });
+  it('should accept service name', () => {
+    const config = normalizeConfig({ serviceName: 'custom-service-name' });
     expect(config.serviceName).to.equal('custom-service-name');
   });
 
-  it('should accept service name from env var', function() {
+  it('should accept service name from env var', () => {
     process.env['INSTANA_SERVICE_NAME'] = 'very-custom-service-name';
-    var config = normalizeConfig();
+    const config = normalizeConfig();
     expect(config.serviceName).to.equal('very-custom-service-name');
   });
 
-  it('should not accept non-string service name', function() {
-    var config = normalizeConfig({ serviceName: 42 });
+  it('should not accept non-string service name', () => {
+    const config = normalizeConfig({ serviceName: 42 });
     expect(config.serviceName).to.not.exist;
   });
 
-  it('should use custom config.metrics.timeBetweenHealthcheckCalls', function() {
-    var config = normalizeConfig({
+  it('should use custom config.metrics.timeBetweenHealthcheckCalls', () => {
+    const config = normalizeConfig({
       metrics: {
         timeBetweenHealthcheckCalls: 9876
       }
@@ -51,50 +51,50 @@ describe('util.normalizeConfig', function() {
     expect(config.timeBetweenHealthcheckCalls).to.not.exist;
   });
 
-  it('should use legacy config.timeBetweenHealthcheckCalls', function() {
-    var config = normalizeConfig({ timeBetweenHealthcheckCalls: 1234 });
+  it('should use legacy config.timeBetweenHealthcheckCalls', () => {
+    const config = normalizeConfig({ timeBetweenHealthcheckCalls: 1234 });
     expect(config.metrics.timeBetweenHealthcheckCalls).to.equal(1234);
     expect(config.timeBetweenHealthcheckCalls).to.not.exist;
   });
 
-  it('should disable tracing', function() {
-    var config = normalizeConfig({ tracing: { enabled: false } });
+  it('should disable tracing', () => {
+    const config = normalizeConfig({ tracing: { enabled: false } });
     expect(config.tracing.enabled).to.be.false;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
     expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
-  it('should disable tracing via INSTANA_DISABLE_TRACING', function() {
+  it('should disable tracing via INSTANA_DISABLE_TRACING', () => {
     process.env['INSTANA_DISABLE_TRACING'] = true;
-    var config = normalizeConfig();
+    const config = normalizeConfig();
     expect(config.tracing.enabled).to.be.false;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
   });
 
-  it('should disable automatic tracing', function() {
-    var config = normalizeConfig({ tracing: { automaticTracingEnabled: false } });
+  it('should disable automatic tracing', () => {
+    const config = normalizeConfig({ tracing: { automaticTracingEnabled: false } });
     expect(config.tracing.enabled).to.be.true;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
     expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
-  it('should disable automatic tracing (legacy config)', function() {
-    var config = normalizeConfig({ tracing: { disableAutomaticTracing: true } });
+  it('should disable automatic tracing (legacy config)', () => {
+    const config = normalizeConfig({ tracing: { disableAutomaticTracing: true } });
     expect(config.tracing.enabled).to.be.true;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
     expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
-  it('should disable automatic tracing via INSTANA_DISABLE_AUTO_INSTR', function() {
+  it('should disable automatic tracing via INSTANA_DISABLE_AUTO_INSTR', () => {
     process.env['INSTANA_DISABLE_AUTO_INSTR'] = 'true';
-    var config = normalizeConfig();
+    const config = normalizeConfig();
     expect(config.tracing.enabled).to.be.true;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
     expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
-  it('should not enable automatic tracing when tracing is disabled in general', function() {
-    var config = normalizeConfig({
+  it('should not enable automatic tracing when tracing is disabled in general', () => {
+    const config = normalizeConfig({
       tracing: {
         enabled: false,
         automaticTracingEnabled: true
@@ -105,8 +105,8 @@ describe('util.normalizeConfig', function() {
     expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
-  it('should use custom transmission settings', function() {
-    var config = normalizeConfig({
+  it('should use custom transmission settings', () => {
+    const config = normalizeConfig({
       tracing: {
         maxBufferedSpans: 13,
         forceTransmissionStartingAt: 2
@@ -116,8 +116,8 @@ describe('util.normalizeConfig', function() {
     expect(config.tracing.forceTransmissionStartingAt).to.equal(2);
   });
 
-  it('should use extra http headers (and normalize to lower case)', function() {
-    var config = normalizeConfig({
+  it('should use extra http headers (and normalize to lower case)', () => {
+    const config = normalizeConfig({
       tracing: {
         http: {
           extraHttpHeadersToCapture: ['yo', 'LO']
@@ -127,8 +127,8 @@ describe('util.normalizeConfig', function() {
     expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['yo', 'lo']);
   });
 
-  it('should reject non-array extra http headers configuration value', function() {
-    var config = normalizeConfig({
+  it('should reject non-array extra http headers configuration value', () => {
+    const config = normalizeConfig({
       tracing: {
         http: {
           extraHttpHeadersToCapture: 'yolo'
@@ -139,49 +139,49 @@ describe('util.normalizeConfig', function() {
     expect(config.tracing.http.extraHttpHeadersToCapture).to.be.empty;
   });
 
-  it('should accept numerical custom stack trace length', function() {
-    var config = normalizeConfig({ tracing: { stackTraceLength: 666 } });
+  it('should accept numerical custom stack trace length', () => {
+    const config = normalizeConfig({ tracing: { stackTraceLength: 666 } });
     expect(config.tracing.stackTraceLength).to.equal(666);
   });
 
-  it('should normalize numbers for custom stack trace length', function() {
-    var config = normalizeConfig({ tracing: { stackTraceLength: -28.08 } });
+  it('should normalize numbers for custom stack trace length', () => {
+    const config = normalizeConfig({ tracing: { stackTraceLength: -28.08 } });
     expect(config.tracing.stackTraceLength).to.be.a('number');
     expect(config.tracing.stackTraceLength).to.equal(28);
   });
 
-  it('should accept number-like strings for custom stack trace length', function() {
-    var config = normalizeConfig({ tracing: { stackTraceLength: '1302' } });
+  it('should accept number-like strings for custom stack trace length', () => {
+    const config = normalizeConfig({ tracing: { stackTraceLength: '1302' } });
     expect(config.tracing.stackTraceLength).to.be.a('number');
     expect(config.tracing.stackTraceLength).to.equal(1302);
   });
 
-  it('should normalize number-like strings for custom stack trace length', function() {
-    var config = normalizeConfig({ tracing: { stackTraceLength: '-16.04' } });
+  it('should normalize number-like strings for custom stack trace length', () => {
+    const config = normalizeConfig({ tracing: { stackTraceLength: '-16.04' } });
     expect(config.tracing.stackTraceLength).to.be.a('number');
     expect(config.tracing.stackTraceLength).to.equal(16);
   });
 
-  it('should reject non-numerical strings for custom stack trace length', function() {
-    var config = normalizeConfig({ tracing: { stackTraceLength: 'three' } });
+  it('should reject non-numerical strings for custom stack trace length', () => {
+    const config = normalizeConfig({ tracing: { stackTraceLength: 'three' } });
     expect(config.tracing.stackTraceLength).to.be.a('number');
     expect(config.tracing.stackTraceLength).to.equal(10);
   });
 
-  it('should reject custom stack trace length which is neither a number nor a string', function() {
-    var config = normalizeConfig({ tracing: { stackTraceLength: false } });
+  it('should reject custom stack trace length which is neither a number nor a string', () => {
+    const config = normalizeConfig({ tracing: { stackTraceLength: false } });
     expect(config.tracing.stackTraceLength).to.be.a('number');
     expect(config.tracing.stackTraceLength).to.equal(10);
   });
 
-  it('should read stack trace length from INSTANA_STACK_TRACE_LENGTH', function() {
+  it('should read stack trace length from INSTANA_STACK_TRACE_LENGTH', () => {
     process.env['INSTANA_STACK_TRACE_LENGTH'] = '3';
-    var config = normalizeConfig();
+    const config = normalizeConfig();
     expect(config.tracing.stackTraceLength).to.equal(3);
   });
 
-  it('should accept custom secrets config', function() {
-    var config = normalizeConfig({
+  it('should accept custom secrets config', () => {
+    const config = normalizeConfig({
       secrets: {
         matcherMode: 'equals',
         keywords: ['custom-secret', 'sheesh']
@@ -191,18 +191,18 @@ describe('util.normalizeConfig', function() {
     expect(config.secrets.keywords).to.deep.equal(['custom-secret', 'sheesh']);
   });
 
-  it('should reject non-string matcher mode', function() {
-    var config = normalizeConfig({ secrets: { matcherMode: 43 } });
+  it('should reject non-string matcher mode', () => {
+    const config = normalizeConfig({ secrets: { matcherMode: 43 } });
     expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
   });
 
-  it('should reject unknown string matcher mode', function() {
-    var config = normalizeConfig({ secrets: { matcherMode: 'whatever' } });
+  it('should reject unknown string matcher mode', () => {
+    const config = normalizeConfig({ secrets: { matcherMode: 'whatever' } });
     expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
   });
 
-  it('should reject non-array keywords', function() {
-    var config = normalizeConfig({ secrets: { keywords: 'yes' } });
+  it('should reject non-array keywords', () => {
+    const config = normalizeConfig({ secrets: { keywords: 'yes' } });
     expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
   });
 

--- a/packages/core/test/util/propertySizes_test.js
+++ b/packages/core/test/util/propertySizes_test.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var propertySizes = require('../../src/util/propertySizes');
+const propertySizes = require('../../src/util/propertySizes');
 
-describe('util.propertySizes', function() {
-  it('should report sizes of first level attributes', function() {
-    var sizes = propertySizes({
+describe('util.propertySizes', () => {
+  it('should report sizes of first level attributes', () => {
+    const sizes = propertySizes({
       string: 'Ohai!',
       number: 1234,
       booleanTrue: true,
@@ -22,8 +22,8 @@ describe('util.propertySizes', function() {
     expect(find(sizes, 'booleanFalse')).to.equal(5);
   });
 
-  it('should not report undefined/null properties', function() {
-    var sizes = propertySizes({
+  it('should not report undefined/null properties', () => {
+    const sizes = propertySizes({
       nullValue: null,
       undefinedValue: undefined
     });
@@ -33,8 +33,8 @@ describe('util.propertySizes', function() {
     expect(find(sizes, 'undefinedValue')).to.not.exist;
   });
 
-  it('should not report nested properties', function() {
-    var sizes = propertySizes({
+  it('should not report nested properties', () => {
+    const sizes = propertySizes({
       string: 'level 1',
       number: 1302,
       data: {
@@ -58,7 +58,7 @@ describe('util.propertySizes', function() {
 });
 
 function find(sizes, property) {
-  for (var i = 0; i < sizes.length; i++) {
+  for (let i = 0; i < sizes.length; i++) {
     if (sizes[i].property === property) {
       return sizes[i].length;
     }

--- a/packages/core/test/util/require_hook/requireHook_test.js
+++ b/packages/core/test/util/require_hook/requireHook_test.js
@@ -2,44 +2,44 @@
 
 'use strict';
 
-var proxyquire = require('proxyquire');
-var expect = require('chai').expect;
-var sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const expect = require('chai').expect;
+const sinon = require('sinon');
 
-describe('util/requireHook', function() {
-  var requireHook;
-  var hook;
+describe('util/requireHook', () => {
+  let requireHook;
+  let hook;
 
-  beforeEach(function() {
+  beforeEach(() => {
     requireHook = proxyquire('../../../src/util/requireHook', {});
     hook = sinon.stub();
   });
 
-  afterEach(function() {
+  afterEach(() => {
     requireHook.teardownForTestPurposes();
   });
 
-  describe('onModuleLoad', function() {
-    it('must not inform aboute load modules when not initialized', function(done) {
+  describe('onModuleLoad', () => {
+    it('must not inform aboute load modules when not initialized', done => {
       requireHook.onModuleLoad('./testModuleA', hook);
-      setTimeout(function() {
+      setTimeout(() => {
         expect(hook.callCount).to.equal(0);
         done();
       }, 100);
       require('./testModuleA');
     });
 
-    it('must not forcefully load modules', function(done) {
+    it('must not forcefully load modules', done => {
       requireHook.init();
       requireHook.onModuleLoad('./testModuleA', hook);
 
-      setTimeout(function() {
+      setTimeout(() => {
         expect(hook.callCount).to.equal(0);
         done();
       }, 100);
     });
 
-    it('must inform about loaded modules', function() {
+    it('must inform about loaded modules', () => {
       requireHook.init();
       requireHook.onModuleLoad('./testModuleA', hook);
 
@@ -49,7 +49,7 @@ describe('util/requireHook', function() {
       expect(hook.getCall(0).args[0]).to.equal('module a');
     });
 
-    it('must not inform aboute loaded modules twice', function() {
+    it('must not inform aboute loaded modules twice', () => {
       requireHook.init();
       requireHook.onModuleLoad('./testModuleA', hook);
 
@@ -60,7 +60,7 @@ describe('util/requireHook', function() {
       expect(hook.getCall(0).args[0]).to.equal('module a');
     });
 
-    it('must support loading of two separate modules', function() {
+    it('must support loading of two separate modules', () => {
       requireHook.init();
       requireHook.onModuleLoad('./testModuleA', hook);
       requireHook.onModuleLoad('./testModuleB', hook);
@@ -73,7 +73,7 @@ describe('util/requireHook', function() {
       expect(hook.getCall(1).args[0]).to.equal('module a');
     });
 
-    it('must support redefinition of module exports', function() {
+    it('must support redefinition of module exports', () => {
       requireHook.init();
       requireHook.onModuleLoad('./testModuleA', hook);
       hook.returns('a');
@@ -85,7 +85,7 @@ describe('util/requireHook', function() {
       expect(hook.getCall(0).args[0]).to.equal('module a');
     });
 
-    it('must support require chains', function() {
+    it('must support require chains', () => {
       requireHook.init();
       requireHook.onModuleLoad('./testModuleA', hook);
       hook.returns('42');
@@ -97,27 +97,27 @@ describe('util/requireHook', function() {
     });
   });
 
-  describe('onFileLoad', function() {
-    it('must not inform aboute load modules when not initialized', function(done) {
+  describe('onFileLoad', () => {
+    it('must not inform aboute load modules when not initialized', done => {
       requireHook.onFileLoad(/testModuleA/, hook);
-      setTimeout(function() {
+      setTimeout(() => {
         expect(hook.callCount).to.equal(0);
         done();
       }, 100);
       require('./testModuleA');
     });
 
-    it('must not forcefully load modules', function(done) {
+    it('must not forcefully load modules', done => {
       requireHook.init();
       requireHook.onFileLoad(/testModuleA/, hook);
 
-      setTimeout(function() {
+      setTimeout(() => {
         expect(hook.callCount).to.equal(0);
         done();
       }, 100);
     });
 
-    it('must inform about loaded modules', function() {
+    it('must inform about loaded modules', () => {
       requireHook.init();
       requireHook.onFileLoad(/testModuleA/, hook);
 
@@ -127,7 +127,7 @@ describe('util/requireHook', function() {
       expect(hook.getCall(0).args[0]).to.equal('module a');
     });
 
-    it('must not inform aboute loaded modules twice', function() {
+    it('must not inform aboute loaded modules twice', () => {
       requireHook.init();
       requireHook.onFileLoad(/testModuleA/, hook);
 
@@ -138,7 +138,7 @@ describe('util/requireHook', function() {
       expect(hook.getCall(0).args[0]).to.equal('module a');
     });
 
-    it('must support loading of two separate modules', function() {
+    it('must support loading of two separate modules', () => {
       requireHook.init();
       requireHook.onFileLoad(/testModuleA/, hook);
       requireHook.onFileLoad(/testModuleB/, hook);
@@ -151,7 +151,7 @@ describe('util/requireHook', function() {
       expect(hook.getCall(1).args[0]).to.equal('module a');
     });
 
-    it('must support redefinition of module exports', function() {
+    it('must support redefinition of module exports', () => {
       requireHook.init();
       requireHook.onFileLoad(/testModuleA/, hook);
       hook.returns('a');
@@ -163,10 +163,10 @@ describe('util/requireHook', function() {
       expect(hook.getCall(0).args[0]).to.equal('module a');
     });
 
-    describe('real modules', function() {
-      it('must support loading of specific files within a module', function() {
+    describe('real modules', () => {
+      it('must support loading of specific files within a module', () => {
         requireHook.init();
-        var pattern = requireHook.buildFileNamePattern(['node_modules', 'express', 'lib', 'router', 'route.js']);
+        const pattern = requireHook.buildFileNamePattern(['node_modules', 'express', 'lib', 'router', 'route.js']);
         requireHook.onFileLoad(pattern, hook);
 
         expect(require('express')).to.be.a('function');

--- a/packages/core/test/util/require_hook/testModuleC.js
+++ b/packages/core/test/util/require_hook/testModuleC.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = 'module c: ' + require('./testModuleA');
+module.exports = `module c: ${require('./testModuleA')}`;

--- a/packages/core/test/util/slidingWindow_test.js
+++ b/packages/core/test/util/slidingWindow_test.js
@@ -2,35 +2,33 @@
 
 'use strict';
 
-var sinon = require('sinon');
-var expect = require('chai').expect;
-var slidingWindow = require('../../src/util/slidingWindow');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const slidingWindow = require('../../src/util/slidingWindow');
 
-describe('slidingWindow', function() {
-  var clock;
-  var w;
+describe('slidingWindow', () => {
+  let clock;
+  let w;
 
-  beforeEach(function() {
+  beforeEach(() => {
     clock = sinon.useFakeTimers();
     w = slidingWindow.create({ duration: 10000 });
   });
 
-  afterEach(function() {
+  afterEach(() => {
     clock.restore();
   });
 
-  it('should add points and make them available via reducers', function() {
+  it('should add points and make them available via reducers', () => {
     w.addPoint(5);
     clock.tick(1000);
     w.addPoint(4);
 
-    var result = w.reduce(function(a, b) {
-      return a + b;
-    }, 0);
+    const result = w.reduce((a, b) => a + b, 0);
     expect(result).to.equal(9);
   });
 
-  it('should only include points that are located in the window', function() {
+  it('should only include points that are located in the window', () => {
     w.addPoint(5); // at 0ms
 
     clock.tick(1000);
@@ -42,35 +40,33 @@ describe('slidingWindow', function() {
     clock.tick(10000);
     w.addPoint(6); // at 14000ms
 
-    var result = w.reduce(function(a, b) {
-      return a + b;
-    }, 0);
+    const result = w.reduce((a, b) => a + b, 0);
     expect(result).to.equal(8);
   });
 
-  it('should provide the desired percentiles', function() {
+  it('should provide the desired percentiles', () => {
     w.addPoint(1);
     w.addPoint(2);
     w.addPoint(3);
     w.addPoint(4);
     w.addPoint(5);
 
-    var percentiles = w.getPercentiles([0.5, 0.25, 0.75, 0.9]);
+    const percentiles = w.getPercentiles([0.5, 0.25, 0.75, 0.9]);
     expect(percentiles).to.deep.equal([3, 2, 4, 5]);
   });
 
-  it('should handle percentiles when there are no values', function() {
-    var percentiles = w.getPercentiles([0.5, 0.25]);
+  it('should handle percentiles when there are no values', () => {
+    const percentiles = w.getPercentiles([0.5, 0.25]);
     expect(percentiles).to.deep.equal([0, 0]);
   });
 
-  it('should handle percentiles when there is only one value', function() {
+  it('should handle percentiles when there is only one value', () => {
     w.addPoint(5);
-    var percentiles = w.getPercentiles([0.5, 0.25, 0.75]);
+    const percentiles = w.getPercentiles([0.5, 0.25, 0.75]);
     expect(percentiles).to.deep.equal([5, 5, 5]);
   });
 
-  it('should return unique values', function() {
+  it('should return unique values', () => {
     w.addPoint('1foo');
     w.addPoint('3blub');
     w.addPoint('1foo');

--- a/packages/core/test/util/stackTrace_test.js
+++ b/packages/core/test/util/stackTrace_test.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var expect = require('chai').expect;
-var path = require('path');
+const expect = require('chai').expect;
+const path = require('path');
 
-var stackTrace = require('../../src/util/stackTrace');
+const stackTrace = require('../../src/util/stackTrace');
 
-describe('util/stackTrace', function() {
-  it('must capture stack traces in a handleable format', function() {
-    var stack = stackTrace.captureStackTrace(10);
+describe('util/stackTrace', () => {
+  it('must capture stack traces in a handleable format', () => {
+    const stack = stackTrace.captureStackTrace(10);
     expect(stack[0].c).to.equal(path.join(__dirname, 'stackTrace_test.js'));
   });
 
-  it('must support custom reference functions', function() {
-    var stack;
+  it('must support custom reference functions', () => {
+    let stack;
 
     (function a() {
       (function b() {
@@ -28,8 +28,8 @@ describe('util/stackTrace', function() {
     expect(stack[1].m).to.equal('a');
   });
 
-  it('must restrict length of stack traces', function() {
-    var stack;
+  it('must restrict length of stack traces', () => {
+    let stack;
 
     (function a() {
       (function b() {

--- a/packages/core/test/util/uniq_test.js
+++ b/packages/core/test/util/uniq_test.js
@@ -2,23 +2,23 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var uniq = require('../../src/util/uniq');
+const expect = require('chai').expect;
+const uniq = require('../../src/util/uniq');
 
-describe('uniq', function() {
-  it('should not fail for empty arrays', function() {
+describe('uniq', () => {
+  it('should not fail for empty arrays', () => {
     expect(uniq([])).to.deep.equal([]);
   });
 
-  it('should not fail for arrays of length 1', function() {
+  it('should not fail for arrays of length 1', () => {
     expect(uniq([2])).to.deep.equal([2]);
   });
 
-  it('should remove duplicates', function() {
+  it('should remove duplicates', () => {
     expect(uniq([1, 1, 2, 3, 3, 4])).to.deep.equal([1, 2, 3, 4]);
   });
 
-  it('should remove duplicates in unsorted inputs', function() {
+  it('should remove duplicates in unsorted inputs', () => {
     expect(uniq([4, 2, 1, 3, 2, 4])).to.deep.equal([1, 2, 3, 4]);
   });
 });

--- a/packages/core/test/util/url_test.js
+++ b/packages/core/test/util/url_test.js
@@ -2,24 +2,24 @@
 
 'use strict';
 
-var urlUtils = require('../../src/util/url');
-var expect = require('chai').expect;
+const urlUtils = require('../../src/util/url');
+const expect = require('chai').expect;
 
-describe('util/url', function() {
-  describe('discardUrlParameters', function() {
-    it('must strip query parameters', function() {
+describe('util/url', () => {
+  describe('discardUrlParameters', () => {
+    it('must strip query parameters', () => {
       expect(urlUtils.discardUrlParameters('https://google.com/search?foo=bar')).to.equal('https://google.com/search');
     });
 
-    it('must strip matrix parameters', function() {
+    it('must strip matrix parameters', () => {
       expect(urlUtils.discardUrlParameters('https://google.com/search;foo=bar')).to.equal('https://google.com/search');
     });
 
-    it('must keep the URL intact when no parameters exist', function() {
+    it('must keep the URL intact when no parameters exist', () => {
       expect(urlUtils.discardUrlParameters('https://google.com/search/')).to.equal('https://google.com/search/');
     });
 
-    it('must discard of mix of various parameter types', function() {
+    it('must discard of mix of various parameter types', () => {
       expect(urlUtils.discardUrlParameters('https://google.com/search/;foo=bar?query=true#blub')).to.equal(
         'https://google.com/search/'
       );

--- a/packages/core/test/utils.js
+++ b/packages/core/test/utils.js
@@ -2,9 +2,9 @@
 
 'use strict';
 
-var Promise = require('bluebird');
+const Promise = require('bluebird');
 
-var config = require('./config');
+const config = require('./config');
 
 exports.retry = function retry(fn, time, until) {
   if (time == null) {
@@ -21,9 +21,7 @@ exports.retry = function retry(fn, time, until) {
 
   return Promise.delay(time / 20)
     .then(fn)
-    .catch(function() {
-      return retry(fn, time, until);
-    });
+    .catch(() => retry(fn, time, until));
 };
 
 exports.expectOneMatching = function expectOneMatching(arr, fn) {
@@ -31,10 +29,10 @@ exports.expectOneMatching = function expectOneMatching(arr, fn) {
     throw new Error('Could not find an item which matches all the criteria. Got 0 items.');
   }
 
-  var error;
+  let error;
 
-  for (var i = 0; i < arr.length; i++) {
-    var item = arr[i];
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
 
     try {
       fn(item);
@@ -46,27 +44,22 @@ exports.expectOneMatching = function expectOneMatching(arr, fn) {
 
   if (error) {
     throw new Error(
-      'Could not find an item which matches all the criteria. Got ' +
-        arr.length +
-        ' items. Last error: ' +
-        error.message +
-        '. All Items:\n' +
-        JSON.stringify(arr, 0, 2) +
-        '. Error stack trace: ' +
-        error.stack
+      `Could not find an item which matches all the criteria. Got ${arr.length} items. Last error: ${
+        error.message
+      }. All Items:\n${JSON.stringify(arr, 0, 2)}. Error stack trace: ${error.stack}`
     );
   }
 };
 
 exports.getSpansByName = function getSpansByName(arr, name) {
-  var result = [];
+  const result = [];
 
   if (!arr || arr.length === 0) {
     return result;
   }
 
-  for (var i = 0; i < arr.length; i++) {
-    var item = arr[i];
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
     if (item.n === name) {
       result.push(item);
     }

--- a/packages/legacy-sensor/test/api/app.js
+++ b/packages/legacy-sensor/test/api/app.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var instana = require('../../')({
+const instana = require('../../')({
   agentPort: process.env.AGENT_PORT,
   level: 'warn',
   tracing: {
@@ -10,22 +10,20 @@ var instana = require('../../')({
   }
 });
 
-var express = require('express');
-var morgan = require('morgan');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
-app.get('/', function(req, res) {
-  return res.sendStatus(200);
-});
+app.get('/', (req, res) => res.sendStatus(200));
 
-app.get('/api', function(req, res) {
-  return res.send({
+app.get('/api', (req, res) =>
+  res.send({
     currentSpan: typeof instana.currentSpan,
     sdk: {
       callback: {
@@ -52,15 +50,15 @@ app.get('/api', function(req, res) {
       activate: typeof instana.opentracing.activate,
       deactivate: typeof instana.opentracing.deactivate
     }
-  });
-});
+  })
+);
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/legacy-sensor/test/api/controls.js
+++ b/packages/legacy-sensor/test/api/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../../collector/test/tracing/AbstractControls');
+const AbstractControls = require('../../../collector/test/tracing/AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   opts.port = 3216;
   AbstractControls.call(this, opts);

--- a/packages/legacy-sensor/test/api/test.js
+++ b/packages/legacy-sensor/test/api/test.js
@@ -1,34 +1,32 @@
 'use strict';
 
-var expect = require('chai').expect;
+const expect = require('chai').expect;
 
-var config = require('../../../collector/test/config');
-var utils = require('../../../collector/test/utils');
+const config = require('../../../collector/test/config');
+const utils = require('../../../collector/test/utils');
 
 describe('legacy sensor/API', function() {
   this.timeout(config.getTestTimeout());
 
-  var agentControls = require('../../../collector/test/apps/agentStubControls');
-  var AppControls = require('./controls');
-  var appControls = new AppControls({
-    agentControls: agentControls
+  const agentControls = require('../../../collector/test/apps/agentStubControls');
+  const AppControls = require('./controls');
+  const appControls = new AppControls({
+    agentControls
   });
 
   agentControls.registerTestHooks();
   appControls.registerTestHooks();
 
-  beforeEach(function() {
-    return agentControls.waitUntilAppIsCompletelyInitialized(appControls.getPid());
-  });
+  beforeEach(() => agentControls.waitUntilAppIsCompletelyInitialized(appControls.getPid()));
 
-  it('all exports', function() {
-    return utils.retry(function() {
-      return appControls
+  it('all exports', () =>
+    utils.retry(() =>
+      appControls
         .sendRequest({
           method: 'GET',
           path: '/api'
         })
-        .then(function(instana) {
+        .then(instana => {
           expect(instana.currentSpan).to.equal('function');
           expect(instana.sdk.callback.startEntrySpan).to.equal('function');
           expect(instana.sdk.callback.completeEntrySpan).to.equal('function');
@@ -47,7 +45,6 @@ describe('legacy sensor/API', function() {
           expect(instana.opentracing.createTracer).to.equal('function');
           expect(instana.opentracing.activate).to.equal('function');
           expect(instana.opentracing.deactivate).to.equal('function');
-        });
-    });
-  });
+        })
+    ));
 });

--- a/packages/legacy-sensor/test/config.js
+++ b/packages/legacy-sensor/test/config.js
@@ -1,13 +1,13 @@
 'use strict';
 
-exports.getAppStdio = function() {
+exports.getAppStdio = () => {
   if (process.env.WITH_STDOUT || process.env.CI) {
     return [process.stdin, process.stdout, process.stderr, 'ipc'];
   }
   return [process.stdin, 'ignore', process.stderr, 'ipc'];
 };
 
-exports.getTestTimeout = function() {
+exports.getTestTimeout = () => {
   if (process.env.CI) {
     return 30000;
   }

--- a/packages/legacy-sensor/test/metrics/app.js
+++ b/packages/legacy-sensor/test/metrics/app.js
@@ -10,26 +10,24 @@ require('../../')({
   }
 });
 
-var express = require('express');
-var morgan = require('morgan');
+const express = require('express');
+const morgan = require('morgan');
 
-var app = express();
-var logPrefix = 'Express App (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
-app.get('/', function(req, res) {
-  return res.sendStatus(200);
-});
+app.get('/', (req, res) => res.sendStatus(200));
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/legacy-sensor/test/metrics/controls.js
+++ b/packages/legacy-sensor/test/metrics/controls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../../collector/test/tracing/AbstractControls');
+const AbstractControls = require('../../../collector/test/tracing/AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'app.js');
   opts.port = 3216;
   AbstractControls.call(this, opts);

--- a/packages/legacy-sensor/test/metrics/test.js
+++ b/packages/legacy-sensor/test/metrics/test.js
@@ -1,45 +1,42 @@
 'use strict';
 
-var expect = require('chai').expect;
-var _ = require('lodash');
+const expect = require('chai').expect;
+const _ = require('lodash');
 
-var config = require('../../../collector/test/config');
-var utils = require('../../../collector/test/utils');
+const config = require('../../../collector/test/config');
+const utils = require('../../../collector/test/utils');
 
 describe('legacy sensor/metrics', function() {
   this.timeout(config.getTestTimeout());
 
-  var agentControls = require('../../../collector/test/apps/agentStubControls');
-  var AppControls = require('./controls');
-  var appControls = new AppControls({
-    agentControls: agentControls
+  const agentControls = require('../../../collector/test/apps/agentStubControls');
+  const AppControls = require('./controls');
+  const appControls = new AppControls({
+    agentControls
   });
 
   agentControls.registerTestHooks();
   appControls.registerTestHooks();
 
-  beforeEach(function() {
-    return agentControls.waitUntilAppIsCompletelyInitialized(appControls.getPid());
-  });
+  beforeEach(() => agentControls.waitUntilAppIsCompletelyInitialized(appControls.getPid()));
 
-  it('must report metrics', function() {
-    return utils.retry(function() {
-      return agentControls.getAllMetrics(appControls.getPid()).then(function(allMetrics) {
+  it('must report metrics', () =>
+    utils.retry(() =>
+      agentControls.getAllMetrics(appControls.getPid()).then(allMetrics => {
         expect(findMetric(allMetrics, ['activeHandles'])).to.exist;
         expect(findMetric(allMetrics, ['gc', 'minorGcs'])).to.exist;
         expect(findMetric(allMetrics, ['gc', 'majorGcs'])).to.exist;
         expect(findMetric(allMetrics, ['healthchecks'])).to.exist;
         expect(findMetric(allMetrics, ['healthchecks'])).to.exist;
         expect(findMetric(allMetrics, ['versions'])).to.exist;
-        expect('v' + findMetric(allMetrics, ['versions', 'node'])).to.equal(process.version);
-      });
-    });
-  });
+        expect(`v${findMetric(allMetrics, ['versions', 'node'])}`).to.equal(process.version);
+      })
+    ));
 });
 
 function findMetric(allMetrics, _path) {
-  for (var i = allMetrics.length - 1; i >= 0; i--) {
-    var value = _.get(allMetrics[i], ['data'].concat(_path));
+  for (let i = allMetrics.length - 1; i >= 0; i--) {
+    const value = _.get(allMetrics[i], ['data'].concat(_path));
     if (value !== undefined) {
       return value;
     }

--- a/packages/legacy-sensor/test/tracing/clientApp.js
+++ b/packages/legacy-sensor/test/tracing/clientApp.js
@@ -10,58 +10,50 @@ require('../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var rp = require('request-promise');
-var express = require('express');
-var semver = require('semver');
-var morgan = require('morgan');
+const bodyParser = require('body-parser');
+const rp = require('request-promise');
+const express = require('express');
+const semver = require('semver');
+const morgan = require('morgan');
 
 // WHATWG URL class is globally availabe as of Node.js 10.0.0, needs to be required in older versions.
-var URL = semver.lt(process.versions.node, '10.0.0') ? require('url').URL : global.URL;
+const URL = semver.lt(process.versions.node, '10.0.0') ? require('url').URL : global.URL;
 
-var http = require('http');
-var baseUrl = 'http://127.0.0.1:' + process.env.SERVER_PORT;
+const http = require('http');
+const baseUrl = `http://127.0.0.1:${process.env.SERVER_PORT}`;
 
-var app = express();
-var logPrefix = 'Express HTTP client: Client (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express HTTP client: Client (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   rp({
     method: 'GET',
-    url: baseUrl + '/',
+    url: `${baseUrl}/`,
     strictSSL: false
   })
-    .then(function() {
+    .then(() => {
       res.sendStatus(200);
     })
-    .catch(function() {
+    .catch(() => {
       res.sendStatus(500);
     });
 });
 
-app.get('/request-url-and-options', function(req, res) {
-  http
-    .request(createUrl(req, '/request-url-opts'), { rejectUnauthorized: false }, function() {
-      return res.sendStatus(200);
-    })
-    .end();
+app.get('/request-url-and-options', (req, res) => {
+  http.request(createUrl(req, '/request-url-opts'), { rejectUnauthorized: false }, () => res.sendStatus(200)).end();
 });
 
-app.get('/request-url-only', function(req, res) {
-  http
-    .request(createUrl(req, '/request-only-url'), function() {
-      return res.sendStatus(200);
-    })
-    .end();
+app.get('/request-url-only', (req, res) => {
+  http.request(createUrl(req, '/request-only-url'), () => res.sendStatus(200)).end();
 });
 
-app.get('/request-options-only', function(req, res) {
+app.get('/request-options-only', (req, res) => {
   http
     .request(
       {
@@ -70,14 +62,12 @@ app.get('/request-options-only', function(req, res) {
         method: 'GET',
         path: '/request-only-opts'
       },
-      function() {
-        return res.sendStatus(200);
-      }
+      () => res.sendStatus(200)
     )
     .end();
 });
 
-app.get('/request-options-only-null-headers', function(req, res) {
+app.get('/request-options-only-null-headers', (req, res) => {
   http
     .request(
       {
@@ -87,26 +77,20 @@ app.get('/request-options-only-null-headers', function(req, res) {
         path: '/request-only-opts',
         headers: null
       },
-      function() {
-        return res.sendStatus(200);
-      }
+      () => res.sendStatus(200)
     )
     .end();
 });
 
-app.get('/get-url-and-options', function(req, res) {
-  http.get(createUrl(req, '/get-url-opts'), { rejectUnauthorized: false }, function() {
-    return res.sendStatus(200);
-  });
+app.get('/get-url-and-options', (req, res) => {
+  http.get(createUrl(req, '/get-url-opts'), { rejectUnauthorized: false }, () => res.sendStatus(200));
 });
 
-app.get('/get-url-only', function(req, res) {
-  http.get(createUrl(req, '/get-only-url'), function() {
-    return res.sendStatus(200);
-  });
+app.get('/get-url-only', (req, res) => {
+  http.get(createUrl(req, '/get-only-url'), () => res.sendStatus(200));
 });
 
-app.get('/get-options-only', function(req, res) {
+app.get('/get-options-only', (req, res) => {
   http.get(
     {
       hostname: '127.0.0.1',
@@ -114,29 +98,27 @@ app.get('/get-options-only', function(req, res) {
       method: 'GET',
       path: '/get-only-opts'
     },
-    function() {
-      return res.sendStatus(200);
-    }
+    () => res.sendStatus(200)
   );
 });
 
-app.get('/timeout', function(req, res) {
+app.get('/timeout', (req, res) => {
   rp({
     method: 'GET',
-    url: baseUrl + '/timeout',
+    url: `${baseUrl}/timeout`,
     timeout: 500,
     strictSSL: false
   })
-    .then(function() {
+    .then(() => {
       res.sendStatus(200);
     })
-    .catch(function() {
+    .catch(() => {
       res.sendStatus(500);
     });
 });
 
-app.get('/abort', function(req, res) {
-  var clientRequest = http.request({
+app.get('/abort', (req, res) => {
+  const clientRequest = http.request({
     method: 'GET',
     hostname: '127.0.0.1',
     port: process.env.SERVER_PORT,
@@ -145,19 +127,19 @@ app.get('/abort', function(req, res) {
 
   clientRequest.end();
 
-  setTimeout(function() {
+  setTimeout(() => {
     clientRequest.abort();
     res.sendStatus(200);
   }, 1500);
 });
 
-app.get('/request-malformed-url', function(req, res) {
+app.get('/request-malformed-url', (req, res) => {
   try {
     http
       .request(
         //
         'ha-te-te-peh://999.0.0.1:not-a-port/malformed-url', //
-        function() {
+        () => {
           console.log('This should not have happend!');
         }
       )
@@ -171,16 +153,14 @@ app.get('/request-malformed-url', function(req, res) {
           method: 'GET',
           path: '/request-only-opts'
         },
-        function() {
-          return res.sendStatus(200);
-        }
+        () => res.sendStatus(200)
       )
       .end();
   }
 });
 
-app.listen(process.env.APP_PORT, function() {
-  log('Listening on port: ' + process.env.APP_PORT);
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
 });
 
 function createUrl(req, urlPath) {
@@ -188,7 +168,7 @@ function createUrl(req, urlPath) {
 }
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/legacy-sensor/test/tracing/clientControls.js
+++ b/packages/legacy-sensor/test/tracing/clientControls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../../collector/test/tracing/AbstractControls');
+const AbstractControls = require('../../../collector/test/tracing/AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'clientApp.js');
   opts.port = 3216;
   AbstractControls.call(this, opts);

--- a/packages/legacy-sensor/test/tracing/serverApp.js
+++ b/packages/legacy-sensor/test/tracing/serverApp.js
@@ -10,22 +10,22 @@ require('../../')({
   }
 });
 
-var bodyParser = require('body-parser');
-var express = require('express');
-var fs = require('fs');
-var morgan = require('morgan');
-var path = require('path');
+const bodyParser = require('body-parser');
+const express = require('express');
+const fs = require('fs');
+const morgan = require('morgan');
+const path = require('path');
 
-var app = express();
-var logPrefix = 'Express HTTP client: Server (' + process.pid + '):\t';
+const app = express();
+const logPrefix = `Express HTTP client: Server (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
-  app.use(morgan(logPrefix + ':method :url :status'));
+  app.use(morgan(`${logPrefix}:method :url :status`));
 }
 
 app.use(bodyParser.json());
 
-app.get('/', function(req, res) {
+app.get('/', (req, res) => {
   res.set('Foobar', '42');
   res.sendStatus(200);
 });
@@ -37,19 +37,19 @@ app.get('/', function(req, res) {
   '/get-url-opts',
   '/get-only-url',
   '/get-only-opts'
-].forEach(function(p) {
-  app.get(p, function(req, res) {
+].forEach(p => {
+  app.get(p, (req, res) => {
     res.sendStatus(200);
   });
 });
 
-app.get('/timeout', function(req, res) {
-  setTimeout(function() {
+app.get('/timeout', (req, res) => {
+  setTimeout(() => {
     res.sendStatus(200);
   }, 10000);
 });
 
-app.put('/continue', function(req, res) {
+app.put('/continue', (req, res) => {
   // Node http server will automatically send 100 Continue when it receives a request with an "Expect: 100-continue"
   // header present, unless we override the 'checkContinue' listener. For our test case, the default behaviour is just
   // fine.
@@ -57,7 +57,7 @@ app.put('/continue', function(req, res) {
 });
 
 if (process.env.USE_HTTPS === 'true') {
-  var sslDir = path.join(__dirname, '..', '..', '..', 'apps', 'ssl');
+  const sslDir = path.join(__dirname, '..', '..', '..', 'apps', 'ssl');
   require('https')
     .createServer(
       {
@@ -66,17 +66,17 @@ if (process.env.USE_HTTPS === 'true') {
       },
       app
     )
-    .listen(process.env.APP_PORT, function() {
-      log('Listening (HTTPS!) on port: ' + process.env.APP_PORT);
+    .listen(process.env.APP_PORT, () => {
+      log(`Listening (HTTPS!) on port: ${process.env.APP_PORT}`);
     });
 } else {
-  app.listen(process.env.APP_PORT, function() {
-    log('Listening on port: ' + process.env.APP_PORT);
+  app.listen(process.env.APP_PORT, () => {
+    log(`Listening on port: ${process.env.APP_PORT}`);
   });
 }
 
 function log() {
-  var args = Array.prototype.slice.call(arguments);
+  const args = Array.prototype.slice.call(arguments);
   args[0] = logPrefix + args[0];
   console.log.apply(console, args);
 }

--- a/packages/legacy-sensor/test/tracing/serverControls.js
+++ b/packages/legacy-sensor/test/tracing/serverControls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
-var AbstractControls = require('../../../collector/test/tracing/AbstractControls');
+const AbstractControls = require('../../../collector/test/tracing/AbstractControls');
 
-var Controls = (module.exports = function Controls(opts) {
+const Controls = (module.exports = function Controls(opts) {
   opts.appPath = path.join(__dirname, 'serverApp.js');
   opts.port = 3217;
   AbstractControls.call(this, opts);

--- a/packages/legacy-sensor/test/tracing/test.js
+++ b/packages/legacy-sensor/test/tracing/test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var expect = require('chai').expect;
-var semver = require('semver');
-var constants = require('@instana/core').tracing.constants;
-var supportedVersion = require('@instana/core').tracing.supportedVersion;
+const expect = require('chai').expect;
+const semver = require('semver');
+const constants = require('@instana/core').tracing.constants;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
 
-var config = require('../../../collector/test/config');
-var utils = require('../../../collector/test/utils');
+const config = require('../../../collector/test/config');
+const utils = require('../../../collector/test/utils');
 
-var agentControls;
-var ClientControls;
-var ServerControls;
+let agentControls;
+let ClientControls;
+let ServerControls;
 
 describe('legacy sensor/tracing', function() {
   if (!supportedVersion(process.versions.node)) {
@@ -25,20 +25,20 @@ describe('legacy sensor/tracing', function() {
 
   agentControls.registerTestHooks();
 
-  var serverControls = new ServerControls({
-    agentControls: agentControls
+  const serverControls = new ServerControls({
+    agentControls
   });
   serverControls.registerTestHooks();
 
-  var clientControls = new ClientControls({
-    agentControls: agentControls,
+  const clientControls = new ClientControls({
+    agentControls,
     env: {
       SERVER_PORT: serverControls.port
     }
   });
   clientControls.registerTestHooks();
 
-  it('must trace request(<string>, options, cb)', function() {
+  it('must trace request(<string>, options, cb)', () => {
     if (semver.lt(process.versions.node, '10.9.0')) {
       // The (url, options[, callback]) API only exists since Node 10.9.0:
       return;
@@ -49,94 +49,92 @@ describe('legacy sensor/tracing', function() {
         method: 'GET',
         path: '/request-url-and-options'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var clientSpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const clientSpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/request-url-opts/);
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/request-url-opts/);
               expect(span.t).to.equal(clientSpan.t);
               expect(span.p).to.equal(clientSpan.s);
             });
-          });
-        });
-      });
+          })
+        )
+      );
   });
 
-  it('must trace request(<string>, cb)', function() {
-    return clientControls
+  it('must trace request(<string>, cb)', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/request-url-only'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var clientSpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const clientSpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/request-only-url/);
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/request-only-url/);
               expect(span.t).to.equal(clientSpan.t);
               expect(span.p).to.equal(clientSpan.s);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace request(options, cb)', function() {
-    return clientControls
+  it('must trace request(options, cb)', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/request-options-only'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var clientSpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const clientSpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/request-only-opts/);
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/request-only-opts/);
               expect(span.t).to.equal(clientSpan.t);
               expect(span.p).to.equal(clientSpan.s);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must capture sync exceptions', function() {
-    return clientControls
+  it('must capture sync exceptions', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/request-malformed-url'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var entrySpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const entrySpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/request-malformed-url/);
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
@@ -146,45 +144,43 @@ describe('legacy sensor/tracing', function() {
               expect(span.p).to.equal(entrySpan.s);
             });
 
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/request-only-opts/);
               expect(span.t).to.equal(entrySpan.t);
               expect(span.p).to.equal(entrySpan.s);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace request(options, cb) with { headers: null }', function() {
-    return clientControls
+  it('must trace request(options, cb) with { headers: null }', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/request-options-only-null-headers'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var clientSpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const clientSpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/request-only-opts/);
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/request-only-opts/);
               expect(span.t).to.equal(clientSpan.t);
               expect(span.p).to.equal(clientSpan.s);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace get(<string>, options, cb)', function() {
+  it('must trace get(<string>, options, cb)', () => {
     if (semver.lt(process.versions.node, '10.9.0')) {
       // The (url, options[, callback]) API only exists since Node 10.9.0.
       return;
@@ -194,141 +190,136 @@ describe('legacy sensor/tracing', function() {
         method: 'GET',
         path: '/get-url-and-options'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var clientSpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const clientSpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/get-url-opts/);
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/get-url-opts/);
               expect(span.t).to.equal(clientSpan.t);
               expect(span.p).to.equal(clientSpan.s);
             });
-          });
-        });
-      });
+          })
+        )
+      );
   });
 
-  it('must trace get(<string>, cb)', function() {
-    return clientControls
+  it('must trace get(<string>, cb)', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/get-url-only'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var clientSpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const clientSpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/get-only-url/);
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/get-only-url/);
               expect(span.t).to.equal(clientSpan.t);
               expect(span.p).to.equal(clientSpan.s);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace get(options, cb)', function() {
-    return clientControls
+  it('must trace get(options, cb)', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/get-options-only'
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            var clientSpan = utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            const clientSpan = utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.data.http.url).to.match(/\/get-only-opts/);
             });
-            utils.expectOneMatching(spans, function(span) {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.server');
               expect(span.k).to.equal(constants.ENTRY);
               expect(span.data.http.url).to.match(/\/get-only-opts/);
               expect(span.t).to.equal(clientSpan.t);
               expect(span.p).to.equal(clientSpan.s);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace calls that fail due to connection refusal', function() {
-    return serverControls
+  it('must trace calls that fail due to connection refusal', () =>
+    serverControls
       .kill()
-      .then(function() {
-        return clientControls.sendRequest({
+      .then(() =>
+        clientControls.sendRequest({
           method: 'GET',
           path: '/timeout',
           simple: false
-        });
-      })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+        })
+      )
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
               expect(span.data.http.error).to.match(/ECONNREFUSED/);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace calls that fail due to timeouts', function() {
-    return clientControls
+  it('must trace calls that fail due to timeouts', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/timeout',
         simple: false
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
               expect(span.data.http.error).to.match(/Timeout/);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 
-  it('must trace aborted calls', function() {
-    return clientControls
+  it('must trace aborted calls', () =>
+    clientControls
       .sendRequest({
         method: 'GET',
         path: '/abort',
         simple: false
       })
-      .then(function() {
-        return utils.retry(function() {
-          return agentControls.getSpans().then(function(spans) {
-            utils.expectOneMatching(spans, function(span) {
+      .then(() =>
+        utils.retry(() =>
+          agentControls.getSpans().then(spans => {
+            utils.expectOneMatching(spans, span => {
               expect(span.n).to.equal('node.http.client');
               expect(span.k).to.equal(constants.EXIT);
               expect(span.ec).to.equal(1);
               expect(span.data.http.error).to.match(/aborted/);
             });
-          });
-        });
-      });
-  });
+          })
+        )
+      ));
 });


### PR DESCRIPTION
For all packages, the command

    lebab --replace . \
          --transform \
              arrow,arrow-return,obj-shorthand,let,template && \
      npm run prettier

has been run in their *test* folders. For now, src folders have not
been converted yet.

The applied transforms all use syntax that is supported since
Node.js 4.x. Later, we might

1) also transform production code (src folders in packages), and
2) use transforms that require Node.js 6.