### PR TITLE
fix(metrics): register gc stats loader listener immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix garbage collection metrics being reported falsely as not supported when `node_modules/gcstats.js` exists.
+
 ## 1.117.2
 - Do not assume type local by default for OpenTracing spans. Instead, assume type entry when no parent context is available and only assume local if a parent context is available.
 - Update to shimmer@1.2.1.

--- a/packages/collector/test/metrics/app/test.js
+++ b/packages/collector/test/metrics/app/test.js
@@ -65,6 +65,10 @@ describe('snapshot data and metrics', function() {
         expect(findMetric(allMetrics, ['gc', 'minorGcs'])).to.exist;
         expect(findMetric(allMetrics, ['gc', 'majorGcs'])).to.exist;
 
+        const gc = aggregated.gc;
+        expect(gc).to.be.an('object');
+        expect(gc.statsSupported).to.be.true;
+
         expect(findMetric(allMetrics, ['healthchecks'])).to.exist;
         expect(findMetric(allMetrics, ['heapSpaces'])).to.exist;
         expect(findMetric(allMetrics, ['http'])).to.exist;

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -25,11 +25,11 @@ const nativeModuleLoader = require('./util/nativeModuleRetry')({
     'https://www.instana.com/docs/ecosystem/node-js/installation/#native-addons'
 });
 
-nativeModuleLoader.on('loaded', eventLoopStats_ => {
+nativeModuleLoader.once('loaded', eventLoopStats_ => {
   eventLoopStats = eventLoopStats_;
 });
 
-nativeModuleLoader.on('failed', () => {
+nativeModuleLoader.once('failed', () => {
   exports.currentPayload.statsSupported = false;
 });
 


### PR DESCRIPTION
This fixes an issue where GC metrics would not be available when the
dependency gcstats.js was already present in node_modules and the
activation of the gc metrics module would happen too late.