### PR TITLE
fix(sdk): run original fn in SDK wrappers when tracing is not active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- fix: run original function in runInAsyncContext/runPromiseInAsyncContext when tracing is not active.
+
 ## 1.113.0
 - Instrument MongoDB native driver unified topology.
 - Add configuration mechanism to disable copying of precompiled add-ons (`INSTANA_COPY_PRECOMPILED_NATIVE_ADDONS=false`).

--- a/packages/collector/test/tracing/misc/restore_context/app.js
+++ b/packages/collector/test/tracing/misc/restore_context/app.js
@@ -34,7 +34,7 @@ app.post('/run', (req, res) => {
   customCallbackQueue.push(() => {
     instana.sdk.runInAsyncContext(activeContext, () => {
       pino.warn('Should be traced.');
-      return res.sendStatus(200);
+      return res.send('Done! ✅');
     });
   });
 });
@@ -47,17 +47,23 @@ app.post('/run-promise', (req, res) => {
 app.post('/enter-and-leave', (req, res) => {
   const activeContext = instana.sdk.getAsyncContext();
   customCallbackQueue.push(() => {
-    instana.core.tracing.getCls().enterAsyncContext(activeContext);
+    // enter/exit async context is not exposed via the SDK
+    // We are testing it here for completeness sake, not because sdk client code can/should actually use it.
+    if (instana.core.tracing.getCls()) {
+      instana.core.tracing.getCls().enterAsyncContext(activeContext);
+    }
     pino.warn('Should be traced.');
-    res.sendStatus(200);
-    instana.core.tracing.getCls().leaveAsyncContext(activeContext);
+    res.send('Done! ✅');
+    if (instana.core.tracing.getCls()) {
+      instana.core.tracing.getCls().leaveAsyncContext(activeContext);
+    }
   });
 });
 
 function createPromise(res) {
   return new Promise(resolve => {
     pino.warn('Should be traced.');
-    res.sendStatus(200);
+    res.send('Done! ✅');
     resolve();
   });
 }

--- a/packages/collector/test/tracing/misc/restore_context/test.js
+++ b/packages/collector/test/tracing/misc/restore_context/test.js
@@ -10,7 +10,7 @@ const expect = require('chai').expect;
 const constants = require('@instana/core').tracing.constants;
 const supportedVersion = require('@instana/core').tracing.supportedVersion;
 const config = require('../../../../../core/test/config');
-const testUtils = require('../../../../../core/test/test_util');
+const { delay, expectAtLeastOneMatching, retry } = require('../../../../../core/test/test_util');
 const ProcessControls = require('../../../test_util/ProcessControls');
 const globalAgent = require('../../../globalAgent');
 
@@ -23,53 +23,87 @@ mochaSuiteFn('tracing/restore context', function() {
 
   globalAgent.setUpCleanUpHooks();
 
-  const controls = new ProcessControls({
-    dirname: __dirname,
-    useGlobalAgent: true,
-    port: 3222
+  describe('tracing enabled', () => {
+    const controls = new ProcessControls({
+      dirname: __dirname,
+      useGlobalAgent: true,
+      port: 3222
+    });
+    ProcessControls.setUpHooks(controls);
+    registerAllTests(controls, true);
   });
-  ProcessControls.setUpHooks(controls);
 
-  [
-    //
-    'run',
-    'run-promise',
-    'enter-and-leave'
-  ].forEach(apiVariant => registerSuite(apiVariant));
+  describe('tracing disabled', () => {
+    const controls = new ProcessControls({
+      dirname: __dirname,
+      useGlobalAgent: true,
+      tracingEnabled: false,
+      port: 3222
+    });
+    ProcessControls.setUpHooks(controls);
+    registerAllTests(controls, false);
+  });
 
-  function registerSuite(apiVariant) {
-    describe('restore context', function() {
-      it(//
-      `must capture spans after async context loss when context is manually restored (${apiVariant}))`, () => {
+  function registerAllTests(controls, tracingEnabled) {
+    [
+      //
+      'run',
+      'run-promise',
+      'enter-and-leave'
+    ].forEach(apiVariant => registerTest(controls, tracingEnabled, apiVariant));
+  }
+
+  function registerTest(controls, tracingEnabled, apiVariant) {
+    it(
+      `must capture spans after async context loss when context is manually restored (${apiVariant}, tracing ` +
+        `enabled: ${tracingEnabled}))`,
+      () => {
         const url = `/${apiVariant}`;
         return controls
           .sendRequest({
             method: 'POST',
             path: url
           })
-          .then(() => verify(url));
-      });
+          .then(response => verify(url, response, tracingEnabled));
+      }
+    );
+  }
+
+  function verify(url, response, tracingEnabled) {
+    expect(response).to.equal('Done! ✅');
+    if (tracingEnabled) {
+      return verifySpans(url);
+    } else {
+      return verifyNoSpans();
+    }
+  }
+
+  function verifySpans(url) {
+    return retry(() =>
+      agentControls.getSpans().then(spans => {
+        const httpEntry = expectAtLeastOneMatching(spans, [
+          span => expect(span.n).to.equal('node.http.server'),
+          span => expect(span.k).to.equal(constants.ENTRY),
+          span => expect(span.p).to.not.exist,
+          span => expect(span.data.http.method).to.equal('POST'),
+          span => expect(span.data.http.url).to.equal(url)
+        ]);
+
+        expectAtLeastOneMatching(spans, [
+          span => expect(span.n).to.equal('log.pino'),
+          span => expect(span.k).to.equal(constants.EXIT),
+          span => expect(span.p).to.equal(httpEntry.s),
+          span => expect(span.data.log.message).to.equal('Should be traced.')
+        ]);
+      })
+    );
+  }
+
+  function verifyNoSpans() {
+    return retry(async () => {
+      await delay(500);
+      const spans = await agentControls.getSpans();
+      expect(spans.length).to.equal(0);
     });
   }
 });
-
-function verify(url) {
-  return testUtils.retry(() =>
-    agentControls.getSpans().then(spans => {
-      const httpEntry = testUtils.expectAtLeastOneMatching(spans, [
-        span => expect(span.n).to.equal('node.http.server'),
-        span => expect(span.k).to.equal(constants.ENTRY),
-        span => expect(span.p).to.not.exist,
-        span => expect(span.data.http.method).to.equal('POST'),
-        span => expect(span.data.http.url).to.equal(url)
-      ]);
-
-      testUtils.expectAtLeastOneMatching(spans, [
-        span => expect(span.n).to.equal('log.pino'),
-        span => expect(span.k).to.equal(constants.EXIT),
-        span => expect(span.p).to.equal(httpEntry.s),
-        span => expect(span.data.log.message).to.equal('Should be traced.')
-      ]);
-    })
-  );
-}

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -217,7 +217,7 @@ exports.leaveAsyncContext = function leaveAsyncContext(context) {
 
 exports.runInAsyncContext = function runInAsyncContext(context, fn) {
   if (!exports.ns) {
-    return null;
+    return fn();
   }
   if (context == null) {
     logger.warn('Ignoring runInAsyncContext call because passed context was null or undefined.');
@@ -228,7 +228,7 @@ exports.runInAsyncContext = function runInAsyncContext(context, fn) {
 
 exports.runPromiseInAsyncContext = function runPromiseInAsyncContext(context, fn) {
   if (!exports.ns) {
-    return null;
+    return fn();
   }
   if (context == null) {
     logger.warn('Ignoring runPromiseInAsyncContext call because passed context was null or undefined.');

--- a/packages/core/src/tracing/sdk/index.js
+++ b/packages/core/src/tracing/sdk/index.js
@@ -50,7 +50,7 @@ exports.getAsyncContext = function getAsyncContext() {
  */
 exports.runInAsyncContext = function runInAsyncContext(context, fn) {
   if (!cls) {
-    return;
+    return fn();
   }
   cls.runInAsyncContext(context, fn);
 };
@@ -68,7 +68,7 @@ exports.runInAsyncContext = function runInAsyncContext(context, fn) {
  */
 exports.runPromiseInAsyncContext = function runPromiseInAsyncContext(context, fn) {
   if (!cls) {
-    return null;
+    return fn();
   }
   return cls.runPromiseInAsyncContext(context, fn);
 };


### PR DESCRIPTION
This applies to runInAsyncContext, runPromiseInAsyncContext.