### PR TITLE
fix(tracing): avoid false positive warning about initializing too late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Avoid false positive warning about @instana/core being initialized too late in the presence of other instrumentation packages that need to be loaded before everything else.
+
 ## 1.111.0:
 - Do not instrument npm or yarn when started via @instana/collector/src/immediate (instead, only instrument the child process started by npm start or yarn start).
 - Do not instrument npm or yarn on AWS Fargate (instead, only instrument the child process started by npm start or yarn start).

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -23,6 +23,7 @@ exports.registerAdditionalInstrumentations = function registerAdditionalInstrume
 
 exports.preInit = function preInit() {
   var preliminaryConfig = normalizeConfig();
+  exports.util.hasThePackageBeenInitializedTooLate();
   exports.util.requireHook.init(preliminaryConfig);
   exports.tracing.preInit(preliminaryConfig);
 };


### PR DESCRIPTION
Users that also use the package `@contrast/agent` (for example, by starting their app via `node -r @contrast/agent ...`) would see the warning 

>  It seems you have initialized the @instana/collector package too late. Please check our documentation on that, in particular https://www.instana.com/docs/ecosystem/node-js/installation/#installing-the-nodejs-collector-package and https://www.instana.com/docs/ecosystem/node-js/installation/#common-pitfalls. Tracing might only work partially with this setup, that is, some calls will not be captured.

We can be a bit smarter about this and avoid this warning heuristically: If we see that `@contrast/agent` has been loaded, we can exclude the packages that `@contrast/agent` loads from our check.