### PR TITLE
fix(tracing): capture spans for HTTP entries that time out client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Also capture incoming HTTP calls that time out on the client side or are aborted on the server side (via `req.destroy()`).
+
 ## 1.84.0
 - Add support for the [log4js](https://www.npmjs.com/package/log4js) logging package.
 - [AWS Lambda]: Instrument deprecated legacy Lambda API (context.done, context.succeed, and context.fail).

--- a/packages/collector/test/tracing/AbstractControls.js
+++ b/packages/collector/test/tracing/AbstractControls.js
@@ -92,22 +92,15 @@ AbstractControls.prototype.getPid = function getPid() {
 };
 
 AbstractControls.prototype.sendRequest = function(opts) {
-  const headers = opts.headers || {};
   if (opts.suppressTracing === true) {
-    headers['X-INSTANA-L'] = '0';
+    opts.headers = opts.headers || {};
+    opts.headers['X-INSTANA-L'] = '0';
   }
 
-  return request({
-    method: opts.method,
-    url: this.baseUrl + opts.path,
-    json: true,
-    body: opts.body,
-    headers,
-    qs: opts.qs,
-    simple: opts.simple,
-    resolveWithFullResponse: opts.resolveWithFullResponse,
-    strictSSL: false
-  });
+  opts.url = this.baseUrl + opts.path;
+  opts.json = true;
+  opts.strictSSL = false;
+  return request(opts);
 };
 
 AbstractControls.prototype.sendViaIpc = function(message) {

--- a/packages/collector/test/tracing/messaging/kafkajs/test.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/test.js
@@ -80,7 +80,7 @@ describe('tracing/kafkajs', function() {
               error,
               useSendBatch,
               useEachBatch,
-              suppress: true
+              suppressTracing: true
             }).then(() =>
               utils.retry(() =>
                 getMessages(consumerControls)
@@ -139,11 +139,12 @@ describe('tracing/kafkajs', function() {
   });
 
   // eslint-disable-next-line object-curly-newline
-  function send({ key, value, error, useSendBatch, useEachBatch, suppress }) {
+  function send({ key, value, error, useSendBatch, useEachBatch, suppressTracing }) {
     const req = {
       method: 'POST',
       path: '/send-messages',
       simple: true,
+      suppressTracing,
       body: {
         key,
         value,
@@ -152,11 +153,6 @@ describe('tracing/kafkajs', function() {
         useEachBatch
       }
     };
-    if (suppress) {
-      req.headers = {
-        'X-INSTANA-L': '0'
-      };
-    }
     return producerControls.sendRequest(req);
   }
 


### PR DESCRIPTION
Create entry spans for incoming HTTP requests that
a) time out on the client side, or
b) are aborted on the server side (via req.destroy()).