### PR TITLE
fix(tracing): do not remove tags from lower priority spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Do not remove tags from lower priority spans when changing the span type (e.g. http -> graphql)
+
 ## 1.92.1
 - Fix mongodb tracing for outdated versions of the mongodb package.
 

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -252,10 +252,6 @@ InstanaSpan.prototype.disableAutoEnd = function disableAutoEnd() {
   this.manualEndMode = true;
 };
 
-InstanaSpan.prototype.resetData = function resetData() {
-  this.data = this.data && this.data.service != null ? { service: this.data.service } : {};
-};
-
 function call(fn) {
   fn();
 }

--- a/packages/core/src/tracing/instrumentation/protocols/graphql.js
+++ b/packages/core/src/tracing/instrumentation/protocols/graphql.js
@@ -121,7 +121,6 @@ function traceQueryOrMutation(
     // entry span still have the the correct parent span ID.
     span = activeEntrySpan;
     span.n = 'graphql.server';
-    span.resetData();
   }
 
   return cls.ns.runAndReturn(function() {


### PR DESCRIPTION
E.g. keep http (or amqp) tags when overwriting an http (amqp) span with
a graphql span.