### PR TITLE
fix(lambda): cache target handler across invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.79.1
+- [AWS Lambda]: Cache target handler across invocations.
+
 ## 1.79.0
 - Add auto-wrap package for AWS Lambda to enable Lambda tracing without code modification.
 

--- a/packages/aws-lambda-auto-wrap/src/index.js
+++ b/packages/aws-lambda-auto-wrap/src/index.js
@@ -12,9 +12,14 @@ const TWO_DOTS = '..';
 
 const lambdaRuntimeErrors = require(`${RUNTIME_PATH}/Errors.js`);
 
-exports.handler = function instanaAutowrapHandler(event, context, callback) {
+let wrappedHandler;
+
+if (!wrappedHandler) {
   const targetHandler = loadTargetHandlerFunction();
-  const wrappedHandler = instana.wrap(targetHandler);
+  wrappedHandler = instana.wrap(targetHandler);
+}
+
+exports.handler = function instanaAutowrapHandler(event, context, callback) {
   return wrappedHandler(event, context, callback);
 };
 
@@ -39,11 +44,9 @@ function loadTargetHandlerFunction() {
   if (!targetHandlerFunction) {
     throw new lambdaRuntimeErrors.HandlerNotFound(`${targetHandlerEnvVar} is undefined or not exported`);
   }
-
   if (typeof targetHandlerFunction !== 'function') {
     throw new lambdaRuntimeErrors.HandlerNotFound(`${targetHandlerEnvVar} is not a function`);
   }
-
   return targetHandlerFunction;
 }
 

--- a/packages/aws-lambda/.gitignore
+++ b/packages/aws-lambda/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 instana-aws-lambda.tgz
+instana-aws-lambda-auto-wrap.tgz
 npm-debug*

--- a/packages/aws-lambda/lambdas/bin/deploy-demo.sh
+++ b/packages/aws-lambda/lambdas/bin/deploy-demo.sh
@@ -77,10 +77,11 @@ for lambda_zip_file in demo-*.zip ; do
         # TODO Also remove Lambda layer if zip file contained @instana/aws-lambda
       fi
     else
-      echo This lambda function definition currently has no Instana layer at all, adding it now.
+      echo This lambda function definition currently has no Instana layer at all, adding it now. I\'ll also set the auto-wrap handler.
       aws --region $REGION lambda update-function-configuration \
         --function-name $function_name \
-        --layers "$LAYER_ARN"
+        --layers "$LAYER_ARN" \
+        --handler instana-aws-lambda-auto-wrap.handler
     fi
   fi
 

--- a/packages/aws-lambda/lambdas/demo-cloudwatch-events-processor/index.js
+++ b/packages/aws-lambda/lambdas/demo-cloudwatch-events-processor/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-const instana = require('@instana/aws-lambda'); // provided by Lambda layer "instana"
-
 const pg = require('pg');
 
 const pgHost = process.env.RDS_HOSTNAME || 'localhost';
@@ -17,7 +14,7 @@ console.log(
   }`
 );
 
-exports.handler = instana.awsLambda.wrap(async event => {
+exports.handler = async event => {
   if (!event.time || typeof event.time !== 'string') {
     // malformed event, probably not triggered by a CloudWatch event
     console.log('Event has no timestamp or timestamp is not a string. Aborting.');
@@ -39,7 +36,7 @@ exports.handler = instana.awsLambda.wrap(async event => {
   } finally {
     await client.end();
   }
-});
+};
 
 async function connect() {
   const client = new pg.Client({

--- a/packages/aws-lambda/lambdas/demo-cloudwatch-events-processor/package.json
+++ b/packages/aws-lambda/lambdas/demo-cloudwatch-events-processor/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@instana/aws-lambda": "file:../../instana-aws-lambda.tgz",
+    "instana-aws-lambda-auto-wrap": "file:../../instana-aws-lambda-auto-wrap.tgz",
     "pg": "^7.12.1"
   }
 }

--- a/packages/aws-lambda/lambdas/demo-http-api/index.js
+++ b/packages/aws-lambda/lambdas/demo-http-api/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-const instana = require('@instana/aws-lambda'); // provided by Lambda layer "instana"
-
 const pg = require('pg');
 const request = require('request-promise');
 
@@ -20,7 +17,7 @@ console.log(
   }`
 );
 
-exports.handler = instana.wrap(async event => {
+exports.handler = async event => {
   if (!event.httpMethod || !event.path) {
     // malformed event, probably not an API gateway request
     return { statusCode: 400, headers: corsAllowAll() };
@@ -34,7 +31,7 @@ exports.handler = instana.wrap(async event => {
     return handleSingleItemRequest(event);
   }
   return { statusCode: 404, headers: corsAllowAll() };
-});
+};
 
 async function handleItemsRequest(event) {
   if (event.httpMethod === 'GET') {

--- a/packages/aws-lambda/lambdas/demo-http-api/package.json
+++ b/packages/aws-lambda/lambdas/demo-http-api/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@instana/aws-lambda": "file:../../instana-aws-lambda.tgz",
+    "instana-aws-lambda-auto-wrap": "file:../../instana-aws-lambda-auto-wrap.tgz",
     "pg": "^7.12.1",
     "request": "^2.88.0",
     "request-promise": "^4.2.4"

--- a/packages/aws-lambda/lambdas/demo-s3-watcher/index.js
+++ b/packages/aws-lambda/lambdas/demo-s3-watcher/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-const instana = require('@instana/aws-lambda'); // provided by Lambda layer "instana"
-
 const pg = require('pg');
 
 const pgHost = process.env.RDS_HOSTNAME || 'localhost';
@@ -17,7 +14,7 @@ console.log(
   }`
 );
 
-exports.handler = instana.wrap(async event => {
+exports.handler = async event => {
   const label = event.Records.slice(0, 20).map(
     s3Record =>
       `${s3Record.eventName}: ${s3Record.s3 && s3Record.s3.bucket ? s3Record.s3.bucket.name : ''}/${s3RecordToObject(
@@ -34,7 +31,7 @@ exports.handler = instana.wrap(async event => {
   } finally {
     await client.end();
   }
-});
+};
 
 function s3RecordToObject(s3Record) {
   if (s3Record.s3 && s3Record.s3.object && s3Record.s3.object.key) {

--- a/packages/aws-lambda/lambdas/demo-s3-watcher/package.json
+++ b/packages/aws-lambda/lambdas/demo-s3-watcher/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@instana/aws-lambda": "file:../../instana-aws-lambda.tgz",
+    "instana-aws-lambda-auto-wrap": "file:../../instana-aws-lambda-auto-wrap.tgz",
     "pg": "^7.12.1"
   }
 }

--- a/packages/aws-lambda/lambdas/demo-trigger/index.js
+++ b/packages/aws-lambda/lambdas/demo-trigger/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-const instana = require('@instana/aws-lambda'); // provided by Lambda layer "instana"
-
 const async_ = require('async');
 const request = require('request-promise');
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -12,7 +9,7 @@ const uuid = require('uuid/v4');
 const bucket = process.env.BUCKET_NAME || 'instana-lambda-demo';
 const apiUrl = process.env.API_URL || 'https://wn69a84ebf.execute-api.us-east-2.amazonaws.com/default';
 
-exports.handler = instana.wrap((event, context, callback) => {
+exports.handler = (event, context, callback) => {
   console.log('Triggering API request.');
   triggerHttpRequest().finally(() => {
     async_.waterfall(
@@ -69,7 +66,7 @@ exports.handler = instana.wrap((event, context, callback) => {
       }
     );
   });
-});
+};
 
 function triggerHttpRequest() {
   let method;

--- a/packages/aws-lambda/lambdas/demo-trigger/package.json
+++ b/packages/aws-lambda/lambdas/demo-trigger/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@instana/aws-lambda": "file:../../instana-aws-lambda.tgz",
+    "instana-aws-lambda-auto-wrap": "file:../../instana-aws-lambda-auto-wrap.tgz",
     "async": "^3.1.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -186,10 +186,10 @@ function postHandler(entrySpan, error, result, callback) {
     if (err) {
       // We intentionally do not propagate the error from the backend request - the customer's lambda needs to finish
       // successfully, no matter if we have been able to report metrics and spans.
-      logger.warn('Could not send data to backend.', err.message);
-      logger.debug('Could not send data to backend.', err);
+      logger.warn('Could not send traces and metrics to Instana.', err.message);
+      logger.debug('Could not send traces and metrics to Instana.', err);
     } else {
-      logger.info('Data has been sent to backend.');
+      logger.info('Traces and metrics have been sent to Instana.');
     }
     callback();
   });


### PR DESCRIPTION
Also:
- remove manual wrap from demo lambdas
- require target handler outside of auto-wrap handler function