### PR TITLE
refactor(tests): add API to express expectations as an array

### DIFF
--- a/packages/aws-lambda/test/multiple_calls/test.js
+++ b/packages/aws-lambda/test/multiple_calls/test.js
@@ -5,8 +5,7 @@ const path = require('path');
 const constants = require('@instana/core').tracing.constants;
 
 const Control = require('../Control');
-const delay = require('../../../core/test/test_util/delay');
-const expectExactlyNMatching = require('../../../core/test/test_util/expectExactlyNMatching');
+const { delay, expectExactlyNMatching } = require('../../../core/test/test_util');
 const config = require('../../../serverless/test/config');
 
 const functionName = 'functionName';
@@ -114,23 +113,23 @@ describe('multiple lambda handler calls', function() {
   }
 
   function verifyLambdaEntries(spans) {
-    return expectExactlyNMatching(spans, 3, span => {
-      expect(span.t).to.exist;
-      expect(span.p).to.not.exist;
-      expect(span.s).to.exist;
-      expect(span.n).to.equal('aws.lambda.entry');
-      expect(span.k).to.equal(constants.ENTRY);
-      expect(span.f).to.be.an('object');
-      expect(span.f.h).to.not.exist;
-      expect(span.f.hl).to.be.true;
-      expect(span.f.cp).to.equal('aws');
-      expect(span.f.e).to.equal(qualifiedArn);
-      expect(span.async).to.not.exist;
-      expect(span.data.lambda).to.be.an('object');
-      expect(span.data.lambda.runtime).to.equal('nodejs');
-      expect(span.data.lambda.error).to.not.exist;
-      expect(span.error).to.not.exist;
-      expect(span.ec).to.equal(0);
-    });
+    return expectExactlyNMatching(spans, 3, [
+      span => expect(span.t).to.exist,
+      span => expect(span.p).to.not.exist,
+      span => expect(span.s).to.exist,
+      span => expect(span.n).to.equal('aws.lambda.entry'),
+      span => expect(span.k).to.equal(constants.ENTRY),
+      span => expect(span.f).to.be.an('object'),
+      span => expect(span.f.h).to.not.exist,
+      span => expect(span.f.hl).to.be.true,
+      span => expect(span.f.cp).to.equal('aws'),
+      span => expect(span.f.e).to.equal(qualifiedArn),
+      span => expect(span.async).to.not.exist,
+      span => expect(span.data.lambda).to.be.an('object'),
+      span => expect(span.data.lambda.runtime).to.equal('nodejs'),
+      span => expect(span.data.lambda.error).to.not.exist,
+      span => expect(span.error).to.not.exist,
+      span => expect(span.ec).to.equal(0)
+    ]);
   }
 });

--- a/packages/collector/test/tracing/misc/batching/test.js
+++ b/packages/collector/test/tracing/misc/batching/test.js
@@ -5,12 +5,7 @@ const expect = require('chai').expect;
 const constants = require('@instana/core').tracing.constants;
 const supportedVersion = require('@instana/core').tracing.supportedVersion;
 const config = require('../../../../../core/test/config');
-const {
-  getSpansByName,
-  expectAtLeastOneMatching,
-  expectExactlyOneMatching,
-  retry
-} = require('../../../../../core/test/test_util');
+const { getSpansByName, expectExactlyOneMatching, retry } = require('../../../../../core/test/test_util');
 
 const ProcessControls = require('../../../test_util/ProcessControls');
 
@@ -106,25 +101,25 @@ describe('tracing/batching', function() {
 
           return retry(() =>
             agentControls.getSpans().then(spans => {
-              const entrySpan = expectAtLeastOneMatching(spans, span => {
-                expect(span.n).to.equal('node.http.server');
-                expect(span.data.http.method).to.equal('POST');
-              });
+              const entrySpan = expectExactlyOneMatching(spans, [
+                span => expect(span.n).to.equal('node.http.server'),
+                span => expect(span.data.http.method).to.equal('POST')
+              ]);
 
               expect(spans).to.have.lengthOf(3);
 
-              expectExactlyOneMatching(spans, span => {
-                expect(span.t).to.equal(entrySpan.t);
-                expect(span.p).to.equal(entrySpan.s);
-                expect(span.n).to.equal('redis');
-                expect(span.k).to.equal(constants.EXIT);
-                expect(span.f.e).to.equal(String(controls.getPid()));
-                expect(span.f.h).to.equal('agent-stub-uuid');
-                expect(span.ec).to.equal(0);
-                expect(span.b).to.be.an('object');
-                expect(span.b.s).to.equal(3);
-                expect(span.b.d).to.be.a('number');
-              });
+              expectExactlyOneMatching(spans, [
+                span => expect(span.t).to.equal(entrySpan.t),
+                span => expect(span.p).to.equal(entrySpan.s),
+                span => expect(span.n).to.equal('redis'),
+                span => expect(span.k).to.equal(constants.EXIT),
+                span => expect(span.f.e).to.equal(String(controls.getPid())),
+                span => expect(span.f.h).to.equal('agent-stub-uuid'),
+                span => expect(span.ec).to.equal(0),
+                span => expect(span.b).to.be.an('object'),
+                span => expect(span.b.s).to.equal(3),
+                span => expect(span.b.d).to.be.a('number')
+              ]);
 
               verifyHttpExit(controls, spans, entrySpan);
             })
@@ -142,31 +137,32 @@ describe('tracing/batching', function() {
 
           return retry(() =>
             agentControls.getSpans().then(spans => {
-              const entrySpan = expectAtLeastOneMatching(spans, span => {
-                expect(span.n).to.equal('node.http.server');
-                expect(span.data.http.method).to.equal('POST');
-              });
+              const entrySpan = expectExactlyOneMatching(spans, [
+                span => expect(span.n).to.equal('node.http.server'),
+                span => expect(span.data.http.method).to.equal('POST')
+              ]);
 
               expect(spans).to.have.lengthOf(3);
 
-              expectExactlyOneMatching(spans, span => {
-                expect(span.t).to.equal(entrySpan.t);
-                expect(span.p).to.equal(entrySpan.s);
-                expect(span.n).to.equal('redis');
-                expect(span.k).to.equal(constants.EXIT);
-                expect(span.f.e).to.equal(String(controls.getPid()));
-                expect(span.f.h).to.equal('agent-stub-uuid');
-                expect(span.ec).to.equal(2);
+              expectExactlyOneMatching(spans, [
+                span => expect(span.t).to.equal(entrySpan.t),
+                span => expect(span.p).to.equal(entrySpan.s),
+                span => expect(span.n).to.equal('redis'),
+                span => expect(span.k).to.equal(constants.EXIT),
+                span => expect(span.f.e).to.equal(String(controls.getPid())),
+                span => expect(span.f.h).to.equal('agent-stub-uuid'),
+                span => expect(span.ec).to.equal(2),
+
                 // The get calls have errors, thus they should be more significant than the set call for batching.
-                expect(span.data.redis.command).to.equal('get');
+                span => expect(span.data.redis.command).to.equal('get'),
 
-                expect(span.b).to.be.an('object');
-                expect(span.b.s).to.equal(3);
-                expect(span.b.d).to.be.greaterThan(0);
+                span => expect(span.b).to.be.an('object'),
+                span => expect(span.b.s).to.equal(3),
+                span => expect(span.b.d).to.be.greaterThan(0),
 
-                expect(span.data.redis.error).to.be.a('string');
-                expect(span.data.redis.error).to.contain('wrong number of arguments for');
-              });
+                span => expect(span.data.redis.error).to.be.a('string'),
+                span => expect(span.data.redis.error).to.contain('wrong number of arguments for')
+              ]);
 
               verifyHttpExit(controls, spans, entrySpan);
             })
@@ -175,19 +171,19 @@ describe('tracing/batching', function() {
   }
 
   function verifyHttpExit(controls, spans, parent) {
-    expectExactlyOneMatching(spans, span => {
-      expect(span.t).to.equal(parent.t);
-      expect(span.p).to.equal(parent.s);
-      expect(span.n).to.equal('node.http.client');
-      expect(span.k).to.equal(constants.EXIT);
-      expect(span.f.e).to.equal(String(controls.getPid()));
-      expect(span.f.h).to.equal('agent-stub-uuid');
-      expect(span.async).to.not.exist;
-      expect(span.error).to.not.exist;
-      expect(span.ec).to.equal(0);
-      expect(span.data.http.method).to.equal('GET');
-      expect(span.data.http.url).to.match(/http:\/\/127\.0\.0\.1:3210/);
-      expect(span.data.http.status).to.equal(200);
-    });
+    expectExactlyOneMatching(spans, [
+      span => expect(span.t).to.equal(parent.t),
+      span => expect(span.p).to.equal(parent.s),
+      span => expect(span.n).to.equal('node.http.client'),
+      span => expect(span.k).to.equal(constants.EXIT),
+      span => expect(span.f.e).to.equal(String(controls.getPid())),
+      span => expect(span.f.h).to.equal('agent-stub-uuid'),
+      span => expect(span.async).to.not.exist,
+      span => expect(span.error).to.not.exist,
+      span => expect(span.ec).to.equal(0),
+      span => expect(span.data.http.method).to.equal('GET'),
+      span => expect(span.data.http.url).to.match(/http:\/\/127\.0\.0\.1:3210/),
+      span => expect(span.data.http.status).to.equal(200)
+    ]);
   }
 });

--- a/packages/core/test/test_util/expectAtLeastOneMatching.js
+++ b/packages/core/test/test_util/expectAtLeastOneMatching.js
@@ -1,35 +1,16 @@
 'use strict';
 
-const fail = require('chai').assert.fail;
+const { findAllMatchingItems, reportFailure } = require('./matchingItems');
 
-const stringifyItems = require('./stringifyItems');
+module.exports = exports = function expectAtLeastOneMatching(items, expectations) {
+  const matchResult = findAllMatchingItems(items, expectations);
+  const matches = matchResult.getMatches();
 
-module.exports = exports = function expectAtLeastOneMatching(arr, fn) {
-  if (!arr || arr.length === 0) {
-    fail('Could not find an item which matches all the criteria. Got 0 items.');
-  }
-
-  let error;
-
-  for (let i = 0; i < arr.length; i++) {
-    const item = arr[i];
-
-    try {
-      fn(item);
-      return item;
-    } catch (e) {
-      error = e;
-    }
-  }
-
-  if (error) {
-    // Clone the stack before creating a new error object, otherwise the stack of the new error object (including the
-    // stringified spans) will be added again, basically duplicating the list of spans we add to the error message.
-    const stack = Object.assign('', error.stack);
-    throw new Error(
-      `Could not find an item which matches all the criteria. Got ${arr.length} items. Last error: ${
-        error.message
-      }. All Items:\n${stringifyItems(arr)}. Error stack trace: ${stack}`
-    );
+  if (matches.length >= 1) {
+    return matches[0];
+  } else if (matchResult.getError()) {
+    reportFailure(matchResult, 'at least one matching item');
+  } else {
+    throw new Error('Invalid state in expectAtLeastOneMatching: There were no matches but also no error');
   }
 };

--- a/packages/core/test/test_util/expectExactlyNMatching.js
+++ b/packages/core/test/test_util/expectExactlyNMatching.js
@@ -1,46 +1,27 @@
 'use strict';
 
-const fail = require('chai').assert.fail;
-
+const { findAllMatchingItems, reportFailure } = require('./matchingItems');
 const stringifyItems = require('./stringifyItems');
 
-module.exports = exports = function expectExactlyNMatching(arr, n, fn) {
-  if (!arr || arr.length === 0) {
-    fail(`Could not find excactly ${n} item(s) which matched all the criteria. Got 0 items.`);
-  }
-
-  const matches = [];
-  let error;
-
-  for (let i = 0; i < arr.length; i++) {
-    const item = arr[i];
-
-    try {
-      fn(item);
-      matches.push(item);
-    } catch (e) {
-      error = e;
-    }
-  }
+module.exports = exports = function expectExactlyNMatching(items, n, expectations) {
+  const matchResult = findAllMatchingItems(items, expectations);
+  const matches = matchResult.getMatches();
 
   if (matches.length === n) {
     return matches;
+  } else if (matches.length === 0 && matchResult.getError()) {
+    reportFailure(matchResult, `exactly ${n} matching item`);
   } else if (matches.length !== n) {
     throw new Error(
       `Found ${matches.length} matching items, but expected exactly ${n}: All matching items:\n${stringifyItems(
         matches
       )} `
     );
-  } else if (error) {
-    // Clone the stack before creating a new error object, otherwise the stack of the new error object (including the
-    // stringified spans) will be added again, basically duplicating the list of spans we add to the error message.
-    const stack = Object.assign('', error.stack);
-    throw new Error(
-      `Could not find exactly ${n} matches. Last error: ${error.message}. All Items:\n${stringifyItems(
-        arr
-      )}. Error stack trace: ${stack}`
-    );
+  } else if (matchResult.getError()) {
+    reportFailure(matchResult, `exactly ${n} matching item(s)`);
   } else {
-    throw new Error('Invalid state in expectExactlyNMatching.');
+    throw new Error(
+      'Invalid state in expectExactlyNMatching. Neither correct nor wrong number of matches and no error.'
+    );
   }
 };

--- a/packages/core/test/test_util/expectExactlyOneMatching.js
+++ b/packages/core/test/test_util/expectExactlyOneMatching.js
@@ -1,27 +1,11 @@
 'use strict';
 
-const fail = require('chai').assert.fail;
-
+const { findAllMatchingItems, reportFailure } = require('./matchingItems');
 const stringifyItems = require('./stringifyItems');
 
-module.exports = exports = function expectExactlyOneMatching(arr, fn) {
-  if (!arr || arr.length === 0) {
-    fail('Could not find excactly one item which matches all the criteria. Got 0 items.');
-  }
-
-  const matches = [];
-  let error;
-
-  for (let i = 0; i < arr.length; i++) {
-    const item = arr[i];
-
-    try {
-      fn(item);
-      matches.push(item);
-    } catch (e) {
-      error = e;
-    }
-  }
+module.exports = exports = function expectExactlyOneMatching(items, expectations) {
+  const matchResult = findAllMatchingItems(items, expectations);
+  const matches = matchResult.getMatches();
 
   if (matches.length === 1) {
     return matches[0];
@@ -31,15 +15,8 @@ module.exports = exports = function expectExactlyOneMatching(arr, fn) {
         matches.length
       }: All matching items:\n${stringifyItems(matches)} `
     );
-  } else if (error) {
-    // Clone the stack before creating a new error object, otherwise the stack of the new error object (including the
-    // stringified spans) will be added again, basically duplicating the list of spans we add to the error message.
-    const stack = Object.assign('', error.stack);
-    throw new Error(
-      `Could not find an item which matches all the criteria. Got ${arr.length} items. Last error: ${
-        error.message
-      }. All Items:\n${stringifyItems(arr)}. Error stack trace: ${stack}`
-    );
+  } else if (matchResult.getError()) {
+    reportFailure(matchResult, 'exactly one matching item');
   } else {
     throw new Error('Invalid state in expectExactlyOneMatching: There was no match but also no error');
   }

--- a/packages/core/test/test_util/matchingItems.js
+++ b/packages/core/test/test_util/matchingItems.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const fail = require('chai').assert.fail;
+
+const stringifyItems = require('./stringifyItems');
+
+class MatchResult {
+  constructor(items, expectations) {
+    if (!Array.isArray(items)) {
+      throw new Error(`items needs to be an array: ${items}`);
+    }
+    if (!Array.isArray(expectations) && typeof expectations !== 'function') {
+      throw new Error(`expectations needs to be an array of functions or a function: ${expectations}`);
+    }
+    this.items = items;
+    this.expectations = expectations;
+    this.matches = [];
+    this.saveBestMatch = Array.isArray(expectations);
+    this.bestMatchPassed = 0;
+  }
+
+  getItems() {
+    return this.items;
+  }
+
+  getExpectations() {
+    return this.expectations;
+  }
+
+  getMatches() {
+    return this.matches;
+  }
+
+  addMatch(item) {
+    this.matches.push(item);
+  }
+
+  getError() {
+    return this.error;
+  }
+
+  setError(error) {
+    this.error = error;
+  }
+
+  isSaveBestMatch() {
+    return this.saveBestMatch;
+  }
+
+  getBestMatch() {
+    return this.bestMatch;
+  }
+
+  setBestMatch(bestMatch) {
+    this.bestMatch = bestMatch;
+  }
+
+  getBestMatchPassed() {
+    return this.bestMatchPassed;
+  }
+
+  setBestMatchPassed(bestMatchPassed) {
+    this.bestMatchPassed = bestMatchPassed;
+  }
+
+  getFailedExpectation() {
+    return this.failedExpectation;
+  }
+
+  setFailedExpectation(failedExpectation) {
+    this.failedExpectation = failedExpectation;
+  }
+}
+
+exports.MatchResult = MatchResult;
+
+exports.findAllMatchingItems = function findAllMatchingItems(items, expectations) {
+  if (!items || items.length === 0) {
+    fail('Could not find any matching items which match all the criteria. In fact, there were zero items.');
+  }
+
+  const result = new MatchResult(items, expectations);
+
+  let mostRecentExpectation = null;
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    let passed;
+
+    try {
+      if (Array.isArray(expectations)) {
+        // More recent tests pass an array of functions with individual expectations. This is preferable over the legacy
+        // API because it provides much better output in case of a failure. This is of particularly crucial for the
+        // occasional flaky test on CI.
+        for (passed = 0; passed < expectations.length; passed++) {
+          mostRecentExpectation = expectations[passed];
+          expectations[passed](item);
+        }
+      } else if (typeof expectations === 'function') {
+        // Legacy tests just pass one big function which executes all expectations.
+        expectations(item);
+      }
+      result.addMatch(item);
+    } catch (error) {
+      if (result.isSaveBestMatch()) {
+        if (passed >= result.getBestMatchPassed()) {
+          result.setBestMatch(item);
+          result.setBestMatchPassed(passed);
+          result.setFailedExpectation(mostRecentExpectation);
+          result.setError(error);
+        }
+      } else {
+        result.setError(error);
+      }
+    }
+  }
+  return result;
+};
+
+exports.reportFailure = function reportFailure(result, lookingFor) {
+  // Clone the stack before creating a new error object, otherwise the stack of the new error object (including the
+  // stringified spans) will be added again, basically duplicating the list of spans we add to the error message.
+  const stack = Object.assign('', result.error.stack);
+  let errorMessageReported = false;
+  let message = `Could not find the required matching items while looking for ${lookingFor}.\n----\n`;
+  if (result.isSaveBestMatch() && result.getBestMatch()) {
+    message += `Best matching item:\n${stringifyItems(result.getBestMatch())}\n`;
+    message += `This item passed the first ${result.getBestMatchPassed()} (of ${
+      result.getExpectations().length
+    }) expectations.\n`;
+    if (result.getFailedExpectation()) {
+      message += `This expectationt failed: ${result.getFailedExpectation().toString()}\n`;
+      message += `And it failed with this error: ${result.getError().message}\n`;
+      errorMessageReported = true;
+    }
+    message += '----\nMore details:\n';
+  }
+  message += `Got ${result.getItems().length} items in total.\n`;
+  if (!process.env.OMIT_ITEM_LIST_ON_MATCH_FAILURE) {
+    message += `All Items:\n${stringifyItems(result.getItems())}\n`;
+  }
+  if (!errorMessageReported) {
+    message += `Last error: ${result.getError().message}\n`;
+  }
+  message += `Error stack trace:\n${stack}`;
+  throw new Error(message);
+};


### PR DESCRIPTION
    Previously expectExactlyOneItem and friends (which are heavily used in
    the tracing tests) only excepted a single function which contained all
    relevant expectations. If it failed, it was unclear, which of the
    expectations had failed, making it

    (a) hard to troubleshoot failing tests locally, and
    (b) making it impossible to know why exactly a test had failed on CI.

    This introduces a new API that accepts an array of individual
    expectations (each as its own function). Thus, we can report accurately
    which item would have matched best and which expectation exactly made
    the match fail.

    This also migrates two arbitrary tests to the new API. Other tests will
    be migrated later on.