### PR TITLE
fix(lambda): add a connection timeout in addition to read timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- [AWS Lambda] Fix: Add a connection timeout in addition to the read/idle timeout.
+
 ## 1.95.1
 - Capture the error message and/or stack trace when completing and SDK span with an error.
 

--- a/packages/aws-lambda/lambdas/bin/create-zips.sh
+++ b/packages/aws-lambda/lambdas/bin/create-zips.sh
@@ -18,6 +18,8 @@ rm -rf instana-aws-lambda*.tgz
 # Note: ${BUILD_LAMBDAS_WITH-xyz} -> default expansion with default xyz, to avoid bash error "unbound variable"
 # when set -u is active.
 
+echo Building all local tar.gz files.
+
 if [[ -z "${BUILD_LAMBDAS_WITH-}" ]]; then
   echo "Environmant variable BUILD_LAMBDAS_WITH has not been provided, assuming \"npm\" (build with latest npm package)."
 fi
@@ -43,11 +45,11 @@ mv instana-aws-lambda-auto-wrap*.tgz ../aws-lambda/instana-aws-lambda-auto-wrap.
 cd ../aws-lambda
 
 if [[ "${BUILD_LAMBDAS_WITH-npm}" == "npm" ]]; then
-  echo "Building all Lambda zips with the latest npm packages."
+  echo "Building Lambda zip file(s) with the latest npm packages."
 elif [[ "${BUILD_LAMBDAS_WITH-}" == "local" ]]; then
-  echo "Building all Lambda zips with the local tar.gz files."
+  echo "Building Lambda zip file(s) with the local tar.gz files."
 elif [[ "$BUILD_LAMBDAS_WITH" == "layer" ]]; then
-  echo "Building all Lambda zips without @instana/aws-lambda, assuming the AWS Lambda layer \"instana\" is (or will be) configured."
+  echo "Building Lambda zip file(s) without @instana/aws-lambda, assuming the AWS Lambda layer \"instana-nodejs\" is (or will be) configured."
 else
   echo "Unknown option for BUILD_LAMBDAS_WITH: $BUILD_LAMBDAS_WITH"
   echo Aborting.
@@ -56,12 +58,23 @@ fi
 
 popd > /dev/null
 
-for lambda_directory in */ ; do
+if [[ -z $1 ]]; then
+  echo Creating *all* zip files.
+  echo
+  for lambda_directory in */ ; do
+    if [[ -d "$lambda_directory" && ! -L "$lambda_directory" && -e "$lambda_directory/bin/create-zip.sh" ]]; then
+      echo "next directory: $lambda_directory"
+      $lambda_directory/bin/create-zip.sh
+    else
+      echo "skipping directory: $lambda_directory"
+    fi
+  done
+else
+  echo "Creating *only* $1.zip"
+  lambda_directory=$1
   if [[ -d "$lambda_directory" && ! -L "$lambda_directory" && -e "$lambda_directory/bin/create-zip.sh" ]]; then
-    echo "next directory: $lambda_directory"
     $lambda_directory/bin/create-zip.sh
   else
-    echo "skipping directory: $lambda_directory"
+    echo "Cannot create zip file for $lambda_directory, either the directory does not exist or is a symlink or it has no bin/create-zip.sh script."
   fi
-done
-
+fi

--- a/packages/aws-lambda/lambdas/bin/rebuild-redeploy-single.sh
+++ b/packages/aws-lambda/lambdas/bin/rebuild-redeploy-single.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+cd `dirname $BASH_SOURCE`/..
+
+bin/create-zips.sh $1
+bin/deploy-demo.sh $1
+

--- a/packages/aws-lambda/lambdas/mock-backend/bin/create-zip.sh
+++ b/packages/aws-lambda/lambdas/mock-backend/bin/create-zip.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+cd `dirname $BASH_SOURCE`/..
+
+source ../bin/create-zip-util
+createZip
+

--- a/packages/aws-lambda/lambdas/mock-backend/index.js
+++ b/packages/aws-lambda/lambdas/mock-backend/index.js
@@ -1,0 +1,116 @@
+/* eslint-disable consistent-return */
+
+'use strict';
+
+const unresponsive = process.env.UNRESPONSIVE === 'true';
+
+exports.handler = async event => {
+  console.log('invoked with', event);
+  if (!event.httpMethod || !event.path || !event.body) {
+    // malformed event, probably not an API gateway request
+    return { statusCode: 400 };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405 };
+  }
+
+  if (event.path === '/serverless/bundle') {
+    return postBundle(event);
+  } else if (event.path === '/serverless/metrics') {
+    return postMetrics(event);
+  } else if (event.path === '/serverless/traces') {
+    return postTraces(event);
+  }
+  return { statusCode: 404 };
+};
+
+async function postBundle(event) {
+  console.log('incoming bundle');
+  if (unresponsive) {
+    return doNotRespond();
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body);
+  } catch (e) {
+    return responseWithMessage(400, 'Malformed HTTP request body, please send JSON.');
+  }
+
+  if (!body.metrics) {
+    return responseWithMessage(400, 'Payload has no metrics.');
+  }
+  if (typeof body.metrics !== 'object') {
+    return responseWithMessage(400, 'The metrics value in the payload is no object.');
+  }
+  if (Array.isArray(body.metrics)) {
+    return responseWithMessage(400, 'The metrics value in the payload is an array.');
+  }
+  if (!body.spans) {
+    return responseWithMessage(400, 'Payload has no spans.');
+  }
+  if (!Array.isArray(body.spans)) {
+    return responseWithMessage(400, 'The spans value in the payload is no array.');
+  }
+  return { statusCode: 201 };
+}
+
+async function postMetrics(event) {
+  console.log('incoming metrics');
+  if (unresponsive) {
+    return doNotRespond();
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body);
+  } catch (e) {
+    return responseWithMessage(400, 'Malformed HTTP request body, please send JSON.');
+  }
+
+  if (typeof body !== 'object') {
+    return responseWithMessage(400, 'The payload is no object.');
+  }
+  if (Array.isArray(body)) {
+    return responseWithMessage(400, 'The payload is an array.');
+  }
+  return { statusCode: 201 };
+}
+
+async function postTraces(event) {
+  console.log('incoming spans');
+  if (unresponsive) {
+    return doNotRespond();
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body);
+  } catch (e) {
+    return responseWithMessage(400, 'Malformed HTTP request body, please send JSON.');
+  }
+
+  if (!Array.isArray(body)) {
+    return responseWithMessage(400, 'The payload is no array.');
+  }
+  return { statusCode: 201 };
+}
+
+function responseWithMessage(statusCode, message) {
+  return responseWithPayload(statusCode, { message });
+}
+
+function responseWithPayload(statusCode, body) {
+  return {
+    statusCode,
+    body: JSON.stringify(body)
+  };
+}
+
+async function doNotRespond() {
+  // Intentionally delaying the response until after the Lambda timeout for tests that verify proper timeout handling in
+  // backend_connector.
+  await new Promise(resolve => setTimeout(resolve, 4000));
+  return { statusCode: 501 };
+}

--- a/packages/aws-lambda/lambdas/mock-backend/package.json
+++ b/packages/aws-lambda/lambdas/mock-backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mock-backend",
+  "description": "A dummy to replace serverless-acceptor to test various connection problems and timeout situations.",
+  "version": "1.0.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/instana/nodejs-sensor.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Bastian Krol <bastian.krol@instana.com>",
+  "license": "MIT"
+}

--- a/packages/aws-lambda/lambdas/wrapped-async/index.js
+++ b/packages/aws-lambda/lambdas/wrapped-async/index.js
@@ -3,11 +3,8 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const instana = require('@instana/aws-lambda'); // provided by Lambda layer "instana"
 
-const fetch = require('node-fetch');
-
 exports.handler = instana.wrap(async event => {
   console.log('in actual handler');
-  await fetch('https://example.com');
   if (event.error) {
     throw new Error('Boom!');
   } else {


### PR DESCRIPTION
In particular, use the timeout attribute in the request options instead
of adding the timeout via req.setTimeout.

The subtle difference is hidden quite well in the docs:

https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback:
> Once a socket is assigned to this request **and is connected**
> socket.setTimeout() will be called.

In other words, the timeout will only be applied **after** the connection
has been established. That means, if establishing the TCP connection
already takes very long, a timeout set like this will not become
effective. Effectively, this timeout is only a read/idle timeout on
that kicks in if nothing happens on the connection (e.g. we get no
response).

–VERSUS–

https://nodejs.org/api/http.html#http_http_request_options_callback:
> [...]
> timeout <number>: A number specifying the socket timeout in
> milliseconds. This will set the timeout **before** the socket is
> connected.

In other words, a timeout configured via the request _options_ takes
care of not being able to establish a TCP connection as well as a
read/idle timeout.