### PR TITLE
fix(tracing): fix TypeError in @elastic/elasticsearch instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Instrument `sqs-consumer` to capture exit child spans of SQS entries correctly.
+- Add additional check in instrumentation for `@elastic/elasticsearch` to fix TypeError when no action is present.
 
 ## 1.119.2
 - [AWS Fargate]: Fix secrets filtering for environment variables.

--- a/packages/core/src/tracing/instrumentation/database/elasticsearchModern.js
+++ b/packages/core/src/tracing/instrumentation/database/elasticsearchModern.js
@@ -219,7 +219,7 @@ function processParams(span, params) {
     span.data.elasticsearch.index = toStringEsMultiParameter(params.index);
     span.data.elasticsearch.type = toStringEsMultiParameter(params.type);
     span.data.elasticsearch.id = params.id;
-    if (action.indexOf('search') === 0) {
+    if (action && action.indexOf('search') === 0) {
       span.data.elasticsearch.query = tracingUtil.shortenDatabaseStatement(JSON.stringify(params));
     }
   }


### PR DESCRIPTION
This fixes `TypeError: Cannot read property 'indexOf' of undefined\n at processParams (/usr/src/app/node_modules/@instana/core/src/tracing/instrumentation/database/elasticsearchModern.js:222:16`.