### PR TITLE
feat: do not instrument npm or yarn

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,12 @@ module.exports = {
     'no-use-before-define': ['error', 'nofunc'],
     'object-curly-spacing': 'off',
     'operator-linebreak': 'off',
+    'prefer-const': [
+      'error',
+      {
+        destructuring: 'all'
+      }
+    ],
     'prefer-arrow-callback': 'off',
     'space-before-function-paren': 'off',
     strict: ['error', 'global'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased:
 - Do not instrument npm or yarn when started via @instana/collector/src/immediate (instead, only instrument the child process started by npm start or yarn start).
+- Do not instrument npm or yarn on AWS Fargate (instead, only instrument the child process started by npm start or yarn start).
+- Do not instrument npm or yarn on Google Cloud Run (instead, only instrument the child process started by npm start or yarn start).
 
 ## 1.110.5:
 - Depend on exact versions of `@instana` packages, not a version range. This makes sure all `@instana` packages are updated in sync and it avoids internal packages like `core` being updated while consuming packages like `collector` stay on an older version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased:
+- Do not instrument npm or yarn when started via @instana/collector/src/immediate (instead, only instrument the child process started by npm start or yarn start).
+
 ## 1.110.5:
 - Depend on exact versions of `@instana` packages, not a version range. This makes sure all `@instana` packages are updated in sync and it avoids internal packages like `core` being updated while consuming packages like `collector` stay on an older version.
 

--- a/packages/autoprofile/lib/auto_profiler.js
+++ b/packages/autoprofile/lib/auto_profiler.js
@@ -222,7 +222,7 @@ class AutoProfiler {
       };
     }
 
-    let schedulers = [];
+    const schedulers = [];
     if (self.cpuSamplerScheduler.started) {
       schedulers.push(self.cpuSamplerScheduler);
     }
@@ -282,10 +282,10 @@ class AutoProfiler {
   }
 
   matchVersion(min, max) {
-    let versionRegexp = /v?(\d+)\.(\d+)\.(\d+)/;
+    const versionRegexp = /v?(\d+)\.(\d+)\.(\d+)/;
 
     let m = versionRegexp.exec(process.version);
-    let currN = 1e9 * parseInt(m[1], 10) + 1e6 * parseInt(m[2], 10) + 1e3 * parseInt(m[3], 10);
+    const currN = 1e9 * parseInt(m[1], 10) + 1e6 * parseInt(m[2], 10) + 1e3 * parseInt(m[3], 10);
 
     let minN = 0;
     if (min) {

--- a/packages/autoprofile/lib/profile.js
+++ b/packages/autoprofile/lib/profile.js
@@ -68,7 +68,7 @@ class CallSite {
   depth() {
     let max = 0;
 
-    for (let child of this.children.values()) {
+    for (const child of this.children.values()) {
       const d = child.depth();
       if (d > max) {
         max = d;
@@ -80,7 +80,7 @@ class CallSite {
 
   toJson() {
     const childrenJson = [];
-    for (let child of this.children.values()) {
+    for (const child of this.children.values()) {
       childrenJson.push(child.toJson());
     }
 
@@ -118,7 +118,7 @@ class Profile {
 
   toJson() {
     const rootsJson = [];
-    for (let root of this.roots.values()) {
+    for (const root of this.roots.values()) {
       rootsJson.push(root.toJson());
     }
 

--- a/packages/autoprofile/lib/profile_recorder.js
+++ b/packages/autoprofile/lib/profile_recorder.js
@@ -54,7 +54,7 @@ class ProfileRecorder {
   }
 
   flush(callback) {
-    let now = Date.now();
+    const now = Date.now();
 
     if (this.queue.length === 0) {
       return callback(null);
@@ -66,7 +66,7 @@ class ProfileRecorder {
     }
 
     // read queue
-    let outgoing = this.queue;
+    const outgoing = this.queue;
     this.queue = [];
 
     this.lastFlushTs = now;

--- a/packages/autoprofile/lib/sampler_scheduler.js
+++ b/packages/autoprofile/lib/sampler_scheduler.js
@@ -91,7 +91,7 @@ class SamplerScheduler {
       return null;
     }
 
-    let spanStart = Date.now();
+    const spanStart = Date.now();
 
     let stopped = false;
     const self = this;
@@ -142,9 +142,9 @@ class SamplerScheduler {
     }
     this.profiler.debug(this.config.logPrefix + ': reporting profile.');
 
-    let profile = this.sampler.buildProfile(this.profileDuration, Date.now() - this.profileStartTs);
+    const profile = this.sampler.buildProfile(this.profileDuration, Date.now() - this.profileStartTs);
 
-    let externalPid = this.profiler.getExternalPid();
+    const externalPid = this.profiler.getExternalPid();
     if (externalPid) {
       profile.processId = '' + externalPid;
     }

--- a/packages/autoprofile/lib/samplers/allocation_sampler.js
+++ b/packages/autoprofile/lib/samplers/allocation_sampler.js
@@ -31,10 +31,10 @@ class AllocationSampler {
   }
 
   stopSampler() {
-    let allocationProfileRoot = this.profiler.addon.readAllocationProfile();
+    const allocationProfileRoot = this.profiler.addon.readAllocationProfile();
     this.profiler.addon.stopAllocationSampler();
     if (allocationProfileRoot) {
-      let includeAgentFrames = this.profiler.getOption('includeAgentFrames');
+      const includeAgentFrames = this.profiler.getOption('includeAgentFrames');
       this.updateProfile(this.top, allocationProfileRoot.children, includeAgentFrames);
     }
   }
@@ -46,7 +46,7 @@ class AllocationSampler {
         return;
       }
 
-      let child = parent.findOrAddChild(node.func_name, node.file_name, node.line_num);
+      const child = parent.findOrAddChild(node.func_name, node.file_name, node.line_num);
 
       child.measurement += node.size;
       child.numSamples += node.count;
@@ -56,13 +56,13 @@ class AllocationSampler {
   }
 
   buildProfile(duration, timespan) {
-    let roots = new Set();
+    const roots = new Set();
     // eslint-disable-next-line no-restricted-syntax
-    for (let child of this.top.children.values()) {
+    for (const child of this.top.children.values()) {
       roots.add(child);
     }
 
-    let profile = new Profile(
+    const profile = new Profile(
       this.profiler,
       Profile.c.CATEGORY_MEMORY,
       Profile.c.TYPE_MEMORY_ALLOCATION_RATE,

--- a/packages/autoprofile/lib/samplers/async_sampler.js
+++ b/packages/autoprofile/lib/samplers/async_sampler.js
@@ -96,7 +96,7 @@ class AsyncSampler {
 
     function before(asyncId) {
       try {
-        let sample = self.samples.get(asyncId);
+        const sample = self.samples.get(asyncId);
         if (!sample) {
           return;
         }
@@ -135,9 +135,9 @@ class AsyncSampler {
       this.profileDuration += this.hrmillis() - this.spanStart;
     } else {
       let spanEnd = this.spanStart;
-      for (let sample of this.samples.values()) {
+      for (const sample of this.samples.values()) {
         if (sample.time) {
-          let sampleEnd = sample.start + sample.time;
+          const sampleEnd = sample.start + sample.time;
           if (sampleEnd > spanEnd) {
             spanEnd = sampleEnd;
           }
@@ -157,9 +157,9 @@ class AsyncSampler {
   }
 
   updateProfile() {
-    let includeAgentFrames = this.profiler.getOption('includeAgentFrames');
+    const includeAgentFrames = this.profiler.getOption('includeAgentFrames');
 
-    for (let sample of this.samples.values()) {
+    for (const sample of this.samples.values()) {
       if (!sample.time) {
         continue;
       }
@@ -176,7 +176,7 @@ class AsyncSampler {
 
       // update profile
       let node = this.top;
-      for (let frame of frames) {
+      for (const frame of frames) {
         let methodName = '';
         if (frame.getFunctionName()) {
           methodName = frame.getFunctionName();
@@ -193,8 +193,8 @@ class AsyncSampler {
   }
 
   createStackTrace(sample, includeAgentFrames) {
-    let frames = new Map();
-    let processed = new Set();
+    const frames = new Map();
+    const processed = new Set();
 
     while (sample && !processed.has(sample.asyncId)) {
       processed.add(sample.asyncId);
@@ -244,12 +244,12 @@ class AsyncSampler {
   }
 
   buildProfile(duration, timespan) {
-    let roots = new Set();
-    for (let child of this.top.children.values()) {
+    const roots = new Set();
+    for (const child of this.top.children.values()) {
       roots.add(child);
     }
 
-    let profile = new Profile(
+    const profile = new Profile(
       this.profiler,
       Profile.c.CATEGORY_TIME,
       Profile.c.TYPE_ASYNC_CALLS,

--- a/packages/autoprofile/lib/samplers/cpu_sampler.js
+++ b/packages/autoprofile/lib/samplers/cpu_sampler.js
@@ -36,21 +36,21 @@ class CpuSampler {
   }
 
   stopSampler() {
-    let cpuProfileRoot = this.profiler.addon.stopCpuSampler();
+    const cpuProfileRoot = this.profiler.addon.stopCpuSampler();
     if (cpuProfileRoot) {
-      let includeAgentFrames = this.profiler.getOption('includeAgentFrames');
+      const includeAgentFrames = this.profiler.getOption('includeAgentFrames');
       this.updateProfile(this.top, cpuProfileRoot.children, includeAgentFrames);
     }
   }
 
   buildProfile(duration, timespan) {
-    let roots = new Set();
+    const roots = new Set();
     // eslint-disable-next-line no-restricted-syntax
-    for (let child of this.top.children.values()) {
+    for (const child of this.top.children.values()) {
       roots.add(child);
     }
 
-    let profile = new Profile(
+    const profile = new Profile(
       this.profiler,
       Profile.c.CATEGORY_CPU,
       Profile.c.TYPE_CPU_USAGE,
@@ -76,7 +76,7 @@ class CpuSampler {
         return;
       }
 
-      let child = parent.findOrAddChild(node.func_name, node.file_name, node.line_num);
+      const child = parent.findOrAddChild(node.func_name, node.file_name, node.line_num);
 
       child.measurement += node.hit_count;
       child.numSamples += node.hit_count;

--- a/packages/autoprofile/lib/utils.js
+++ b/packages/autoprofile/lib/utils.js
@@ -20,7 +20,7 @@ class Utils {
   }
 
   generateSha1(text) {
-    let h = crypto.createHash('sha1');
+    const h = crypto.createHash('sha1');
     h.update(text);
     return h.digest('hex');
   }

--- a/packages/autoprofile/test/auto_profiler.test.js
+++ b/packages/autoprofile/test/auto_profiler.test.js
@@ -49,7 +49,7 @@ describe('AutoProfiler', () => {
 
   describe('profile()', () => {
     it('should profile with CPU sampler', done => {
-      let span = profiler.profile();
+      const span = profiler.profile();
       assert(span);
 
       // do some work

--- a/packages/autoprofile/test/profile.test.js
+++ b/packages/autoprofile/test/profile.test.js
@@ -13,19 +13,19 @@ describe('Profile', () => {
 
   describe('toJson()', () => {
     it('should convert profile to json', done => {
-      let roots = new Set();
+      const roots = new Set();
 
-      let root1 = new CallSite(profiler, 'meth1', 'file1', 1);
+      const root1 = new CallSite(profiler, 'meth1', 'file1', 1);
       root1.measurement = 10;
       root1.numSamples = 1;
       roots.add(root1);
 
-      let child1 = new CallSite(profiler, 'meth2', 'file2', 2);
+      const child1 = new CallSite(profiler, 'meth2', 'file2', 2);
       child1.measurement = 5;
       child1.numSamples = 1;
       root1.addChild(child1);
 
-      let profile = new Profile(
+      const profile = new Profile(
         profiler,
         Profile.c.CATEGORY_CPU,
         Profile.c.TYPE_CPU_USAGE,
@@ -82,15 +82,15 @@ describe('CallSite', () => {
 
   describe('depth()', () => {
     it('should return max depth', done => {
-      let root = new CallSite(profiler, 'root', '', 0);
+      const root = new CallSite(profiler, 'root', '', 0);
 
-      let child1 = new CallSite(profiler, 'child1', '', 0);
+      const child1 = new CallSite(profiler, 'child1', '', 0);
       root.addChild(child1);
 
-      let child2 = new CallSite(profiler, 'child2', '', 0);
+      const child2 = new CallSite(profiler, 'child2', '', 0);
       root.addChild(child2);
 
-      let child2child1 = new CallSite(profiler, 'child2child1', '', 0);
+      const child2child1 = new CallSite(profiler, 'child2child1', '', 0);
       child2.addChild(child2child1);
 
       assert.equal(root.depth(), 3);
@@ -103,9 +103,9 @@ describe('CallSite', () => {
 
   describe('addChild()', () => {
     it('should add child', done => {
-      let root = new CallSite(profiler, 'root', '', 0);
+      const root = new CallSite(profiler, 'root', '', 0);
 
-      let child1 = new CallSite(profiler, 'child1', '', 0);
+      const child1 = new CallSite(profiler, 'child1', '', 0);
       root.addChild(child1);
 
       assert.deepEqual(child1, root.findChild('child1', '', 0));
@@ -116,9 +116,9 @@ describe('CallSite', () => {
 
   describe('removeChild()', () => {
     it('should remove child', done => {
-      let root = new CallSite(profiler, 'root', '', 0);
+      const root = new CallSite(profiler, 'root', '', 0);
 
-      let child1 = new CallSite(profiler, 'child1', '', 0);
+      const child1 = new CallSite(profiler, 'child1', '', 0);
       root.removeChild(child1);
 
       assert(!root.findChild('child1', '', 0));
@@ -129,7 +129,7 @@ describe('CallSite', () => {
 
   describe('increment()', () => {
     it('should increment value', done => {
-      let b = new CallSite(profiler, 'root', '', 0);
+      const b = new CallSite(profiler, 'root', '', 0);
       b.increment(0.1, 1);
       b.increment(0.2, 2);
 

--- a/packages/autoprofile/test/samplers/allocation_sampler.test.js
+++ b/packages/autoprofile/test/samplers/allocation_sampler.test.js
@@ -18,7 +18,7 @@ describe('AllocationSampler', () => {
         return;
       }
 
-      let sampler = new AllocationSampler(profiler);
+      const sampler = new AllocationSampler(profiler);
       if (!sampler.test()) {
         done();
         return;
@@ -29,15 +29,15 @@ describe('AllocationSampler', () => {
         sampler.startSampler();
         setTimeout(() => {
           sampler.stopSampler();
-          let profile = sampler.buildProfile(1000, 10);
+          const profile = sampler.buildProfile(1000, 10);
 
           // console.log(util.inspect(profile.toJson(), {showHidden: false, depth: null}))
           callback(null, JSON.stringify(profile.toJson()).match(/allocation_sampler.test.js/));
         }, 1000);
 
-        let mem1 = [];
+        const mem1 = [];
         function memLeak() {
-          let mem2 = [];
+          const mem2 = [];
           for (let i = 0; i < 200000; i++) {
             mem1.push(Math.random());
             mem2.push(Math.random());

--- a/packages/autoprofile/test/samplers/async_sampler.test.js
+++ b/packages/autoprofile/test/samplers/async_sampler.test.js
@@ -29,7 +29,7 @@ describe('AsyncSampler', () => {
 
   describe('extractFrames()', () => {
     it('should extract frames', done => {
-      let sampler = new AsyncSampler(profiler);
+      const sampler = new AsyncSampler(profiler);
       if (!sampler.test()) {
         done();
         return;
@@ -53,7 +53,7 @@ describe('AsyncSampler', () => {
         }
       }
 
-      let sample = {
+      const sample = {
         asyncId: 1,
         stack: generateStackTrace(0)
       };
@@ -61,7 +61,7 @@ describe('AsyncSampler', () => {
       sampler.samples = new Map();
       sampler.samples.set(1, sample);
 
-      let frames = sampler.createStackTrace(sample, true);
+      const frames = sampler.createStackTrace(sample, true);
 
       let found = false;
       frames.forEach(frame => {
@@ -78,7 +78,7 @@ describe('AsyncSampler', () => {
 
   describe('startProfiling()', () => {
     it('should record async profile', done => {
-      let sampler = new AsyncSampler(profiler);
+      const sampler = new AsyncSampler(profiler);
       if (!sampler.test()) {
         done();
         return;
@@ -99,7 +99,7 @@ describe('AsyncSampler', () => {
         sampler.startSampler();
         setTimeout(() => {
           sampler.stopSampler();
-          let profile = sampler.buildProfile(1000, 10);
+          const profile = sampler.buildProfile(1000, 10);
           assert(JSON.stringify(profile.toJson()).match(/async_sampler.test.js/));
           done();
         }, 1000);

--- a/packages/autoprofile/test/samplers/cpu_sampler.test.js
+++ b/packages/autoprofile/test/samplers/cpu_sampler.test.js
@@ -13,7 +13,7 @@ describe('CpuSampler', () => {
 
   describe('startProfile()', () => {
     it('should record profile', done => {
-      let sampler = new CpuSampler(profiler);
+      const sampler = new CpuSampler(profiler);
       if (!sampler.test()) {
         done();
         return;
@@ -25,7 +25,7 @@ describe('CpuSampler', () => {
 
         setTimeout(() => {
           sampler.stopSampler();
-          let profile = sampler.buildProfile(500, 10);
+          const profile = sampler.buildProfile(500, 10);
 
           callback(null, JSON.stringify(profile.toJson()).match(/cpu_sampler.test.js/));
         }, 500);

--- a/packages/autoprofile/test/utils.test.js
+++ b/packages/autoprofile/test/utils.test.js
@@ -11,8 +11,8 @@ describe('Utils', () => {
 
   describe('generateUuid()', () => {
     it('should generate uuid', done => {
-      let uuid1 = profiler.utils.generateUuid();
-      let uuid2 = profiler.utils.generateUuid();
+      const uuid1 = profiler.utils.generateUuid();
+      const uuid2 = profiler.utils.generateUuid();
 
       assert.equal(uuid1.length, 32);
       assert.notEqual(uuid1, uuid2);
@@ -23,7 +23,7 @@ describe('Utils', () => {
 
   describe('generateSha1()', () => {
     it('should generate sha1', done => {
-      let sha1 = profiler.utils.generateSha1('some text');
+      const sha1 = profiler.utils.generateSha1('some text');
       assert.equal(sha1, '37aa63c77398d954473262e1a0057c1e632eda77');
 
       done();

--- a/packages/aws-fargate/images/inspector/index.js
+++ b/packages/aws-fargate/images/inspector/index.js
@@ -13,7 +13,7 @@ const metadataUriEnvVarV3 = 'ECS_CONTAINER_METADATA_URI';
 const metadataUriEnvVarV4 = 'ECS_CONTAINER_METADATA_URI_V4';
 
 async function inspect() {
-  let result = ['\n================\nInspecting Task Environment:\n'];
+  const result = ['\n================\nInspecting Task Environment:\n'];
   result.push(`Node.js version: ${process.versions.node}`);
 
   result.push('Inspecting: Amazon ECS container metadata file (opt-in)');

--- a/packages/aws-fargate/images/test-images/Dockerfile-alpine
+++ b/packages/aws-fargate/images/test-images/Dockerfile-alpine
@@ -21,4 +21,4 @@ ENV NODE_OPTIONS="--require /instana/node_modules/@instana/aws-fargate"
 
 EXPOSE 4816
 
-ENTRYPOINT [ "node", "." ]
+ENTRYPOINT [ "npm", "start" ]

--- a/packages/aws-fargate/images/test-images/Dockerfile-alpine-no-build-deps
+++ b/packages/aws-fargate/images/test-images/Dockerfile-alpine-no-build-deps
@@ -14,4 +14,4 @@ ENV NODE_OPTIONS="--require /instana/node_modules/@instana/aws-fargate"
 
 EXPOSE 4816
 
-ENTRYPOINT [ "node", "." ]
+ENTRYPOINT [ "npm", "start" ]

--- a/packages/aws-fargate/images/test-images/Dockerfile-standard
+++ b/packages/aws-fargate/images/test-images/Dockerfile-standard
@@ -17,4 +17,4 @@ ENV NODE_OPTIONS="--require /instana/node_modules/@instana/aws-fargate"
 
 EXPOSE 4816
 
-ENTRYPOINT [ "node", "." ]
+ENTRYPOINT [ "npm", "start" ]

--- a/packages/aws-fargate/src/activate.js
+++ b/packages/aws-fargate/src/activate.js
@@ -12,7 +12,7 @@ const { normalizeConfig } = coreUtil;
 
 let logger = consoleLogger;
 
-let config = normalizeConfig({});
+const config = normalizeConfig({});
 
 function init() {
   if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {

--- a/packages/aws-fargate/src/index.js
+++ b/packages/aws-fargate/src/index.js
@@ -1,10 +1,15 @@
 'use strict';
 
+const { util: coreUtil } = require('@instana/core');
 const { environment: environmentUtil } = require('@instana/serverless');
 
-environmentUtil.validate();
+let isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
 
-if (environmentUtil.isValid()) {
+if (!isExcludedFromInstrumentation) {
+  environmentUtil.validate();
+}
+
+if (!isExcludedFromInstrumentation && environmentUtil.isValid()) {
   module.exports = exports = require('./activate');
 } else {
   module.exports = exports = require('./noop');

--- a/packages/aws-fargate/src/index.js
+++ b/packages/aws-fargate/src/index.js
@@ -3,7 +3,7 @@
 const { util: coreUtil } = require('@instana/core');
 const { environment: environmentUtil } = require('@instana/serverless');
 
-let isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
+const isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
 
 if (!isExcludedFromInstrumentation) {
   environmentUtil.validate();

--- a/packages/aws-fargate/src/metrics/container/containerUtil.js
+++ b/packages/aws-fargate/src/metrics/container/containerUtil.js
@@ -5,7 +5,8 @@ exports.fullyQualifiedContainerId = function fullyQualifiedContainerId(taskArn, 
 };
 
 exports.dataForSecondaryContainer = function dataForSecondaryContainer(all, dockerId) {
-  let dataForThisContainer = all && all.Containers && all.Containers.find(container => container.DockerId === dockerId);
+  const dataForThisContainer =
+    all && all.Containers && all.Containers.find(container => container.DockerId === dockerId);
   return dataForThisContainer || {};
 };
 

--- a/packages/collector/dummy-app/package-lock.json
+++ b/packages/collector/dummy-app/package-lock.json
@@ -5,36 +5,36 @@
   "requires": true,
   "dependencies": {
     "@instana/autoprofile": {
-      "version": "1.100.1",
-      "resolved": "https://registry.npmjs.org/@instana/autoprofile/-/autoprofile-1.100.1.tgz",
-      "integrity": "sha512-IvCQsyUyN0nkfHbVwEYTtXw42+9DEcK72lLmHN7womrp33ehRnRevCWE/MuJxNaPgnTVbHpeDzVexGfbPw+MiQ==",
+      "version": "1.110.5",
+      "resolved": "https://registry.npmjs.org/@instana/autoprofile/-/autoprofile-1.110.5.tgz",
+      "integrity": "sha512-klGnLhHyP/gp8o8Oo/+P74g1vJHfiCXdlQOLY0LemCEFfLbHkR68DGy0Hm1ahPCpMa/37LzWSs5hE14VWf9Zzw==",
       "optional": true,
       "requires": {
+        "detect-libc": "^1.0.3",
         "nan": "^2.14.0",
-        "node-abi": "*",
+        "node-abi": "^2.19.1",
         "node-gyp": "^6.1.0"
       }
     },
     "@instana/collector": {
-      "version": "1.100.1",
-      "resolved": "https://registry.npmjs.org/@instana/collector/-/collector-1.100.1.tgz",
-      "integrity": "sha512-GhwpaiKoMq5Qb5oKfMJQBo531cMjq/U6HpSdM0i7bLtBSSx+Rk5IBj/YR+JDdXzHVMGaxsPxW2O08MUcn7Uk1A==",
+      "version": "1.110.5",
+      "resolved": "https://registry.npmjs.org/@instana/collector/-/collector-1.110.5.tgz",
+      "integrity": "sha512-jmyOUakmmbvjdxWWQsMB18xLicmQHxscw4+enkjwQU1+pHmrGkN748MuWoLOmCbqsV10mpkUe+Cmby/i0IfMlg==",
       "requires": {
-        "@instana/autoprofile": "^1.100.1",
-        "@instana/core": "^1.100.1",
-        "@instana/shared-metrics": "^1.100.1",
+        "@instana/autoprofile": "1.110.5",
+        "@instana/core": "1.110.5",
+        "@instana/shared-metrics": "1.110.5",
         "bunyan": "^1.8.12",
         "netlinkwrapper": "^1.2.0",
         "semver": "5.5.1",
         "serialize-error": "^2.1.0",
-        "shimmer": "1.2.0",
-        "v8-profiler-node8": "^6.2.0"
+        "shimmer": "1.2.0"
       }
     },
     "@instana/core": {
-      "version": "1.100.1",
-      "resolved": "https://registry.npmjs.org/@instana/core/-/core-1.100.1.tgz",
-      "integrity": "sha512-cHq//LYY/vftslkrCO6ElAqSP0sLdzNSqpA/DigK2z28u4X5/9EWHIipUF4K8a+6EyBXXccirXM5V33eYibq4A==",
+      "version": "1.110.5",
+      "resolved": "https://registry.npmjs.org/@instana/core/-/core-1.110.5.tgz",
+      "integrity": "sha512-d6XKwiaSlv2IFNBWAUhx0ng/R0i92RIMEBQCRtwbP2sMeRJcISCEvB2S9TF5Eqbe4L3/V1OXgZcYYvaMeWpMGg==",
       "requires": {
         "async-hook-jl": "^1.7.6",
         "cls-bluebird": "^2.1.0",
@@ -48,14 +48,169 @@
       }
     },
     "@instana/shared-metrics": {
-      "version": "1.100.1",
-      "resolved": "https://registry.npmjs.org/@instana/shared-metrics/-/shared-metrics-1.100.1.tgz",
-      "integrity": "sha512-A8HaUGiKoYRHiSCIqh5ryWpNQYv+m4NUXSWK8cMPyegWEh2DqzF2C5ERi+OZ69gVLS6yDhMYyRGEY3N30p4PDA==",
+      "version": "1.110.5",
+      "resolved": "https://registry.npmjs.org/@instana/shared-metrics/-/shared-metrics-1.110.5.tgz",
+      "integrity": "sha512-7zdBv/dcWaYVehcwrs1ZbhY3+np11kITobtA7N6J2WnbJ9YUKIxzhNlsBLhTy64MNdQSIej0CUWQb1CvCqqHqg==",
       "requires": {
-        "@instana/core": "^1.100.1",
+        "@instana/core": "1.110.5",
+        "detect-libc": "^1.0.3",
         "event-loop-lag": "^1.4.0",
         "event-loop-stats": "1.3.0",
-        "gcstats.js": "1.0.0"
+        "gcstats.js": "1.0.0",
+        "node-gyp": "^7.1.0",
+        "recursive-copy": "^2.0.11",
+        "tar": "^5.0.5"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "optional": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "optional": true
+        },
+        "node-gyp": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+          "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+          "optional": true,
+          "requires": {
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.3",
+            "nopt": "^5.0.0",
+            "npmlog": "^4.1.2",
+            "request": "^2.88.2",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.2",
+            "tar": "^6.0.2",
+            "which": "^2.0.2"
+          },
+          "dependencies": {
+            "tar": {
+              "version": "6.0.5",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+              "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+              "optional": true,
+              "requires": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+          "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+          "optional": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tar": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
+          "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
+          "requires": {
+            "chownr": "^1.1.3",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.0",
+            "mkdirp": "^0.5.0",
+            "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+              "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+            },
+            "mkdirp": {
+              "version": "0.5.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "optional": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "abbrev": {
@@ -106,10 +261,38 @@
         "readable-stream": "^2.0.6"
       }
     },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -150,8 +333,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "optional": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -211,19 +393,18 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "optional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "bunyan": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
+      "integrity": "sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==",
       "requires": {
         "dtrace-provider": "~0.8",
-        "moment": "^2.10.6",
+        "moment": "^2.19.3",
         "mv": "~2",
         "safe-json-stringify": "~1"
       }
@@ -270,8 +451,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "optional": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -316,19 +496,26 @@
       }
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "optional": true,
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "requires": {
         "ms": "^2.1.1"
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "optional": true
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -354,8 +541,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "dotenv": {
       "version": "5.0.1",
@@ -393,6 +579,11 @@
         "shimmer": "^1.2.0"
       }
     },
+    "emitter-mixin": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/emitter-mixin/-/emitter-mixin-0.0.3.tgz",
+      "integrity": "sha1-WUjLKG8uSO3DslGnz8H3iDOW1lw="
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -403,6 +594,14 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
       "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
       "optional": true
+    },
+    "errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -418,7 +617,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/event-loop-lag/-/event-loop-lag-1.4.0.tgz",
       "integrity": "sha512-uNAYTAexGyPI7rms2jSES20nhUoCtjkmxgaOcAfaoaOQ6h3q1+fw6d5MfyfV0zMJpR//+GUYPVXrh2Wbv+E0sQ==",
-      "optional": true,
       "requires": {
         "debug": "^3.1.0"
       }
@@ -576,8 +774,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "optional": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "gauge": {
       "version": "2.7.4",
@@ -616,7 +813,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "optional": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -626,11 +822,23 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "optional": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -689,20 +897,10 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "optional": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "optional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -711,14 +909,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "optional": true
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "optional": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -737,6 +928,27 @@
       "optional": true,
       "requires": {
         "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "requires": {
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -792,6 +1004,11 @@
         "verror": "1.10.0"
       }
     },
+    "junk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
+      "integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI="
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -803,6 +1020,17 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "maximatch": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
+      "integrity": "sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=",
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "media-typer": {
@@ -842,7 +1070,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "optional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -850,8 +1077,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "optional": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -876,22 +1102,20 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "optional": true,
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "optional": true
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "optional": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mv": {
       "version": "2.1.1",
@@ -929,9 +1153,9 @@
       }
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
     "ncp": {
@@ -940,44 +1164,33 @@
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
-    "needle": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
-      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
-      "optional": true,
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      }
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "netlinkwrapper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/netlinkwrapper/-/netlinkwrapper-1.2.0.tgz",
-      "integrity": "sha512-PtL6AeqUn9MhIrPutCAMWxG0mMK69yAcr70dVDUj1PvIwKU3qKR/2PeA7pchoJVZ8E5JO0BDAbGx/bRfC2nBLA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/netlinkwrapper/-/netlinkwrapper-1.2.1.tgz",
+      "integrity": "sha512-rh3hl2EPZOCC0ddEyJOQRb0bmJgAxuCW3dlhJFZ/V/pAQbLHyLy8TJ4EvS8aFOdUGJunvasepIuSDwgs2c37fA==",
       "optional": true,
       "requires": {
         "bindings": "1.5.0",
-        "nan": "2.14.0"
+        "nan": "2.14.1"
       },
       "dependencies": {
         "nan": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
           "optional": true
         }
       }
     },
     "node-abi": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
-      "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
       "optional": true,
       "requires": {
         "semver": "^5.4.1"
@@ -1010,24 +1223,6 @@
         }
       }
     },
-    "node-pre-gyp": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
-      "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
-      }
-    },
     "nopt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
@@ -1036,32 +1231,6 @@
       "requires": {
         "abbrev": "1",
         "osenv": "^0.1.4"
-      }
-    },
-    "npm-bundled": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-      "optional": true,
-      "requires": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-      "optional": true
-    },
-    "npm-packlist": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-      "optional": true,
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1",
-        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "npmlog": {
@@ -1090,8 +1259,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "optional": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -1105,15 +1273,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "optional": true,
       "requires": {
         "wrappy": "1"
       }
     },
     "opentracing": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.4.tgz",
-      "integrity": "sha512-nNnZDkUNExBwEpb7LZaeMeQgvrlO8l4bgY/LvGNZCR0xG/dGWqHqjKrAmR5GUoYo0FIz38kxasvA1aevxWs2CA=="
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.5.tgz",
+      "integrity": "sha512-XLKtEfHxqrWyF1fzxznsv78w3csW41ucHnjiKnfzZLD5FN8UBDZZL1i4q0FR29zjxXhm+2Hop+5Vr/b8tKIvEg=="
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -1145,8 +1312,12 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "optional": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -1158,11 +1329,37 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "optional": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -1172,6 +1369,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
       "version": "1.8.0",
@@ -1204,18 +1406,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "optional": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      }
-    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1231,10 +1421,27 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "recursive-copy": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.11.tgz",
+      "integrity": "sha512-DqL2kO10mUne7XK5BPcwRtOJJZKhddD7IrW4UmHmKrwdV3HLPWcw6Jr4Jh12ooddfJOVz7ynFoFYYnPM7De0Og==",
+      "requires": {
+        "del": "^2.2.0",
+        "emitter-mixin": "0.0.3",
+        "errno": "^0.1.2",
+        "graceful-fs": "^4.1.4",
+        "junk": "^1.0.1",
+        "maximatch": "^0.1.0",
+        "mkdirp": "^0.5.1",
+        "pify": "^2.3.0",
+        "promise": "^7.0.1",
+        "slash": "^1.0.0"
+      }
+    },
     "redis-commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
-      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
     },
     "request": {
       "version": "2.88.2",
@@ -1293,7 +1500,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "optional": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -1313,12 +1519,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "optional": true
     },
     "semver": {
       "version": "5.5.1",
@@ -1405,6 +1605,11 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "optional": true
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -1464,12 +1669,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "optional": true
     },
     "tar": {
       "version": "4.4.13",
@@ -1551,16 +1750,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
-    "v8-profiler-node8": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-6.2.0.tgz",
-      "integrity": "sha512-LfkC7i277+2EUZ0AzWV03ic09Kvd6cSs9c3A/XjhEu/QNFqpO2PqbSiJcN8dNR1aSa3in+jO8+vgj8Zjc77UPA==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.14.1",
-        "node-pre-gyp": "^0.13.0"
-      }
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1597,8 +1786,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "optional": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yallist": {
       "version": "3.1.1",

--- a/packages/collector/dummy-app/src/autoprofile.js
+++ b/packages/collector/dummy-app/src/autoprofile.js
@@ -14,7 +14,7 @@ const fs = require('fs');
 const http = require('http');
 
 function cpuWork(usage, duration) {
-  let usageTimer = setInterval(() => {
+  const usageTimer = setInterval(() => {
     for (let i = 0; i < usage * 300000; i++) {
       Math.random();
     }
@@ -47,16 +47,16 @@ function simulateMemLeak() {
     }
 
     for (let i = 0; i < 5000; i++) {
-      let obj1 = { v: Math.random() };
+      const obj1 = { v: Math.random() };
       mem1.push(obj1);
     }
   }, 1000);
 
   // 5 sec
   setInterval(() => {
-    let mem2 = [];
+    const mem2 = [];
     for (let i = 0; i < 500; i++) {
-      let obj2 = { v: Math.random() };
+      const obj2 = { v: Math.random() };
       mem2.push(obj2);
     }
   }, 5000);

--- a/packages/collector/src/immediate.js
+++ b/packages/collector/src/immediate.js
@@ -6,8 +6,8 @@ const { util: coreUtil } = require('@instana/core');
 // modifying the source code. See
 // https://www.instana.com/docs/ecosystem/node-js/installation#installation-without-modifying-the-source-code
 
-let excludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
+let isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
 
-if (!excludedFromInstrumentation) {
+if (!isExcludedFromInstrumentation) {
   require('./index')();
 }

--- a/packages/collector/src/immediate.js
+++ b/packages/collector/src/immediate.js
@@ -6,7 +6,7 @@ const { util: coreUtil } = require('@instana/core');
 // modifying the source code. See
 // https://www.instana.com/docs/ecosystem/node-js/installation#installation-without-modifying-the-source-code
 
-let isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
+const isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
 
 if (!isExcludedFromInstrumentation) {
   require('./index')();

--- a/packages/collector/src/immediate.js
+++ b/packages/collector/src/immediate.js
@@ -1,3 +1,13 @@
 'use strict';
 
-require('./index')();
+const { util: coreUtil } = require('@instana/core');
+
+// This file can be used with NODE_OPTIONS or `node --require` to instrument a Node.js app with Instana without
+// modifying the source code. See
+// https://www.instana.com/docs/ecosystem/node-js/installation#installation-without-modifying-the-source-code
+
+let excludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
+
+if (!excludedFromInstrumentation) {
+  require('./index')();
+}

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -209,7 +209,19 @@ class AgentStubControls {
     });
   }
 
-  async waitUntilAppIsCompletelyInitialized(pid) {
+  async waitUntilAppIsCompletelyInitialized(originalPid) {
+    let pid;
+    if (typeof originalPid === 'string') {
+      pid = parseInt(originalPid, 10);
+      if (isNaN(pid)) {
+        throw new Error(`PID has type string and cannot be parsed to a number: ${originalPid}`);
+      }
+    } else if (typeof originalPid === 'number') {
+      pid = originalPid;
+    } else {
+      throw new Error(`PID ${originalPid} has invalid type ${typeof originalPid}.`);
+    }
+
     await retry(() =>
       this.getReceivedData().then(data => {
         for (let i = 0, len = data.metrics.length; i < len; i++) {

--- a/packages/collector/test/apps/express.js
+++ b/packages/collector/test/apps/express.js
@@ -21,6 +21,8 @@ const path = require('path');
 const fs = require('fs');
 const app = express();
 
+const port = process.env.APP_PORT || 3215;
+
 const logPrefix = `Express App (${process.pid}):\t`;
 
 if (process.env.WITH_STDOUT) {
@@ -123,18 +125,18 @@ if (process.env.USE_HTTPS === 'true') {
       },
       app
     )
-    .listen(process.env.APP_PORT, () => {
-      log(`Listening (HTTPS!) on port: ${process.env.APP_PORT}`);
+    .listen(port, () => {
+      log(`Listening (HTTPS!) on port: ${port}`);
     });
 } else {
-  app.listen(process.env.APP_PORT, () => {
-    log(`Listening on port: ${process.env.APP_PORT}`);
+  app.listen(port, () => {
+    log(`Listening on port: ${port}`);
   });
 }
 
 function log() {
   const args = Array.prototype.slice.call(arguments);
-  args[0] = `Express App (${process.pid}):\t${args[0]}`;
+  args[0] = `${logPrefix} (${process.pid}):\t${args[0]}`;
   // eslint-disable-next-line no-console
   console.log.apply(console, args);
 }

--- a/packages/collector/test/immediate/app.js
+++ b/packages/collector/test/immediate/app.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// This application is deliberately not instrumented manually with require('@instana/collector'), it is meant to be used
+// with NODE_OPTIONS="--require ...".
+
+const express = require('express');
+const morgan = require('morgan');
+
+const app = express();
+
+const port = process.env.APP_PORT || 3215;
+
+const logPrefix = `Auto Attach (${process.pid}):\t`;
+
+if (process.env.WITH_STDOUT) {
+  app.use(morgan(`${logPrefix}:method :url :status`));
+}
+
+app.get('/', (req, res) => {
+  res.send('OK');
+});
+
+app.listen(port, () => {
+  log(`Listening on port: ${port}`);
+});
+
+function log() {
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `${logPrefix} (${process.pid}):\t${args[0]}`;
+  // eslint-disable-next-line no-console
+  console.log.apply(console, args);
+}

--- a/packages/collector/test/immediate/app.js
+++ b/packages/collector/test/immediate/app.js
@@ -20,6 +20,10 @@ app.get('/', (req, res) => {
   res.send('OK');
 });
 
+app.get('/pid', (req, res) => {
+  res.send(String(process.pid));
+});
+
 app.listen(port, () => {
   log(`Listening on port: ${port}`);
 });

--- a/packages/collector/test/immediate/package.json
+++ b/packages/collector/test/immediate/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "immediate",
+  "version": "1.0.0",
+  "description": "test application",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/instana/nodejs-sensor.git"
+  },
+  "main": "app",
+  "scripts": {
+    "start": "node ."
+  }
+}

--- a/packages/collector/test/immediate/test.js
+++ b/packages/collector/test/immediate/test.js
@@ -1,8 +1,12 @@
 'use strict';
 
 const { expect } = require('chai');
+const { spawn } = require('child_process');
+const _ = require('lodash');
+const request = require('request-promise');
 
 const config = require('../../../core/test/config');
+const { delay, retry } = require('../../../core/test/test_util');
 const ProcessControls = require('../test_util/ProcessControls');
 const globalAgent = require('../globalAgent');
 
@@ -28,6 +32,61 @@ describe('collector/src/immediate', function() {
       // Make sure the npm process did not report to the agent even after waiting for that to happen.
       const pidsThatContactedTheAgent = await agentControls.getDiscoveries();
       expect(pidsThatContactedTheAgent[controls.getPid()]).to.exist;
+    });
+  });
+
+  describe('exclude processes from auto instrumentation', () => {
+    let npmProcess;
+    let appUnderTestPid;
+
+    afterEach(() => {
+      if (npmProcess) {
+        npmProcess.kill();
+      }
+      if (appUnderTestPid) {
+        process.kill(appUnderTestPid);
+      }
+    });
+
+    it('should ignore npm but instrument the actual application', async () => {
+      const env = _.assign({}, process.env, {
+        NODE_OPTIONS: '--require ../../src/immediate',
+        INSTANA_AGENT_PORT: agentControls.agentPort,
+        INSTANA_LOG_LEVEL: 'info'
+      });
+
+      // Start a Node.js application via npm start, this will start two Node.js processes: npm and the actual
+      // application under test (as a child process of npm).
+      npmProcess = spawn('npm', ['start'], {
+        shell: true,
+        cwd: __dirname,
+        stdio: config.getAppStdio(),
+        env
+      });
+
+      // Wait until the application under test is up.
+      appUnderTestPid = await retry(() =>
+        request({
+          url: 'http://localhost:3215/pid',
+          method: 'GET',
+          headers: {
+            'X-INSTANA-L': '0'
+          }
+        })
+      );
+      const npmPid = npmProcess.pid;
+
+      // Make sure the application under test contacted the agent.
+      await agentControls.waitUntilAppIsCompletelyInitialized(appUnderTestPid);
+
+      // Also give the npm process time to report to the agent. (We expect it does not report to the agent but we do not
+      // want the test to pass only because it did not _yet_ report to the agent.)
+      await delay(500);
+
+      // Make sure the npm process did not report to the agent even after waiting for that to happen.
+      const pidsThatContactedTheAgent = await agentControls.getDiscoveries();
+      expect(pidsThatContactedTheAgent[appUnderTestPid]).to.exist;
+      expect(pidsThatContactedTheAgent[npmPid]).to.not.exist;
     });
   });
 });

--- a/packages/collector/test/immediate/test.js
+++ b/packages/collector/test/immediate/test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const config = require('../../../core/test/config');
+const ProcessControls = require('../test_util/ProcessControls');
+const globalAgent = require('../globalAgent');
+
+const agentControls = globalAgent.instance;
+
+describe('collector/src/immediate', function() {
+  globalAgent.setUpCleanUpHooks();
+
+  this.timeout(config.getTestTimeout());
+
+  describe('an application instrumented via NODE_OPTIONS', () => {
+    const controls = new ProcessControls({
+      useGlobalAgent: true,
+      dirname: __dirname,
+      cwd: __dirname,
+      env: {
+        NODE_OPTIONS: '--require ../../src/immediate'
+      }
+    });
+    ProcessControls.setUpHooks(controls);
+
+    it('should have connected to the agent', async () => {
+      // Make sure the npm process did not report to the agent even after waiting for that to happen.
+      const pidsThatContactedTheAgent = await agentControls.getDiscoveries();
+      expect(pidsThatContactedTheAgent[controls.getPid()]).to.exist;
+    });
+  });
+});

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -76,6 +76,8 @@ class ProcessControls {
 
     // absolute path to .js file that should be executed
     this.appPath = opts.appPath;
+    // optional working directory for the child process
+    this.cwd = opts.cwd;
     // for scenarios where the app under tests terminates on its own
     this.dontKillInAfterHook = opts.dontKillInAfterHook;
     // arguments for the app under test
@@ -150,6 +152,9 @@ class ProcessControls {
       stdio: config.getAppStdio(),
       env: this.env
     };
+    if (this.cwd) {
+      forkConfig.cwd = this.cwd;
+    }
 
     this.process = this.args ? fork(this.appPath, this.args, forkConfig) : fork(this.appPath, forkConfig);
 

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -105,7 +105,7 @@ class ProcessControls {
     if (!this.agentControls && this.useGlobalAgent) {
       this.agentControls = globalAgent.instance;
     }
-    let agentPort = this.agentControls ? this.agentControls.agentPort : undefined;
+    const agentPort = this.agentControls ? this.agentControls.agentPort : undefined;
 
     this.env = _.assign(
       {},

--- a/packages/collector/test/test_util/http2Promise.js
+++ b/packages/collector/test/test_util/http2Promise.js
@@ -42,8 +42,7 @@ exports.request = function request(opts) {
   }
 
   return new Promise((resolve, reject) => {
-    let client;
-    client = http2.connect(baseUrl, {
+    const client = http2.connect(baseUrl, {
       ca: cert
     });
 

--- a/packages/collector/test/tracing/database/mongodb/app.js
+++ b/packages/collector/test/tracing/database/mongodb/app.js
@@ -210,7 +210,7 @@ app.post('/long-find', (req, res) => {
 });
 
 app.get('/findall', (req, res) => {
-  let filter = {};
+  const filter = {};
   if (req.query && req.query.unique) {
     filter.unique = req.query.unique;
   }

--- a/packages/collector/test/tracing/logger/log4js/app.js
+++ b/packages/collector/test/tracing/logger/log4js/app.js
@@ -43,7 +43,7 @@ app.post('/log', (req, res) => {
   const useLogMethod = query.useLogMethod === 'true';
 
   let method = null;
-  let args = [];
+  const args = [];
 
   if (useLogMethod) {
     method = logger.log;

--- a/packages/collector/test/tracing/logger/winston/app.js
+++ b/packages/collector/test/tracing/logger/winston/app.js
@@ -52,7 +52,7 @@ app.get('/log', (req, res) => {
 
   let context = null;
   let method = null;
-  let args = [];
+  const args = [];
 
   if (useGlobalLogger) {
     context = winston;

--- a/packages/collector/test/tracing/messaging/kafkajs/consumer.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/consumer.js
@@ -94,7 +94,7 @@ let receivedMessages = [];
 
       try {
         for (let i = 0; i < batch.messages.length; i++) {
-          let message = batch.messages[i];
+          const message = batch.messages[i];
           if (runAsStandAlone) {
             log(
               'batch message',

--- a/packages/collector/test/tracing/misc/restore_context/test.js
+++ b/packages/collector/test/tracing/misc/restore_context/test.js
@@ -36,7 +36,7 @@ mochaSuiteFn('tracing/restore context', function() {
     describe('restore context', function() {
       it(//
       `must capture spans after async context loss when context is manually restored (${apiVariant}))`, () => {
-        let url = `/${apiVariant}`;
+        const url = `/${apiVariant}`;
         return controls
           .sendRequest({
             method: 'POST',

--- a/packages/collector/test/tracing/misc/w3c_trace_context/app.js
+++ b/packages/collector/test/tracing/misc/w3c_trace_context/app.js
@@ -49,7 +49,7 @@ if (!downstreamPort) {
   throw new Error('DOWNSTREAM_PORT is mandatory for this app.');
 }
 
-let server = require('http')
+const server = require('http')
   .createServer()
   .listen(port, () => {
     log(`Listening  on port: ${port}`);

--- a/packages/core/src/tracing/instrumentation/database/elasticsearchModern.js
+++ b/packages/core/src/tracing/instrumentation/database/elasticsearchModern.js
@@ -321,7 +321,7 @@ function instrumentedRequest(ctx, origEsReq, originalArgs) {
 
   // normalize arguments
   let params = originalArgs[0] || {};
-  let options = originalArgs[1];
+  const options = originalArgs[1];
   let callbackIndex = 2;
   let originalCallback = originalArgs[callbackIndex];
   if (typeof originalCallback !== 'function') {
@@ -392,7 +392,7 @@ function findActionInStack(span) {
   if (esApiFrames.length === 0) {
     return;
   }
-  let esApiMethod = esApiFrames[esApiFrames.length - 1].m;
+  const esApiMethod = esApiFrames[esApiFrames.length - 1].m;
   if (!esApiMethod) {
     return;
   }

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -55,7 +55,7 @@ const batchBucketWidth = 18;
 // rare, we omit the check, trading better perfomance for a few missed batch opportunities (if any).
 //
 // The batchingBuckets are cleared once the span buffer is flushed downstream.
-let batchingBuckets = new Map();
+const batchingBuckets = new Map();
 
 exports.init = function init(config, _downstreamConnection) {
   downstreamConnection = _downstreamConnection;
@@ -146,7 +146,7 @@ function addToBatch(span) {
   // we check the span's own bucket and the previous bucket.
   const bucketsForTrace = batchingBuckets.get(span.t);
   const key = batchingBucketKey(span);
-  let hasBeenBatched = findBatchPartnerAndMerge(span, bucketsForTrace, key);
+  const hasBeenBatched = findBatchPartnerAndMerge(span, bucketsForTrace, key);
   if (hasBeenBatched) {
     return true;
   }

--- a/packages/core/src/util/clone.js
+++ b/packages/core/src/util/clone.js
@@ -20,7 +20,7 @@ module.exports = function clone(x) {
     r = {};
 
     // eslint-disable-next-line no-restricted-syntax
-    for (let key in x) {
+    for (const key in x) {
       // eslint-disable-next-line no-prototype-builtins
       if (x.hasOwnProperty(key)) {
         r[key] = clone(x[key]);

--- a/packages/core/src/util/excludedFromInstrumentation.js
+++ b/packages/core/src/util/excludedFromInstrumentation.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// If a process is started with `npm start` or `yarn start`, two separate processes will be started. The first is
+// `node /path/to/npm` (or `node /path/to/yarn`). This process will kick off another process with the actual application
+// (for example, `node /usr/src/app`). When
+// NODE_OPTIONS="--require /usr/src/app/node_modules/@instana/collector/src/immediate" is set, we would instrument both
+// processes, that is, npm/yarn as well as the actual application. Attempting to instrument the npm or yarn process has
+// no value and also creates confusing log output, so we exclude them here explicitly.
+const excludeList = [
+  // Patterns that will prohibit instrumentation:
+  /^.*\/npm/,
+  /^.*\/yarn/
+];
+
+module.exports = exports = function isExcludedFromInstrumentation() {
+  let excludedFromInstrumentation = false;
+  if (process.argv && typeof process.argv[1] === 'string') {
+    excludeList.forEach(pattern => {
+      if (pattern.test(process.argv[1])) {
+        excludedFromInstrumentation = true;
+      }
+    });
+  }
+
+  if (excludedFromInstrumentation) {
+    const logLevelIsDebugOrInfo =
+      process.env.INSTANA_DEBUG ||
+      (process.env.INSTANA_LOG_LEVEL &&
+        (process.env.INSTANA_LOG_LEVEL.toLowerCase() === 'info' ||
+          process.env.INSTANA_LOG_LEVEL.toLowerCase() === 'debug'));
+
+    if (logLevelIsDebugOrInfo) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[Instana] INFO: Not instrumenting process ${process.pid}: ${process.argv[0]} ${process.argv[1]}` +
+          ' - this Node.js process seems to be npm or yarn. A child process started via "npm start" or "yarn start" ' +
+          '_will_ be instrumented, but not npm or yarn itself.'
+      );
+    }
+  }
+
+  return excludedFromInstrumentation;
+};

--- a/packages/core/src/util/excludedFromInstrumentation.js
+++ b/packages/core/src/util/excludedFromInstrumentation.js
@@ -6,21 +6,11 @@
 // NODE_OPTIONS="--require /usr/src/app/node_modules/@instana/collector/src/immediate" is set, we would instrument both
 // processes, that is, npm/yarn as well as the actual application. Attempting to instrument the npm or yarn process has
 // no value and also creates confusing log output, so we exclude them here explicitly.
-const excludeList = [
-  // Patterns that will prohibit instrumentation:
-  /^.*\/npm/,
-  /^.*\/yarn/
-];
+const excludePattern = /^.*\/(yarn|npm)$/i;
 
 module.exports = exports = function isExcludedFromInstrumentation() {
-  let excludedFromInstrumentation = false;
-  if (process.argv && typeof process.argv[1] === 'string') {
-    excludeList.forEach(pattern => {
-      if (pattern.test(process.argv[1])) {
-        excludedFromInstrumentation = true;
-      }
-    });
-  }
+  const excludedFromInstrumentation =
+    process.argv && typeof process.argv[1] === 'string' && excludePattern.test(process.argv[1]);
 
   if (excludedFromInstrumentation) {
     const logLevelIsDebugOrInfo =

--- a/packages/core/src/util/index.js
+++ b/packages/core/src/util/index.js
@@ -6,6 +6,7 @@ module.exports = exports = {
   buffer: require('./buffer'),
   clone: require('./clone'),
   compression: require('./compression'),
+  excludedFromInstrumentation: require('./excludedFromInstrumentation'),
   hasThePackageBeenInitializedTooLate: require('./initializedTooLateHeuristic'),
   normalizeConfig: require('./normalizeConfig'),
   propertySizes: require('./propertySizes'),

--- a/packages/google-cloud-run/images/inspector/index.js
+++ b/packages/google-cloud-run/images/inspector/index.js
@@ -12,7 +12,7 @@ const app = new http.Server();
 const port = process.env.PORT || 8080;
 
 async function inspect() {
-  let result = ['\n================\nInspecting Container Instance Environment:\n'];
+  const result = ['\n================\nInspecting Container Instance Environment:\n'];
   result.push(`Node.js version: ${process.versions.node}`);
   const envVars = ['HOSTNAME', 'PORT', 'K_SERVICE', 'K_REVISION', 'K_CONFIGURATION'];
   for (let i = 0; i < envVars.length; i++) {

--- a/packages/google-cloud-run/images/test-images/Dockerfile-alpine
+++ b/packages/google-cloud-run/images/test-images/Dockerfile-alpine
@@ -21,4 +21,4 @@ ENV NODE_OPTIONS="--require /instana/node_modules/@instana/google-cloud-run"
 
 EXPOSE 4816
 
-ENTRYPOINT [ "node", "." ]
+ENTRYPOINT [ "npm", "start" ]

--- a/packages/google-cloud-run/images/test-images/Dockerfile-standard
+++ b/packages/google-cloud-run/images/test-images/Dockerfile-standard
@@ -17,4 +17,4 @@ ENV NODE_OPTIONS="--require /instana/node_modules/@instana/google-cloud-run"
 
 EXPOSE 4816
 
-ENTRYPOINT [ "node", "." ]
+ENTRYPOINT [ "npm", "start" ]

--- a/packages/google-cloud-run/src/activate.js
+++ b/packages/google-cloud-run/src/activate.js
@@ -11,7 +11,7 @@ const { normalizeConfig } = coreUtil;
 
 let logger = consoleLogger;
 
-let config = normalizeConfig({});
+const config = normalizeConfig({});
 
 function init() {
   if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {

--- a/packages/google-cloud-run/src/index.js
+++ b/packages/google-cloud-run/src/index.js
@@ -1,10 +1,15 @@
 'use strict';
 
+const { util: coreUtil } = require('@instana/core');
 const { environment: environmentUtil } = require('@instana/serverless');
 
-environmentUtil.validate();
+let isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
 
-if (environmentUtil.isValid()) {
+if (!isExcludedFromInstrumentation) {
+  environmentUtil.validate();
+}
+
+if (!isExcludedFromInstrumentation && environmentUtil.isValid()) {
   module.exports = exports = require('./activate');
 } else {
   module.exports = exports = require('./noop');

--- a/packages/google-cloud-run/src/index.js
+++ b/packages/google-cloud-run/src/index.js
@@ -3,7 +3,7 @@
 const { util: coreUtil } = require('@instana/core');
 const { environment: environmentUtil } = require('@instana/serverless');
 
-let isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
+const isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
 
 if (!isExcludedFromInstrumentation) {
   environmentUtil.validate();

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -11,7 +11,7 @@ const tar = require('tar');
 const { fork } = require('child_process');
 const detectLibc = require('detect-libc');
 
-let retryMechanisms = [];
+const retryMechanisms = [];
 if (!process.env.INSTANA_DEV_DISABLE_PRECOMPILED_NATIVE_ADDONS) {
   retryMechanisms.push('copy-precompiled');
 }


### PR DESCRIPTION
If a process is started with `npm start` or `yarn start`, two separate
Node.js processes will be started. The first is `node /path/to/npm`
(or `node /path/to/yarn`). This process will kick off another process
with the actual application (for example, `node /usr/src/app`).

With this change, even when NODE_OPTIONS is set to
"--require /usr/src/app/node_modules/@instana/collector/src/immediate",
only the actual application will be instrumented, but not the npm/yarn
process.