### PR TITLE
basePath is deprecated. Use prefix instead.

### DIFF
--- a/packages/core/src/tracing/instrumentation/frameworks/fastify.js
+++ b/packages/core/src/tracing/instrumentation/frameworks/fastify.js
@@ -97,5 +97,5 @@ function annotateHttpEntrySpanWithPathTemplate(app, opts) {
     return;
   }
 
-  span.data.http.path_tpl = (app.basePath || '') + (opts.url || opts.path || '/');
+  span.data.http.path_tpl = (app.prefix || '') + (opts.url || opts.path || '/');
 }

--- a/packages/core/src/tracing/instrumentation/frameworks/fastify.js
+++ b/packages/core/src/tracing/instrumentation/frameworks/fastify.js
@@ -97,5 +97,7 @@ function annotateHttpEntrySpanWithPathTemplate(app, opts) {
     return;
   }
 
-  span.data.http.path_tpl = (app.prefix || '') + (opts.url || opts.path || '/');
+  const basePathDescriptor = Object.getOwnPropertyDescriptor(fastify, "basePath");
+  const basePathOrPrefix = (basePathDescriptor && basePathDescriptor.get)?app.prefix:app.basePath;
+  span.data.http.path_tpl = (basePathOrPrefix || '') + (opts.url || opts.path || '/');
 }

--- a/packages/core/src/tracing/instrumentation/frameworks/fastify.js
+++ b/packages/core/src/tracing/instrumentation/frameworks/fastify.js
@@ -97,7 +97,7 @@ function annotateHttpEntrySpanWithPathTemplate(app, opts) {
     return;
   }
 
-  const basePathDescriptor = Object.getOwnPropertyDescriptor(fastify, "basePath");
+  const basePathDescriptor = Object.getOwnPropertyDescriptor(app, "basePath");
   const basePathOrPrefix = (basePathDescriptor && basePathDescriptor.get)?app.prefix:app.basePath;
   span.data.http.path_tpl = (basePathOrPrefix || '') + (opts.url || opts.path || '/');
 }


### PR DESCRIPTION
See: https://www.fastify.io/docs/latest/Server/#prefix

Fix for:
https://github.com/instana/nodejs-sensor/issues/163