### PR TITLE
chore: update @types/node to latest 14.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6298,9 +6298,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.43.tgz",
-      "integrity": "sha512-3pwDJjp1PWacPTpH0LcfhgjvurQvrZFBrC6xxjaUEZ7ifUtT32jtjPxEMMblpqd2Mvx+k8haqQJLQxolyGN/cQ==",
+      "version": "14.17.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.1.tgz",
+      "integrity": "sha512-/tpUyFD7meeooTRwl3sYlihx2BrJE7q9XF71EguPFIySj9B7qgnRtHsHTho+0AUm4m1SvWGm6uSncrR94q6Vtw==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/bull": "^3.15.1",
     "@types/chai": "^4.2.18",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.43",
+    "@types/node": "^14.17.1",
     "@types/semver": "^7.3.6",
     "@types/shimmer": "^1.0.1",
     "@types/sinon": "^10.0.1",

--- a/packages/core/src/tracing/clsHooked/context-legacy.js
+++ b/packages/core/src/tracing/clsHooked/context-legacy.js
@@ -210,7 +210,7 @@ Namespace.prototype.exit = function exit(context) {
 };
 
 /**
- * @param {import('node:events').EventEmitter} emitter
+ * @param {import('events').EventEmitter} emitter
  */
 Namespace.prototype.bindEmitter = function bindEmitter(emitter) {
   assert.ok(emitter.on && emitter.addListener && emitter.emit, 'can only bind real EEs');

--- a/packages/core/src/tracing/clsHooked/context.js
+++ b/packages/core/src/tracing/clsHooked/context.js
@@ -226,7 +226,7 @@ Namespace.prototype.bind = function bind(fn, context) {
 /**
  * Binds the given emitter to the currently active CLS context. Work triggered by an emit from that emitter will happen
  * in that CLS context.
- * @param {import('node:events').EventEmitter} emitter
+ * @param {import('events').EventEmitter} emitter
  */
 Namespace.prototype.bindEmitter = function bindEmitter(emitter) {
   assert.ok(emitter.on && emitter.addListener && emitter.emit, 'can only bind real EEs');

--- a/packages/core/src/tracing/sdk/sdk.js
+++ b/packages/core/src/tracing/sdk/sdk.js
@@ -326,7 +326,7 @@ module.exports = exports = function (isCallbackApi) {
   }
 
   /**
-   * @param {import('node:events').EventEmitter} emitter
+   * @param {import('events').EventEmitter} emitter
    */
   function bindEmitter(emitter) {
     if (isActive) {

--- a/packages/core/src/tracing/tracingHeaders.js
+++ b/packages/core/src/tracing/tracingHeaders.js
@@ -73,7 +73,7 @@ exports.init = function (config) {
 /**
  * Inspects the headers of an incoming HTTP request for X-INSTANA-T, X-INSTANA-S, X-INSTANA-L, as well as the W3C trace
  * context headers traceparent and tracestate.
- * @param {import('node:http').IncomingMessage} req
+ * @param {import('http').IncomingMessage} req
  */
 exports.fromHttpRequest = function fromHttpRequest(req) {
   if (!req || !req.headers) {
@@ -86,7 +86,7 @@ exports.fromHttpRequest = function fromHttpRequest(req) {
 /**
  * Inspects the given headers for X-INSTANA-T, X-INSTANA-S, X-INSTANA-L, as well as the W3C trace
  * context headers traceparent and tracestate.
- * @param {import('node:http').IncomingHttpHeaders} headers
+ * @param {import('http').IncomingHttpHeaders} headers
  */
 exports.fromHeaders = function fromHeaders(headers) {
   let xInstanaT = readInstanaTraceId(headers);
@@ -231,7 +231,7 @@ exports.fromHeaders = function fromHeaders(headers) {
 };
 
 /**
- * @param {import('node:http').IncomingHttpHeaders} headers
+ * @param {import('http').IncomingHttpHeaders} headers
  * @returns {string | Array.<string>}
  */
 function readInstanaTraceId(headers) {
@@ -243,7 +243,7 @@ function readInstanaTraceId(headers) {
 }
 
 /**
- * @param {import('node:http').IncomingHttpHeaders} headers
+ * @param {import('http').IncomingHttpHeaders} headers
  * @returns {string | Array.<string>}
  */
 function readInstanaParentId(headers) {
@@ -255,7 +255,7 @@ function readInstanaParentId(headers) {
 }
 
 /**
- * @param {import('node:http').IncomingHttpHeaders} headers
+ * @param {import('http').IncomingHttpHeaders} headers
  */
 function readLevelAndCorrelation(headers) {
   const xInstanaL = headers[constants.traceLevelHeaderNameLowerCase];
@@ -310,7 +310,7 @@ function isSuppressed(level) {
 }
 
 /**
- * @param {import('node:http').IncomingHttpHeaders} headers
+ * @param {import('http').IncomingHttpHeaders} headers
  */
 function readSyntheticMarker(headers) {
   return headers[constants.syntheticHeaderNameLowerCase] === '1';
@@ -325,7 +325,7 @@ function traceStateHasInstanaKeyValuePair(w3cTraceContext) {
 }
 
 /**
- * @param {import('node:http').IncomingHttpHeaders} headers
+ * @param {import('http').IncomingHttpHeaders} headers
  */
 function readW3cTraceContext(headers) {
   const traceParent = /** @type {string} */ (headers[constants.w3cTraceParent]);


### PR DESCRIPTION
Apparently the aliases `node:events`, `node:http` etc. have been removed
with
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/ec6522b3d8f1b15251aaed2f3208f7e697a7ee96#diff-50ed3ba474b514ee7443ee72b00abc59b143f94f70bb8a0a83c3293ec21f4540
so the core modules need to be referred to without the prefix now.