### PR TITLE
fix(tracing): use query._callback for ending a mysql call if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Trace MySql pool cluster calls.
+
 ## 1.82.0
 - Capture synchronous errors in Lambda functions.
 - Handle ARN correctly when a Lambda function is called via an alias.

--- a/packages/collector/test/tracing/database/mysql/controls.js
+++ b/packages/collector/test/tracing/database/mysql/controls.js
@@ -23,12 +23,7 @@ exports.registerTestHooks = opts => {
     env.UPSTREAM_PORT = upstreamPort;
     env.STACK_TRACE_LENGTH = opts.stackTraceLength || 0;
     env.TRACING_ENABLED = opts.enableTracing !== false;
-    if (opts.useMysql2) {
-      env.MYSQL_2_DRIVER = true;
-    }
-    if (opts.useMysql2WithPromises) {
-      env.MYSQL_2_WITH_PROMISES = true;
-    }
+    env.DRIVER_MODE = opts.driverMode;
     if (opts.useExecute) {
       env.USE_EXECUTE = true;
     }


### PR DESCRIPTION
Fixes tracing for queries made via PoolCluster.