### PR TITLE
feat(tracing): avoid triggering fastify's basePath deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Avoid triggering fastify's `basePath` deprecation warning.
+
 ## 1.71.1
 - Remove overaggressive validation warning for HTTP spans.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,6 +101,10 @@
     {
       "name": "Jonathan Samines",
       "email": "jn.samines@gmail.com"
+    },
+    {
+      "name": "beep-boop-beep",
+      "url": "https://github.com/beep-boop-beep"
     }
   ],
   "license": "MIT",

--- a/packages/core/src/tracing/instrumentation/frameworks/fastify.js
+++ b/packages/core/src/tracing/instrumentation/frameworks/fastify.js
@@ -97,5 +97,7 @@ function annotateHttpEntrySpanWithPathTemplate(app, opts) {
     return;
   }
 
-  span.data.http.path_tpl = (app.basePath || '') + (opts.url || opts.path || '/');
+  var basePathDescriptor = Object.getOwnPropertyDescriptor(app, 'basePath');
+  var basePathOrPrefix = basePathDescriptor && basePathDescriptor.get ? app.prefix : app.basePath;
+  span.data.http.path_tpl = (basePathOrPrefix || '') + (opts.url || opts.path || '/');
 }


### PR DESCRIPTION
In Fastify 2.x, basePath is deprecated, so we use prefix instead.

See: https://www.fastify.io/docs/latest/Server/#prefix

At the same time, we keep supporting Fastify 1.x, which uses basePath
instead of prefix.