### PR TITLE
don't fail on errors with circular references

### DIFF
--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -216,7 +216,19 @@ function sendData(path, data, cb, ignore404) {
     ignore404 = false;
   }
 
-  var payload = JSON.stringify(data);
+  const circularReplacer = () => {
+    const seen = new WeakSet();
+    return (_, value) => {
+      if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) {
+          return;
+        }
+        seen.add(value);
+      }
+      return value;
+    };
+  };
+  var payload = JSON.stringify(data, circularReplacer);
 
   logger.debug({ payload: data }, 'Sending payload to %s', path);
   // manually turn into a buffer to correctly identify content-length


### PR DESCRIPTION
we noticed some libraries (Microsoft's @azure/xxxx) throw error objects that have cyclic references and if we attach that error object to the span ...

```typescript
span.log({ event: "error", "error.object": e });
span.setTag("message", e.message);
span.setTag(Tags.ERROR, true);
```

... then it will cause the following error which results in an unhandled promise rejection.

```
TypeError: Converting circular structure to JSON
    at JSON.stringify (\u003canonymous\u003e)
    at sendData (/usr/src/node_modules/@instana/collector/src/agentConnection.js:219:22)
    at Object.sendSpans (/usr/src/node_modules/@instana/collector/src/agentConnection.js:192:3)
    at Timeout.transmitSpans (/usr/src/node_modules/@instana/core/src/tracing/spanBuffer.js:76:24)
```
