### PR TITLE
fix(tracing): fix instrumentation of https client for Node.js 8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Require `cls-bluebird` before installing the require hook for `bluebird` so client code can use `cls-bluebird` without conflicts ([#152](https://github.com/instana/nodejs-sensor/pull/152), thanks to @jonathansamines).
+- Fix tracing of `https` client calls in Node.js 8.9.0.
 
 ## 1.68.3
 - Add additional check to `requireHook` in case other modules interfering with `require` (like `require-in-the-middle`) are present.

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -25,7 +25,7 @@ exports.init = function() {
   // _http_client directly rather than going through the http module. Therefore, beginning with Node 9, explicit
   // instrumentation of the core https module is required. OTOH, in Node <= 8, we must _not_ instrument https, as
   // otherwise we would run our instrumentation code twice (once for https.request and once for http.request).
-  if (semver.gte(process.versions.node, '9.0.0')) {
+  if (semver.gte(process.versions.node, '9.0.0') || process.versions.node === '8.9.0') {
     instrument(coreHttpsModule);
   }
 };


### PR DESCRIPTION
Node had backported the refactoring to use _http_client directly in
https (instead of going through http) from Node.js 9.0.0 to
Node.js 8.9.0, only to revert that immediately in Node.js 8.9.1 a few
days later.

Well, there are folks out there using _exactly_ 8.9.0, so this fix makes
HTTPS client calls tracing possible for that Node.js version.