### PR TITLE
fix(tracing): fix require cycle when client code also uses cls-bluebird

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Require `cls-bluebird` before installing the require hook for `bluebird` so client code can use `cls-bluebird` without conflicts ([#152](https://github.com/instana/nodejs-sensor/pull/152), thanks to @jonathansamines).
+
 ## 1.68.3
 - Add additional check to `requireHook` in case other modules interfering with `require` (like `require-in-the-middle`) are present.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,6 +97,10 @@
     {
       "name": "Osasu Eboh",
       "email": "osasu.eboh@jet.com"
+    },
+    {
+      "name": "Jonathan Samines",
+      "email": "jn.samines@gmail.com"
     }
   ],
   "license": "MIT",

--- a/packages/core/src/tracing/instrumentation/control_flow/bluebird.js
+++ b/packages/core/src/tracing/instrumentation/control_flow/bluebird.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var instrument = require('cls-bluebird');
 var requireHook = require('../../../util/requireHook');
 var cls = require('../../cls');
 
@@ -16,5 +17,5 @@ exports.init = function() {
 };
 
 function patchBluebird(bluebirdModule) {
-  require('cls-bluebird')(cls.ns, bluebirdModule);
+  instrument(cls.ns, bluebirdModule);
 }


### PR DESCRIPTION
By requiring cls-bluebird before registering the require hook for
bluebird.

Supercedes #152 