### PR TITLE
feat(tracing): support for kafka-node >= 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add support for kafka-node >= 4.0.0.
+
 ## 1.70.0
 - Enable uncaught exception reporting in Node 12.x.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2432,9 +2432,9 @@
       "dev": true
     },
     "buffermaker": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffermaker/-/buffermaker-1.2.0.tgz",
-      "integrity": "sha1-u3MlLsCIK3Y56bVWuCnav8LK4bo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/buffermaker/-/buffermaker-1.2.1.tgz",
+      "integrity": "sha512-IdnyU2jDHU65U63JuVQNTHiWjPRH0CS3aYd/WPaEwyX84rFdukhOduAVb1jwUScmb5X0JWPw8NZOrhoLMiyAHQ==",
       "dev": true,
       "requires": {
         "long": "1.1.2"
@@ -6803,25 +6803,37 @@
       "dev": true
     },
     "kafka-node": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/kafka-node/-/kafka-node-2.6.1.tgz",
-      "integrity": "sha512-tpivkSLjiGHRLwx0YN87fMUATOK4NYWESJneHlpikEBNNA5od7fW/ikovS3tWooMqG4Nri55vPFRUNiNvNBWZA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/kafka-node/-/kafka-node-4.1.3.tgz",
+      "integrity": "sha512-C2WHksRCr7vIKmbxYaCk2c5Q1lnHIi6C0f3AioK3ARcRHGO9DpqErcoaS9d8PP62yzTnkYras+iAlmPsZHNSfw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "async": "^2.6.2",
         "binary": "~0.3.0",
-        "bl": "^1.2.0",
+        "bl": "^2.2.0",
         "buffer-crc32": "~0.2.5",
         "buffermaker": "~1.2.0",
         "debug": "^2.1.3",
+        "denque": "^1.3.0",
         "lodash": "^4.17.4",
         "minimatch": "^3.0.2",
         "nested-error-stacks": "^2.0.0",
-        "node-zookeeper-client": "~0.2.2",
         "optional": "^0.1.3",
         "retry": "^0.10.1",
         "snappy": "^6.0.1",
         "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+          "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        }
       }
     },
     "kareem": {
@@ -8140,9 +8152,9 @@
       }
     },
     "node-abi": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
-      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.10.0.tgz",
+      "integrity": "sha512-OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8190,30 +8202,6 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
-    },
-    "node-zookeeper-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.3.tgz",
-      "integrity": "sha512-V4gVHxzQ42iwhkANpPryzfjmqi3Ql3xeO9E/px7W5Yi774WplU3YtqUpnvcL/eJit4UqcfuLOgZLkpf0BPhHmg==",
-      "dev": true,
-      "requires": {
-        "async": "~0.2.7",
-        "underscore": "~1.4.4"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
           "dev": true
         }
       }
@@ -10238,15 +10226,24 @@
       }
     },
     "snappy": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.1.2.tgz",
-      "integrity": "sha512-oYjYCA5/XoYBA5t9lAaQfzq+qJ1eKqoBb7dRCk+BE2dIFe+tMJcpRnraSsK/W9Z6qnXf1oBnhRX9Lr2yMQJ91A==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.2.3.tgz",
+      "integrity": "sha512-HZpVoIxMfQ4fL3iDuMdI1R5xycw1o9YDCAndTKZCY/EHRoKFvzwplttuBBVGeEg2fd1hYiwAXos/sM24W7N1LA==",
       "dev": true,
       "optional": true,
       "requires": {
         "bindings": "^1.3.1",
-        "nan": "^2.12.1",
+        "nan": "^2.14.0",
         "prebuild-install": "^5.2.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "socks": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "graphql-tools": "^4.0.4",
     "grpc": "^1.20.2",
     "ioredis": "^3.2.2",
-    "kafka-node": "^2.6.1",
+    "kafka-node": "^4.1.3",
     "koa": "^2.3.0",
     "koa-bodyparser": "^3.2.0",
     "koa-morgan": "^1.0.1",

--- a/packages/collector/test/tracing/messaging/kafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/kafka/consumer.js
@@ -17,13 +17,49 @@ const request = require('request-promise');
 const kafka = require('kafka-node');
 const uuid = require('uuid/v4');
 
-const client = new kafka.Client(`${process.env.ZOOKEEPER}/`);
-client.on('error', error => {
-  log('Got a client error: %s', error);
-});
+let client;
+if (kafka.Client) {
+  // kafka-node < 4.0.0, client connects via zookeeper
+  client = new kafka.Client(`${process.env.ZOOKEEPER}/`);
+  client.on('error', error => {
+    log('Got a client error: %s', error);
+  });
+} else {
+  // kafka-node >= 4.0.0, they dropped Zookeeper support, client connects directly to kafka
+  client = new kafka.KafkaClient({ kafkaHost: '127.0.0.1:9092' });
+  client.on('error', error => {
+    log('Got a client error: %s', error);
+  });
+}
 
 let consumer;
-if (process.env.CONSUMER_TYPE === 'plain') {
+if (process.env.CONSUMER_TYPE === 'consumerGroup') {
+  log('Using ConsumerGroup');
+  consumer = new kafka.ConsumerGroup(
+    {
+      host: process.env.ZOOKEEPER,
+      fromOffset: 'latest',
+      groupId: uuid()
+    },
+    ['test']
+  );
+  // REMARK: kafka.HighLevelConsumer has been removed in kafka-node@4.0.0. We keep this code here in case
+  // kafka-node < 4.0.0 needs to be tested.
+  // } else if (process.env.CONSUMER_TYPE === 'highLevel') {
+  //   log('Using HighLevelConsumer');
+  //   consumer = new kafka.HighLevelConsumer(
+  //     client,
+  //     [
+  //       {
+  //         topic: 'test'
+  //       }
+  //     ],
+  //     {
+  //       fromOffset: false,
+  //       groupId: uuid()
+  //     }
+  //   );
+} else {
   log('Using Consumer');
   consumer = new kafka.Consumer(
     client,
@@ -36,30 +72,6 @@ if (process.env.CONSUMER_TYPE === 'plain') {
       fromOffset: false,
       groupId: uuid()
     }
-  );
-} else if (process.env.CONSUMER_TYPE === 'highLevel') {
-  log('Using HighLevelConsumer');
-  consumer = new kafka.HighLevelConsumer(
-    client,
-    [
-      {
-        topic: 'test'
-      }
-    ],
-    {
-      fromOffset: false,
-      groupId: uuid()
-    }
-  );
-} else {
-  log('Using ConsumerGroup');
-  consumer = new kafka.ConsumerGroup(
-    {
-      host: process.env.ZOOKEEPER,
-      fromOffset: 'latest',
-      groupId: uuid()
-    },
-    ['test']
   );
 }
 
@@ -76,7 +88,6 @@ consumer.on('error', err => {
 });
 
 consumer.on('message', function() {
-  log('Got message in Kafka consumer', arguments);
   const span = instana.currentSpan();
   span.disableAutoEnd();
   // simulating asynchronous follow up steps with setTimeout and request-promise
@@ -89,6 +100,6 @@ consumer.on('message', function() {
 
 function log() {
   const args = Array.prototype.slice.call(arguments);
-  args[0] = `Express Kafka Producer App (${process.pid}):\t${args[0]}`;
+  args[0] = `Kafka Consumer (${process.pid}):\t${args[0]}`;
   console.log.apply(console, args);
 }

--- a/packages/collector/test/tracing/messaging/kafka/producerControls.js
+++ b/packages/collector/test/tracing/messaging/kafka/producerControls.js
@@ -21,6 +21,7 @@ exports.registerTestHooks = opts => {
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.TRACING_ENABLED = opts.enableTracing !== false;
+    env.PRODUCER_TYPE = opts.producerType;
 
     app = spawn('node', [path.join(__dirname, 'producer.js')], {
       stdio: config.getAppStdio(),

--- a/packages/core/src/tracing/instrumentation/messaging/kafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafka.js
@@ -21,7 +21,14 @@ exports.init = function() {
 function instrument(kafka) {
   shimmer.wrap(Object.getPrototypeOf(kafka.Producer.prototype), 'send', shimSend);
   shimmer.wrap(kafka.Consumer.prototype, 'emit', shimEmit);
-  shimmer.wrap(kafka.HighLevelConsumer.prototype, 'emit', shimEmit);
+  if (kafka.HighLevelConsumer) {
+    // kafka-node 4.0.0 dropped the HighLevelConsumer API
+    shimmer.wrap(kafka.HighLevelConsumer.prototype, 'emit', shimEmit);
+  } else {
+    // kafka-node 4.0.0 refactored the ConsumerGroup to not longer inherit from HighLevelConsumer so it needs to be
+    // shimmed explicitly
+    shimmer.wrap(kafka.ConsumerGroup.prototype, 'emit', shimEmit);
+  }
 }
 
 function shimSend(original) {


### PR DESCRIPTION
Note: The current instrumentation has been tested with kafka-node versions
2.6.1, 3.0.1 and 4.1.3. Version 4.1.3 is used for the test suite from
now on.

Fixes #158.