### PR TITLE
fix(metrics): move event-loop-lag from optionalDeps to dependencies

### DIFF
--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -113,6 +113,10 @@
     {
       "name": "Sebastian Klose",
       "email": "mail@sklose.com"
+    },
+    {
+      "name": "Emelia Smith",
+      "email": "ThisIsMissEm@users.noreply.github.com"
     }
   ],
   "bugs": {

--- a/packages/shared-metrics/package-lock.json
+++ b/packages/shared-metrics/package-lock.json
@@ -650,7 +650,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/event-loop-lag/-/event-loop-lag-1.4.0.tgz",
       "integrity": "sha512-uNAYTAexGyPI7rms2jSES20nhUoCtjkmxgaOcAfaoaOQ6h3q1+fw6d5MfyfV0zMJpR//+GUYPVXrh2Wbv+E0sQ==",
-      "optional": true,
       "requires": {
         "debug": "^3.1.0"
       }

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -43,6 +43,10 @@
     {
       "name": "Bastian Krol",
       "email": "bastian.krol@instana.com"
+    },
+    {
+      "name": "Emelia Smith",
+      "email": "ThisIsMissEm@users.noreply.github.com"
     }
   ],
   "bugs": {
@@ -50,7 +54,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@instana/core": "^1.106.2"
+    "@instana/core": "^1.106.2",
+    "event-loop-lag": "^1.4.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",
@@ -61,7 +66,6 @@
     "prettier": "^1.17.1"
   },
   "optionalDependencies": {
-    "event-loop-lag": "^1.4.0",
     "event-loop-stats": "1.3.0",
     "gcstats.js": "1.0.0"
   }


### PR DESCRIPTION
This ensures installation whilst using
`--ignore-scripts --ignore-optional --production` will install correctly.