### PR TITLE
chore(*): remove obsolete config option for expected Server header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Remove deprecated span attributes `span.error` and `span.async`.
+- Remove obsolete configuration option `config.agentName`/`INSTANA_AGENT_NAME`.
 
 ## 1.92.4
 - [AWS Lambda] Do not try to send data to the Instana back end when a previous request to it has already failed.

--- a/packages/collector/src/agent/opts.js
+++ b/packages/collector/src/agent/opts.js
@@ -4,11 +4,9 @@
 exports.requestTimeout = 5000;
 exports.host = '127.0.0.1';
 exports.port = 42699;
-exports.serverHeader = 'Instana Agent';
 exports.agentUuid = undefined;
 
 exports.init = function init(config) {
   exports.host = config.agentHost;
   exports.port = config.agentPort;
-  exports.serverHeader = config.agentName;
 };

--- a/packages/collector/src/announceCycle/agentHostLookup.js
+++ b/packages/collector/src/announceCycle/agentHostLookup.js
@@ -6,6 +6,8 @@ var http = require('@instana/core').uninstrumentedHttp.http;
 
 var agentOpts = require('../agent/opts');
 
+var EXPECTED_SERVER_HEADER = 'Instana Agent';
+
 var logger;
 logger = require('../logger').getLogger('announceCycle/agentHostLookup', function(newLogger) {
   logger = newLogger;
@@ -103,7 +105,7 @@ function checkHost(host, cb) {
         method: 'GET'
       },
       function(res) {
-        if (res.headers.server === agentOpts.serverHeader) {
+        if (res.headers.server === EXPECTED_SERVER_HEADER) {
           cb(null);
         } else {
           cb(new Error('Host ' + host + ' did not respond with expected agent header. Got: ' + res.headers.server));

--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -5,7 +5,6 @@
 var defaults = {
   agentHost: '127.0.0.1',
   agentPort: 42699,
-  agentName: 'Instana Agent',
   tracing: {
     stackTraceLength: 10
   }
@@ -19,7 +18,6 @@ module.exports = exports = function normalizeConfig(config) {
 
   config.agentHost = config.agentHost || process.env.INSTANA_AGENT_HOST || defaults.agentHost;
   config.agentPort = config.agentPort || parseToPositiveInteger(process.env.INSTANA_AGENT_PORT, defaults.agentPort);
-  config.agentName = config.agentName || process.env.INSTANA_AGENT_NAME || defaults.agentName;
 
   normalizeConfigForUncaughtExceptions(config);
 

--- a/packages/collector/test/util/normalizeConfig_test.js
+++ b/packages/collector/test/util/normalizeConfig_test.js
@@ -14,7 +14,6 @@ describe('util.normalizeConfig', () => {
   function resetEnv() {
     delete process.env['INSTANA_AGENT_HOST'];
     delete process.env['INSTANA_AGENT_PORT'];
-    delete process.env['INSTANA_AGENT_NAME'];
   }
 
   it('should apply all defaults', () => {
@@ -26,23 +25,19 @@ describe('util.normalizeConfig', () => {
   it('should accept custom agent connection configuration', () => {
     const config = normalizeConfig({
       agentHost: 'LOKAL_HORST',
-      agentPort: 1207,
-      agentName: 'Joe'
+      agentPort: 1207
     });
     expect(config.agentHost).to.equal('LOKAL_HORST');
     expect(config.agentPort).to.equal(1207);
-    expect(config.agentName).to.equal('Joe');
   });
 
   it('should accept custom agent connection configuration from environment', () => {
     process.env['INSTANA_AGENT_HOST'] = 'yadayada';
     process.env['INSTANA_AGENT_PORT'] = '1357';
-    process.env['INSTANA_AGENT_NAME'] = 'Cthulhu';
     const config = normalizeConfig();
     expect(config.agentHost).to.equal('yadayada');
     expect(config.agentPort).to.equal(1357);
     expect(config.agentPort).to.be.a('number');
-    expect(config.agentName).to.equal('Cthulhu');
   });
 
   it('should custom stack trace length', () => {
@@ -83,7 +78,6 @@ describe('util.normalizeConfig', () => {
     expect(config).to.be.an('object');
     expect(config.agentHost).to.equal('127.0.0.1');
     expect(config.agentPort).to.equal(42699);
-    expect(config.agentName).to.equal('Instana Agent');
     expect(config.tracing).to.be.an('object');
     expect(config.tracing.stackTraceLength).to.equal(10);
     expect(config.reportUncaughtException).to.be.false;


### PR DESCRIPTION
- remove config.agentName
- do not read env var INSTANA_AGENT_NAME