### PR TITLE
Removed duplicated instrumentation of receiveMessage

### DIFF
--- a/packages/core/src/tracing/instrumentation/cloud/aws/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws/sqs.js
@@ -340,6 +340,7 @@ function instrumentedReceiveMessage(ctx, originalReceiveMessage, originalArgs) {
         );
 
         promise.instanaAsyncContext = cls.getAsyncContext();
+        ctx[originalArgs[0].QueueUrl] = promise.instanaAsyncContext;
 
         // Usually, native promises are handled automatically, that is, their then/catch/finally is executed in the CLS
         // context they have been created in. Apparently, here the promise is created outside the CLS context, thus we
@@ -464,8 +465,9 @@ function shimSQSConsumerExecuteHandler(original) {
 }
 
 function instrumentedSQSConsumerExecuteHandler(ctx, original, originalArgs) {
-  if (ctx.instanaAsyncContext) {
-    return cls.runInAsyncContext(ctx.instanaAsyncContext, () => {
+  const instanaAsyncContext = ctx.sqs[ctx._instanaSqsQueueUrl];
+  if (instanaAsyncContext) {
+    return cls.runInAsyncContext(instanaAsyncContext, () => {
       const span = cls.getCurrentSpan();
       span.disableAutoEnd();
       const res = original.apply(ctx, originalArgs).then(data => {
@@ -495,16 +497,9 @@ function shimSQSConsumerReceiveMessage(original) {
 }
 
 function instrumentedSQSConsumerReceiveMessage(ctx, original, originalArgs) {
-  const originalSQSReceiveMessage = ctx.sqs.receiveMessage;
-
-  ctx.sqs.receiveMessage = function () {
-    const res = originalSQSReceiveMessage.apply(this, arguments);
-    const p = res.promise();
-    if (p.instanaAsyncContext) {
-      ctx.instanaAsyncContext = p.instanaAsyncContext;
-    }
-    return res;
-  };
-
-  return original.apply(ctx, originalArgs);
+  return cls.ns.runAndReturn(() => {
+    // save tge queue url to be used in executeHandler
+    ctx._instanaSqsQueueUrl = originalArgs[0].QueueUrl;
+    return original.apply(ctx, originalArgs);
+  });
 }


### PR DESCRIPTION
The way it was implemented, we were running sqs.receiveMessage twice, causing slowness in the message polling, and also losing some messages that were ending up in the dead letter queue.
Some extra discussion that is relevant: https://github.com/instana/nodejs-sensor/pull/328#discussion_r623862433
Basically, the concern is that a shared object is used in two different queues, so we avoid that by creating an object inside the sqs reference based on  the queue name.