### PR TITLE
fixed false positive test

### DIFF
--- a/packages/collector/test/tracing/cloud/aws/s3/app.js
+++ b/packages/collector/test/tracing/cloud/aws/s3/app.js
@@ -93,7 +93,7 @@ const S3Api = {
       if (!options) {
         options = {};
       }
-      options.Key = '999';
+      options.InvalidS3Key = '999';
     }
 
     return new Promise(async (resolve, reject) => {

--- a/packages/collector/test/tracing/cloud/aws/s3/test.js
+++ b/packages/collector/test/tracing/cloud/aws/s3/test.js
@@ -47,7 +47,7 @@ if (!supportedVersion(process.versions.node)) {
 
 const retryTime = config.getTestTimeout() * 2;
 
-mochaSuiteFn.only('tracing/cloud/aws/s3', function() {
+mochaSuiteFn('tracing/cloud/aws/s3', function() {
   this.timeout(config.getTestTimeout() * 3);
 
   globalAgent.setUpCleanUpHooks();


### PR DESCRIPTION
I changed the way that the tests should fail when testing calls with error by adding a non existent key into the S3 parameters.
Also removed `.only` that should not have been pushed upstream.