### PR TITLE
fix(tracing): add missing cls.ns.exit calls to mongodb instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Trace through graphql-subscriptions PubSub/AsyncIterator.
+- Add missing cls.ns.exit calls in mongodb instrumentation (fix for leaking `cls.ns._set` entries).
 
 ## 1.69.0
 - Add graphql instrumentation ([graphql](https://www.npmjs.com/package/graphql)).


### PR DESCRIPTION
The mongodb instrumentation produced cls.ns.enter without matching
cls.ns.exit calls. This could potentially lead to an evergrowing
cls.ns._set array, causing GC pressure.