### PR TITLE
fix(lambda): fix timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Add instrumentation for AWS S3.
 - Update handling of W3C trace context headers to improve integration with OpenTelemetry.
+- [AWS Lambda] Fix timeouts when the Lambda callback API without `context.callbackWaitsForEmptyEventLoop = false` is used and the Instana back end responds too slowly.
 
 ## 1.114.0
 - Introduction of AWS SQS instrumentation for sending and reading messages.


### PR DESCRIPTION
Lambda functions would previously time out when
(a) the Lambda callback API was used,
(b) `context.callbackWaitsForEmptyEventLoop = false` was not set, and
(c) the Instana back end responded too slowly.

The reason was that the HTTP request to the back end was still pending
and thus the event loop was not empty. Destroying the request manually
fixes this.