### PR TITLE
fix: remove longer span reporting interval in serverless tracers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Remove longer span reporting interval for serverless tracers, use standard interval instead.
+
 ## 1.106.5
 - [Google Cloud Run]: Minor changes for the upcoming Google Cloud Run support. Requires at least Instana back end version 189.
 

--- a/packages/aws-fargate/src/activate.js
+++ b/packages/aws-fargate/src/activate.js
@@ -12,18 +12,7 @@ const { normalizeConfig } = coreUtil;
 
 let logger = consoleLogger;
 
-let config = {};
-
-// @instana/collector sends metric and span data every second. To reduce HTTP overhead we throttle this back:
-// Metrics will be send every second, spans every 5 seconds.
-
-if (!process.env.INSTANA_TRACING_TRANSMISSION_DELAY) {
-  config.tracing = {
-    transmissionDelay: 5000
-  };
-}
-
-config = normalizeConfig(config);
+let config = normalizeConfig({});
 
 function init() {
   if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -200,16 +200,6 @@ function init(event, arnInfo, _config) {
     logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : config.level || process.env.INSTANA_LOG_LEVEL);
   }
 
-  // @instana/collector sends span data every second. To reduce HTTP overhead, in particular for long running Lambdas,
-  // we throttle this back to once every 5 seconds. We guarantee to send everything (metrics and all remaining spans)
-  // with POST /bundle after the Lambda handler has finished.
-  if (!config.tracing) {
-    config.tracing = {};
-  }
-  if (config.tracing.transmissionDelay == null) {
-    config.tracing.transmissionDelay = 5000;
-  }
-
   identityProvider.init(arnInfo);
   backendConnector.init(identityProvider, logger, true, false, 500);
 

--- a/packages/aws-lambda/test/long_running/test.js
+++ b/packages/aws-lambda/test/long_running/test.js
@@ -91,10 +91,11 @@ describe('long running lambdas', () => {
           verifySpans(spans, opts);
           verifyMetrics(metrics);
           // The lambda runs 13 seconds and creates a span every second. We also send spans to serverless acceptor
-          // every 5 seconds + the final bundle. Thus, we should see two intermittent POST requests to /traces and
+          // every second + the final bundle. Thus, we should see around 11-12 intermittent POST requests to /traces and
           // one to /bundle.
           expect(rawSpanArrays).to.be.an('array');
-          expect(rawSpanArrays).to.have.lengthOf(2);
+          expect(rawSpanArrays).to.have.lengthOf.at.least(10);
+          expect(rawSpanArrays).to.have.lengthOf.at.most(13);
           expect(rawBundles).to.be.an('array');
           expect(rawBundles).to.have.lengthOf(1);
         });
@@ -149,7 +150,7 @@ describe('long running lambdas', () => {
           expect(spans).to.have.lengthOf(0);
           expect(metrics).to.have.lengthOf(0);
 
-          // The first POST /spans (after 5 seconds) fails...
+          // The first POST /spans fails...
           expect(rawSpanArrays).to.have.lengthOf(1);
           // ...and we expect @instana/aws-lambda to stop sending spans after that. In particular, we expect the
           // POST /bundle at the end to not happen.

--- a/packages/google-cloud-run/src/activate.js
+++ b/packages/google-cloud-run/src/activate.js
@@ -11,18 +11,7 @@ const { normalizeConfig } = coreUtil;
 
 let logger = consoleLogger;
 
-let config = {};
-
-// @instana/collector sends metric and span data every second. To reduce HTTP overhead we throttle this back:
-// Metrics will be send every second, spans every 5 seconds.
-
-if (!process.env.INSTANA_TRACING_TRANSMISSION_DELAY) {
-  config.tracing = {
-    transmissionDelay: 5000
-  };
-}
-
-config = normalizeConfig(config);
+let config = normalizeConfig({});
 
 function init() {
   if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {


### PR DESCRIPTION
use standard interval instead