### PR TITLE
fix(metrics): provide name and dependencies when package.json is missing

### DIFF
--- a/packages/shared-metrics/src/dependencies.js
+++ b/packages/shared-metrics/src/dependencies.js
@@ -27,7 +27,20 @@ exports.activate = function activate() {
       setTimeout(exports.activate, DELAY).unref();
       return;
     } else if (!packageJsonPath) {
-      return logger.warn('Main package.json could not be found. Stopping dependency analysis.');
+      logger.info(
+        `Main package.json could not be found after ${attempts} retries. Looking for node_modules folder now.`
+      );
+      applicationUnderMonitoring.findNodeModulesFolder((errNodeModules, nodeModulesFolder) => {
+        if (errNodeModules) {
+          return logger.warn('Failed to determine node_modules folder. Reason: %s %s ', err.message, err.stack);
+        } else if (!nodeModulesFolder) {
+          return logger.warn(
+            'Neither the package.json file nor the node_modules folder could be found. Stopping dependency analysis.'
+          );
+        }
+        addDependenciesFromDir(path.join(nodeModulesFolder));
+      });
+      return;
     }
 
     let dependencyDir;

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -24,8 +24,13 @@ exports.activate = function activate() {
       setTimeout(exports.activate, DELAY).unref();
       return;
     } else if (!packageJson) {
+      if (process.mainModule) {
+        exports.currentPayload = process.mainModule.filename;
+      }
       return logger.warn(
-        'Main package.json could not be found. This Node.js app will be labelled "Unknown" in Instana.'
+        `Main package.json could not be found. This Node.js app will be labeled "${
+          exports.currentPayload ? exports.currentPayload : 'Unknown'
+        }" in Instana.`
       );
     }
 


### PR DESCRIPTION
- name: fall back to process.mainModule.filename
- dependencies: look for node_modules folder independently of
  package.json