### PR TITLE
added upper case level for warn and error

### DIFF
--- a/packages/core/src/tracing/instrumentation/loggers/winston.js
+++ b/packages/core/src/tracing/instrumentation/loggers/winston.js
@@ -40,6 +40,10 @@ function instrumentWinston3(createLogger) {
     // npm levels
     shimLevelMethod(derivedLogger, 'error', true);
     shimLevelMethod(derivedLogger, 'warn', false);
+    
+    // custom levels for using upper case log level
+    shimLevelMethod(derivedLogger, 'ERROR', true);
+    shimLevelMethod(derivedLogger, 'WARN', false);
 
     // syslog levels (RFC5424)
     shimLevelMethod(derivedLogger, 'emerg', true);


### PR DESCRIPTION
This change is needed for some users, using a special format of log levels in the upper case.
WARN and ERROR was added to be recognized.

This is a change for non-standard usage of log levels.

See Ticket:
https://support.instana.com/hc/en-us/requests/13370