### PR TITLE
Instrumenting sqs-consumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17407,6 +17407,32 @@
       "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=",
       "dev": true
     },
+    "sqs-consumer": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-5.5.0.tgz",
+      "integrity": "sha512-vzKzOZlZtZarOWbg/nbEoMyNu64XnQ4QB3e74nMBNaIuM/RhelUGNGrvrB83IW6a7/DxKDulM46h2TeQP3/1nA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "rimraf": "^3.0.0",
     "sequelize": "^5.21.3",
     "sinon": "^7.2.4",
+    "sqs-consumer": "5.5.0",
     "superagent": "^5.3.1",
     "tar": "^6.0.5",
     "typescript": "^4.1.4",

--- a/packages/collector/test/tracing/cloud/aws/sqs/sqs-consumer.js
+++ b/packages/collector/test/tracing/cloud/aws/sqs/sqs-consumer.js
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2021
+ */
+
+'use strict';
+
+const instana = require('../../../../../src')();
+const express = require('express');
+const AWS = require('aws-sdk');
+const { Consumer } = require('sqs-consumer');
+const request = require('request-promise');
+const { sendToParent } = require('../../../../../../core/test/test_util');
+const delay = require('../../../../../../core/test/test_util/delay');
+
+AWS.config.update({ region: 'us-east-2' });
+const port = process.env.APP_RECEIVER_PORT || 3216;
+const agentPort = process.env.INSTANA_AGENT_PORT || 80;
+const app = express();
+
+const queueURL = process.env.AWS_SQS_QUEUE_URL;
+const logPrefix = `AWS SQS Consumer API (${process.pid}):\t`;
+let hasStartedPolling = false;
+
+function log() {
+  /* eslint-disable no-console */
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `${logPrefix}${args[0]}`;
+  console.log.apply(console, args);
+  /* eslint-enable no-console */
+}
+
+const sqs = new AWS.SQS();
+
+const consumerApp = Consumer.create({
+  queueUrl: queueURL,
+  sqs,
+  handleMessage: async message => {
+    sendToParent(message);
+    await delay(200);
+    await request(`http://localhost:${agentPort}?msg=${message.Body}`);
+    log(`Sent an HTTP request after receiving message of id ${message.MessageId}`);
+  }
+});
+
+app.get('/', (_req, res) => {
+  if (hasStartedPolling) {
+    res.send('OK');
+  } else {
+    res.status(500).send('Not ready yet.');
+  }
+});
+
+app.listen(port, () => {
+  log(`App started at port ${port}`);
+});
+
+async function startPollingWhenReady() {
+  // Make sure we are connected to the agent before calling sqs.receiveMessage for the first time.
+  if (instana.isConnected()) {
+    consumerApp.start();
+    hasStartedPolling = true;
+  } else {
+    await delay(50);
+    setImmediate(startPollingWhenReady);
+  }
+}
+
+startPollingWhenReady();


### PR DESCRIPTION
We are adding extra SQS instrumentation by instrumenting https://github.com/BBC/sqs-consumer.
Our SQS instrumentation requires some manual work when it comes to receive messages.
SQS-Consumer lib abstracts the polling/reading/deleting messages which is exactly where this manual code should be added, and by instrumenting the library we allow customers to safely use sqs-consumer and still get a proper trace and correlation between spans.