### PR TITLE
fix(lambda): stop sending to back end when a request has already failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- [AWS Lambda] Do not try to send data to the Instana back end when a previous request to it has already failed.
+- [AWS Lambda] Change span offloading intervall to 5 seconds.
+- [AWS Lambda] Make sure that an uninstrumented https connection is used for span offloading.
+
 ## 1.92.3
 - Always capture duration of GraphQL calls.
 - Support `INSTANA_DEBUG` in native serverless tracing.

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -198,6 +198,17 @@ function init(event, arnInfo, _config) {
   } else if (process.env.INSTANA_DEBUG || config.level || process.env.INSTANA_LOG_LEVEL) {
     logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : config.level || process.env.INSTANA_LOG_LEVEL);
   }
+
+  // @instana/collector sends span data every second. To reduce HTTP overhead, in particular for long running Lambdas,
+  // we throttle this back to once every 5 seconds. We guarantee to send everything (metrics and all remaining spans)
+  // with POST /bundle after the Lambda handler has finished.
+  if (!config.tracing) {
+    config.tracing = {};
+  }
+  if (config.tracing.transmissionDelay == null) {
+    config.tracing.transmissionDelay = 5000;
+  }
+
   identityProvider.init(arnInfo);
   backendConnector.init(identityProvider, logger);
 

--- a/packages/aws-lambda/test/integration_test.js
+++ b/packages/aws-lambda/test/integration_test.js
@@ -94,7 +94,7 @@ function registerTests(handlerDefinitionPath) {
   describe('when everything is peachy', function() {
     // - INSTANA_ENDPOINT_URL is configured
     // - INSTANA_AGENT_KEY is configured
-    // - backend is reachable
+    // - back end is reachable
     // - lambda function ends with success
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -110,7 +110,7 @@ function registerTests(handlerDefinitionPath) {
     // - function is called with alias
     // - INSTANA_ENDPOINT_URL is configured
     // - INSTANA_AGENT_KEY is configured
-    // - backend is reachable
+    // - back end is reachable
     // - lambda function ends with success
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -126,7 +126,7 @@ function registerTests(handlerDefinitionPath) {
   describe('when deprecated env var keys are used', function() {
     // - INSTANA_URL is configured (instead of INSTANA_ENDPOINT_URL)
     // - INSTANA_KEY is configured (instead of INSTANA_AGENT_KEY)
-    // - backend is reachable
+    // - back end is reachable
     // - lambda function ends with success
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -140,7 +140,7 @@ function registerTests(handlerDefinitionPath) {
 
   describe('when lambda function yields an error', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable
+    // - back end is reachable
     // - lambda function ends with an error
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -155,7 +155,7 @@ function registerTests(handlerDefinitionPath) {
 
   describe('when lambda function throws a synchronous error', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable
+    // - back end is reachable
     // - lambda function ends with an error
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -170,7 +170,7 @@ function registerTests(handlerDefinitionPath) {
 
   describe('with config', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable
+    // - back end is reachable
     // - client provides a config object
     // - lambda function ends with success
     const control = prelude.bind(this)({
@@ -186,7 +186,7 @@ function registerTests(handlerDefinitionPath) {
 
   describe('with config, when lambda function yields an error', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable
+    // - back end is reachable
     // - client provides a config object
     // - lambda function ends with an error
     const control = prelude.bind(this)({
@@ -265,9 +265,9 @@ function registerTests(handlerDefinitionPath) {
       verify(control, { error: 'lambda-asynchronous', expectMetrics: false, expectSpans: false }));
   });
 
-  describe('when backend is down', function() {
+  describe('when the back end is down', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is not reachable
+    // - back end is not reachable
     // - lambda function ends with success
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -280,9 +280,9 @@ function registerTests(handlerDefinitionPath) {
       verify(control, { error: false, expectMetrics: false, expectSpans: false }));
   });
 
-  describe('when backend is down and the lambda function yields an error', function() {
+  describe('when the back end is down and the lambda function yields an error', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is not reachable
+    // - back end is not reachable
     // - lambda function ends with an error
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -296,9 +296,9 @@ function registerTests(handlerDefinitionPath) {
       verify(control, { error: 'lambda-asynchronous', expectMetrics: false, expectSpans: false }));
   });
 
-  describe('when backend is reachable but does not respond', function() {
+  describe('when the back end is reachable but does not respond', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable, but will never respond (verifies that a reasonable timeout is applied -
+    // - back end is reachable, but will never respond (verifies that a reasonable timeout is applied -
     //   the default timeout would be two minutes)
     // - lambda function ends with success
     const control = prelude.bind(this)({

--- a/packages/aws-lambda/test/long_running/lambda.js
+++ b/packages/aws-lambda/test/long_running/lambda.js
@@ -1,0 +1,32 @@
+/* eslint-disable indent, import/order, no-console, no-await-in-loop */
+
+'use strict';
+
+const instana = require('../..');
+
+const delay = require('../../../core/test/test_util/delay');
+
+const DELAY = process.env.DELAY || 1000;
+const ITERATIONS = process.env.ITERATIONS || 10;
+
+// In production, the package @instana/aws-lambda is located in
+// /var/task/node_modules/@instana/aws-lambda/src/metrics while the main package.json of the Lambda is in
+// /var/task/package.json. The assumption about the relative location does not hold in the tests, so we need to fix the
+// assumed root dir of the Lambda.
+require('../../src/metrics/rootDir').root = require('path').resolve(__dirname, '..', '..');
+
+exports.handler = instana.wrap(async () => {
+  console.log('in actual handler');
+
+  for (let i = 0; i < ITERATIONS; i++) {
+    await instana.sdk.async.startExitSpan('custom-span');
+    await delay(DELAY);
+    instana.sdk.async.completeExitSpan();
+  }
+
+  return {
+    body: {
+      message: 'Stan says hi!'
+    }
+  };
+});

--- a/packages/aws-lambda/test/long_running/test.js
+++ b/packages/aws-lambda/test/long_running/test.js
@@ -1,0 +1,250 @@
+/* eslint-env mocha */
+
+'use strict';
+
+const { inspect } = require('util');
+const { expect } = require('chai');
+const path = require('path');
+const semver = require('semver');
+const constants = require('@instana/core').tracing.constants;
+
+const config = require('../../../serverless/test/config');
+const expectOneMatching = require('../../../serverless/test/util/expect_matching');
+
+const functionName = 'functionName';
+const unqualifiedArn = `arn:aws:lambda:us-east-2:410797082306:function:${functionName}`;
+const version = '$LATEST';
+const qualifiedArn = `${unqualifiedArn}:${version}`;
+
+function prelude(opts) {
+  // The lambda under test creates an SDK span every ${opts.delay} milliseconds.
+  opts.delay = opts.delay || 1000;
+  // The lambda under test does this ${opts.iterations} times, then terminates.
+  opts.iterations = opts.iterations || 10;
+  opts.expectedLambdaRuntime = opts.delay * opts.iterations * 1.1;
+  const timeout = Math.max(opts.expectedLambdaRuntime * 2, config.getTestTimeout());
+  this.timeout(timeout);
+  this.slow(timeout * 0.8);
+
+  if (opts.startBackend == null) {
+    opts.startBackend = true;
+  }
+
+  const env = {
+    DELAY: opts.delay,
+    ITERATIONS: opts.iterations
+  };
+  if (opts.instanaEndpointUrl) {
+    env.INSTANA_ENDPOINT_URL = opts.instanaEndpointUrl;
+  }
+  if (opts.instanaAgentKey) {
+    env.INSTANA_AGENT_KEY = opts.instanaAgentKey;
+  }
+  if (opts.withConfig) {
+    env.WITH_CONFIG = 'true';
+  }
+
+  const Control = require('../../../serverless/test/util/control');
+  const control = new Control({
+    faasRuntimePath: path.join(__dirname, '../runtime_mock'),
+    handlerDefinitionPath: opts.handlerDefinitionPath,
+    startBackend: opts.startBackend,
+    env,
+    timeout
+  });
+  control.registerTestHooks();
+  return control;
+}
+
+describe('long running lambdas', () => {
+  const handlerDefinitionPath = path.join(__dirname, './lambda');
+
+  describe('when the back end is responsive', function() {
+    const opts = {
+      handlerDefinitionPath,
+      instanaEndpointUrl: config.backendBaseUrl,
+      instanaAgentKey: config.instanaAgentKey,
+      delay: 1000,
+      iterations: 15
+    };
+    const control = prelude.bind(this)(opts);
+
+    it('must capture metrics and spans', () => {
+      verifyResponse(control);
+      const duration = Date.now() - control.startedAt;
+      expect(duration).to.be.at.most(opts.expectedLambdaRuntime);
+      return Promise.all([
+        //
+        control.getSpans(),
+        control.getMetrics(),
+        control.getRawBundles(),
+        control.getRawSpanArrays()
+      ]).then(([spans, metrics, rawBundles, rawSpanArrays]) => {
+        verifySpans(spans, opts);
+        verifyMetrics(metrics);
+        // The lambda runs 15 seconds and creates a span every second. We also send spans to serverless acceptor
+        // every 5 seconds + the final bundle. Thus, we should see two intermittent POST requests to /traces and
+        // one to /bundle.
+        expect(rawSpanArrays).to.be.an('array');
+        expect(rawSpanArrays).to.have.lengthOf(2);
+        expect(rawBundles).to.be.an('array');
+        expect(rawBundles).to.have.lengthOf(1);
+      });
+    });
+  });
+
+  describe('when the back end is down', function() {
+    const opts = {
+      handlerDefinitionPath,
+      instanaEndpointUrl: config.backendBaseUrl,
+      instanaAgentKey: config.instanaAgentKey,
+      startBackend: false,
+      // Run for 70 seconds, create a span every 250 ms.
+      delay: 250,
+      iterations: 280
+    };
+    const control = prelude.bind(this)(opts);
+
+    it('must ignore the failed requests gracefully', () => {
+      verifyResponse(control);
+      const duration = Date.now() - control.startedAt;
+      expect(duration).to.be.at.most(opts.expectedLambdaRuntime);
+    });
+  });
+
+  describe('when the back end is reachable but does not respond', function() {
+    const opts = {
+      handlerDefinitionPath,
+      instanaEndpointUrl: config.backendBaseUrl,
+      instanaAgentKey: config.instanaAgentKey,
+      startBackend: 'unresponsive',
+      // run for 30 seconds, create a span every second
+      delay: 1000,
+      iterations: 30
+    };
+    const control = prelude.bind(this)(opts);
+
+    it('must stop trying after first timed out request', () => {
+      verifyResponse(control);
+      const duration = Date.now() - control.startedAt;
+      expect(duration).to.be.at.most(opts.expectedLambdaRuntime);
+      return Promise.all([
+        //
+        control.getSpans(),
+        control.getMetrics(),
+        control.getRawBundles(),
+        control.getRawSpanArrays(),
+        control.getRawMetrics()
+      ]).then(([spans, metrics, rawBundles, rawSpanArrays, rawMetrics]) => {
+        expect(spans).to.have.lengthOf(0);
+        expect(metrics).to.have.lengthOf(0);
+
+        // The first POST /spans (after 5 seconds) fails...
+        expect(rawSpanArrays).to.have.lengthOf(1);
+        // ...and we expect @instana/aws-lambda to stop sending spans after that. In particular, we expect the
+        // POST /bundle at the end to not happen.
+        expect(rawBundles).to.have.lengthOf(0);
+
+        // @instana/aws-lambda never sends metrics while running, it only reports them at the end together with the
+        // bundle.
+        expect(rawMetrics).to.have.lengthOf(0);
+      });
+    });
+  });
+
+  function verifyResponse(control) {
+    /* eslint-disable no-console */
+    if (control.getLambdaErrors() && control.getLambdaErrors().length > 0) {
+      console.log('Unexpected Errors:');
+      console.log(JSON.stringify(control.getLambdaErrors()));
+    }
+    expect(control.getLambdaErrors()).to.be.empty;
+    expect(control.getLambdaResults().length).to.equal(1);
+    const result = control.getLambdaResults()[0];
+    expect(result).to.exist;
+    const body = result.body;
+    expect(body.message).to.equal('Stan says hi!');
+  }
+
+  function verifySpans(spans, opts) {
+    verifyLambdaEntry(spans);
+    verifyNoHttpExits(spans);
+    verifySdkExits(spans, opts);
+  }
+
+  function verifyLambdaEntry(spans) {
+    return expectOneMatching(spans, span => {
+      expect(span.t).to.exist;
+      expect(span.p).to.not.exist;
+      expect(span.s).to.exist;
+      expect(span.n).to.equal('aws.lambda.entry');
+      expect(span.k).to.equal(constants.ENTRY);
+      expect(span.f).to.be.an('object');
+      expect(span.f.h).to.not.exist;
+      expect(span.f.hl).to.be.true;
+      expect(span.f.cp).to.equal('aws');
+      expect(span.f.e).to.equal(qualifiedArn);
+      expect(span.async).to.equal(false);
+      expect(span.data.lambda).to.be.an('object');
+      expect(span.data.lambda.runtime).to.equal('nodejs');
+      expect(span.data.lambda.error).to.not.exist;
+      expect(span.error).to.be.false;
+      expect(span.ec).to.equal(0);
+    });
+  }
+  /**
+   * Verify that our http requests to the back end (for offloading bundles, spans, metrics) are not
+   * accidentally traced, that is, we use an uninstrumented copy of the https module for those requests.
+   */
+  function verifyNoHttpExits(spans) {
+    /* eslint-disable no-console */
+    if (semver.lt(process.versions.node, '9.0.0')) {
+      // In Node.js 8.x.x, the https module uses the http module internally. This means even if we use the
+      // uninstrumented copy of the https module, we have no way of forcing it to use the uninstrumented copy of the
+      // http module internally. Since the Node.js 8 runtime for AWS Lambda has been deprecated quite a while ago, this
+      // is deemed acceptable. The only negative consequence of this shortcoming is that http requests to the Instana
+      // back end might show up in Lambda traces when the Lambda uses Node.js 8.
+      return;
+    }
+    const httpExits = spans.filter(span => span.n === 'node.http.client');
+    if (httpExits.length > 0) {
+      console.log('Unexpected node.http.client spans:');
+      console.log(inspect(httpExits, { depth: null }));
+    }
+    expect(httpExits).to.have.lengthOf(0);
+  }
+
+  function verifySdkExits(spans, opts) {
+    const sdkExits = spans.filter(
+      span =>
+        span.n === 'sdk' && //
+        span.k === 2 &&
+        span.data.sdk.name === 'custom-span' &&
+        span.data.sdk.type === 'exit'
+    );
+    expect(sdkExits).to.have.lengthOf(opts.iterations);
+  }
+
+  function verifyMetrics(allMetrics) {
+    expect(allMetrics).to.exist;
+    expect(Array.isArray(allMetrics)).to.be.true;
+    expect(allMetrics).to.have.lengthOf(1);
+    const allPlugins = allMetrics[0];
+    expect(allPlugins.plugins).to.have.lengthOf(1);
+    const pluginData = allPlugins.plugins[0];
+    expect(pluginData.data).to.exist;
+    expect(pluginData.name).to.equal('com.instana.plugin.aws.lambda');
+    expect(pluginData.entityId).to.equal(qualifiedArn);
+    const metrics = pluginData.data;
+    expect(metrics.sensorVersion).to.match(/1\.\d\d+\.\d+/);
+    expect(metrics.startTime).to.be.at.most(Date.now());
+    expect(metrics.versions).to.be.an('object');
+    expect(metrics.versions.node).to.match(/\d+\.\d+\.\d+/);
+    expect(metrics.versions.v8).to.match(/\d+\.\d+\.\d+/);
+    expect(metrics.versions.uv).to.match(/\d+\.\d+\.\d+/);
+    expect(metrics.versions.zlib).to.match(/\d+\.\d+\.\d+/);
+    expect(metrics.npmPackageDescription).to.equal('Instana tracing and monitoring for Node.js based AWS Lambdas');
+    expect(metrics.npmPackageName).to.equal('@instana/aws-lambda');
+    expect(metrics.npmPackageVersion).to.match(/\d+\.\d+\.\d+/);
+  }
+});

--- a/packages/aws-lambda/test/using_api/test.js
+++ b/packages/aws-lambda/test/using_api/test.js
@@ -51,7 +51,7 @@ describe('Using the API', () => {
   describe('when everything is peachy', function() {
     // - INSTANA_ENDPOINT_URL is configured
     // - INSTANA_AGENT_KEY is configured
-    // - backend is reachable
+    // - back end is reachable
     // - lambda function ends with success
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -64,7 +64,7 @@ describe('Using the API', () => {
 
   describe('when lambda function yields an error', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable
+    // - back end is reachable
     // - lambda function ends with an error
     const control = prelude.bind(this)({
       handlerDefinitionPath,
@@ -78,7 +78,7 @@ describe('Using the API', () => {
 
   describe('with config', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable
+    // - back end is reachable
     // - client provides a config object
     // - lambda function ends with success
     const control = prelude.bind(this)({
@@ -93,7 +93,7 @@ describe('Using the API', () => {
 
   describe('with config, when lambda function yields an error', function() {
     // - INSTANA_ENDPOINT_URL is configured
-    // - backend is reachable
+    // - back end is reachable
     // - client provides a config object
     // - lambda function ends with an error
     const control = prelude.bind(this)({

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -20,7 +20,8 @@ if (process.env.INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS != null) {
 } else {
   minDelayBeforeSendingSpans = 1000;
 }
-var initialDelayBeforeSendingSpans = Math.max(minDelayBeforeSendingSpans, 1000);
+var initialDelayBeforeSendingSpans;
+var transmissionDelay;
 var maxBufferedSpans;
 var forceTransmissionStartingAt;
 
@@ -32,6 +33,8 @@ exports.init = function(config, _downstreamConnection) {
   downstreamConnection = _downstreamConnection;
   maxBufferedSpans = config.tracing.maxBufferedSpans;
   forceTransmissionStartingAt = config.tracing.forceTransmissionStartingAt;
+  transmissionDelay = config.tracing.transmissionDelay;
+  initialDelayBeforeSendingSpans = Math.max(transmissionDelay, minDelayBeforeSendingSpans);
 };
 
 exports.activate = function() {
@@ -84,7 +87,7 @@ function transmitSpans() {
   clearTimeout(transmissionTimeoutHandle);
 
   if (spans.length === 0) {
-    transmissionTimeoutHandle = setTimeout(transmitSpans, 1000);
+    transmissionTimeoutHandle = setTimeout(transmitSpans, transmissionDelay);
     transmissionTimeoutHandle.unref();
     return;
   }
@@ -99,7 +102,7 @@ function transmitSpans() {
       removeSpansIfNecessary();
     }
 
-    transmissionTimeoutHandle = setTimeout(transmitSpans, 1000);
+    transmissionTimeoutHandle = setTimeout(transmitSpans, transmissionDelay);
     transmissionTimeoutHandle.unref();
   });
 }

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -20,6 +20,7 @@ var defaults = {
     automaticTracingEnabled: true,
     forceTransmissionStartingAt: 500,
     maxBufferedSpans: 1000,
+    transmissionDelay: 1000,
     http: {
       extraHttpHeadersToCapture: []
     },
@@ -142,6 +143,7 @@ function normalizeAutomaticTracingEnabled(config) {
 
 function normalizeTracingTransmission(config) {
   config.tracing.maxBufferedSpans = config.tracing.maxBufferedSpans || defaults.tracing.maxBufferedSpans;
+  config.tracing.transmissionDelay = config.tracing.transmissionDelay || defaults.tracing.transmissionDelay;
 
   var originalValue = config.tracing.forceTransmissionStartingAt;
   if (

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -110,11 +110,13 @@ describe('util.normalizeConfig', () => {
     const config = normalizeConfig({
       tracing: {
         maxBufferedSpans: 13,
-        forceTransmissionStartingAt: 2
+        forceTransmissionStartingAt: 2,
+        transmissionDelay: 9753
       }
     });
     expect(config.tracing.maxBufferedSpans).to.equal(13);
     expect(config.tracing.forceTransmissionStartingAt).to.equal(2);
+    expect(config.tracing.transmissionDelay).to.equal(9753);
   });
 
   it('should use extra http headers (and normalize to lower case)', () => {
@@ -244,6 +246,7 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.enabled).to.be.true;
     expect(config.tracing.automaticTracingEnabled).to.be.true;
     expect(config.tracing.disableAutomaticTracing).to.not.exist;
+    expect(config.tracing.transmissionDelay).to.equal(1000);
     expect(config.tracing.forceTransmissionStartingAt).to.equal(500);
     expect(config.tracing.maxBufferedSpans).to.equal(1000);
     expect(config.tracing.disabledTracers).to.deep.equal([]);

--- a/packages/serverless/bin/prepare-audit.sh
+++ b/packages/serverless/bin/prepare-audit.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cd `dirname $BASH_SOURCE`/..
+source ../../bin/add-to-package-lock
+addToPackageLock package-lock.json @instana/core false

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/instana/nodejs-sensor.git"
   },
   "scripts": {
-    "audit": "npm audit --production",
+    "audit": "bin/prepare-audit.sh && npm audit --production; AUDIT_RESULT=$?; git checkout package-lock.json; exit $AUDIT_RESULT",
     "test": "npm run test:mocha",
     "test:mocha": "mocha --reporter spec $(find test -iname '*test.js')",
     "test:debug": "WITH_STDOUT=true npm run test:mocha",
@@ -56,6 +56,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@instana/core": "^1.92.3",
     "semver": "^5.6.0"
   },
   "devDependencies": {

--- a/packages/serverless/test/backend_stub/index.js
+++ b/packages/serverless/test/backend_stub/index.js
@@ -40,6 +40,7 @@ app.use(
 
 app.post('/serverless/bundle', (req, res) => {
   logger.trace('incoming bundle', req.body);
+  receivedData.rawBundles.push(req.body);
   if (unresponsive) {
     // intentionally not responding for tests that verify proper timeout handling
     return;
@@ -68,6 +69,7 @@ app.post('/serverless/bundle', (req, res) => {
 
 app.post('/serverless/metrics', (req, res) => {
   logger.debug('incoming metrics', req.body);
+  receivedData.rawMetrics.push(req.body);
   if (unresponsive) {
     // intentionally not responding for tests that verify proper timeout handling
     return;
@@ -86,6 +88,7 @@ app.post('/serverless/metrics', (req, res) => {
 
 app.post('/serverless/traces', (req, res) => {
   logger.debug('incoming spans', req.body);
+  receivedData.rawSpanArrays.push(req.body);
   if (unresponsive) {
     // intentionally not responding for tests that verify proper timeout handling
     return;
@@ -120,6 +123,27 @@ app.delete('/serverless/received/spans', (req, res) => {
   return res.sendStatus('204');
 });
 
+app.get('/serverless/received/raw/bundles', (req, res) => res.json(receivedData.rawBundles));
+
+app.delete('/serverless/received/raw/bundles', (req, res) => {
+  receivedData.rawBundles = [];
+  return res.sendStatus('204');
+});
+
+app.get('/serverless/received/raw/metrics', (req, res) => res.json(receivedData.rawMetrics));
+
+app.delete('/serverless/received/raw/metrics', (req, res) => {
+  receivedData.rawMetrics = [];
+  return res.sendStatus('204');
+});
+
+app.get('/serverless/received/raw/spanArrays', (req, res) => res.json(receivedData.rawSpanArrays));
+
+app.delete('/serverless/received/raw/spanArrays', (req, res) => {
+  receivedData.rawSpanArrays = [];
+  return res.sendStatus('204');
+});
+
 https.createServer(options, app).listen(port, error => {
   if (error) {
     logger.error(error);
@@ -144,6 +168,9 @@ function addHeaders(req, payload) {
 function resetReceivedData() {
   return {
     metrics: [],
-    spans: []
+    spans: [],
+    rawBundles: [],
+    rawMetrics: [],
+    rawSpanArrays: []
   };
 }


### PR DESCRIPTION
Do not try to send data to the Instana back end when a previous request
to it has already failed. Also, only send spans every 5 seconds and
make sure we use an uninstrumented https connection to send data.