### PR TITLE
feat(metrics): rebuilding native add-ons via node-gyp as opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Instrument MongoDB native driver unified topology.
+- Add configuration mechanism to disable copying of precompiled add-ons (`INSTANA_COPY_PRECOMPILED_NATIVE_ADDONS=false`).
+- Make rebuilding native add-ons via node-gyp an opt-in feature (it is off by default now, use `INSTANA_REBUILD_NATIVE_ADDONS_ON_DEMAND=true` to enable it).
 
 ## 1.112.1
 - Improve heuristic to detect npm or yarn.

--- a/packages/collector/test/nativeModuleRetry/test.js
+++ b/packages/collector/test/nativeModuleRetry/test.js
@@ -100,10 +100,8 @@ describe('retry loading native addons', function() {
     const controls = new ProcessControls({
       appPath: path.join(__dirname, 'app'),
       agentControls,
-      useGlobalAgent: true,
-      env: {
-        INSTANA_DEV_DISABLE_REBUILD_NATIVE_ADDONS: 'true'
-      }
+      useGlobalAgent: true
+      // by default, only copying precompiled binaries is enabled and recompiling them on demand is not
     }).registerTestHooks();
 
     metricAddonsTestConfigs.forEach(
@@ -117,7 +115,8 @@ describe('retry loading native addons', function() {
       appPath: path.join(__dirname, 'app'),
       useGlobalAgent: true,
       env: {
-        INSTANA_DEV_DISABLE_PRECOMPILED_NATIVE_ADDONS: 'true'
+        INSTANA_COPY_PRECOMPILED_NATIVE_ADDONS: 'false',
+        INSTANA_REBUILD_NATIVE_ADDONS_ON_DEMAND: 'true'
       }
     }).registerTestHooks();
 

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -17,10 +17,16 @@ const { fork } = require('child_process');
 const detectLibc = require('detect-libc');
 
 const retryMechanisms = [];
-if (!process.env.INSTANA_DEV_DISABLE_PRECOMPILED_NATIVE_ADDONS) {
+if (
+  !process.env.INSTANA_COPY_PRECOMPILED_NATIVE_ADDONS ||
+  process.env.INSTANA_COPY_PRECOMPILED_NATIVE_ADDONS.toLowerCase() !== 'false'
+) {
   retryMechanisms.push('copy-precompiled');
 }
-if (!process.env.INSTANA_DEV_DISABLE_REBUILD_NATIVE_ADDONS) {
+if (
+  process.env.INSTANA_REBUILD_NATIVE_ADDONS_ON_DEMAND &&
+  process.env.INSTANA_REBUILD_NATIVE_ADDONS_ON_DEMAND.toLowerCase() === 'true'
+) {
   retryMechanisms.push('rebuild');
 }
 


### PR DESCRIPTION
This feature has been on by default previously and is now off by default
and needs to be enabled explicitly via
`INSTANA_REBUILD_NATIVE_ADDONS_ON_DEMAND=true`.

This also adds an option to disable copying precompiled native add-ons
(via `INSTANA_COPY_PRECOMPILED_NATIVE_ADDONS=false`).