### PR TITLE
Applying reusable verification functions and improving execution time

### DIFF
--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -69,24 +69,24 @@ class ProcessControls {
   }
 
   /**
-   * @param opts {{
-   * appPath: string,
-   *   cwd: string,
-   *   port: number,
-   *   dirname: string,
-   *   dontKillInAfterHook: boolean,
-   *   http2: boolean,
-   *   args: [],
-   *   minimalDelay: number,
-   *   usePreInit: boolean,
-   *   useGlobalAgent: boolean,
-   *   tracingEnabled: boolean,
-   *   agentControls: any,
-   *   env: {
-   *     USE_HTTPS: string | boolean,
-   *     [key: string]: any
-   *   },
-   * }} The available options
+   * @typedef {Object} ProcessControlsOptions
+   * @property {string} [appPath]
+   * @property {string} [cwd]
+   * @property {number} [port]
+   * @property {string} [dirname]
+   * @property {boolean} [dontKillInAfterHook]
+   * @property {boolean} [http2]
+   * @property {Array.<*>} [args]
+   * @property {number} [minimalDelay]
+   * @property {boolean} [usePreInit]
+   * @property {boolean} [useGlobalAgent]
+   * @property {boolean} [tracingEnabled]
+   * @property {*} [agentControls]
+   * @property {Object.<string, *} [env]
+   */
+
+  /**
+   * @param {ProcessControlsOptions} opts
    */
   constructor(opts = {}) {
     if (!opts.appPath && !opts.dirname) {

--- a/packages/collector/test/tracing/cloud/aws/promisify_non_sequential.js
+++ b/packages/collector/test/tracing/cloud/aws/promisify_non_sequential.js
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2021
+ */
+
+'use strict';
+
+/**
+ *
+ * @param {(controls: *, response: *, apiPath: *, operation: *, withError: *) => *} verify
+ * @param {Array.<string>} operations
+ * @param {import('../../../test_util/ProcessControls')} appControls
+ * @param {boolean} withError
+ * @param {() => string} getNextCallMethod
+ * @param {import('../../../test_util/ProcessControls').ProcessControlsOptions} [additionalControlOptions]
+ * @returns {Promise.<*>}
+ */
+exports.promisifyNonSequentialCases = function promisifyNonSequentialCases(
+  verify,
+  operations,
+  appControls,
+  withError,
+  getNextCallMethod,
+  additionalControlOptions = {}
+) {
+  return Promise.all(
+    operations.map(operation => {
+      const requestMethod = getNextCallMethod();
+      const withErrorOption = withError ? '?withError=1' : '';
+      const apiPath = `/${operation}/${requestMethod}`;
+      return new Promise((resolve, reject) => {
+        const options = Object.assign(
+          {
+            method: 'GET',
+            path: `${apiPath}${withErrorOption}`,
+            simple: withError === false
+          },
+          additionalControlOptions
+        );
+        appControls
+          .sendRequest(options)
+          .then(response => {
+            resolve(verify(appControls, response, apiPath, operation, withError));
+          })
+          .catch(reject);
+      });
+    })
+  );
+};

--- a/packages/collector/test/tracing/messaging/bull/receiver.js
+++ b/packages/collector/test/tracing/messaging/bull/receiver.js
@@ -20,6 +20,7 @@ const receiver = new Queue(queueName, redisServer);
 const bullJobName = process.env.BULL_JOB_NAME || 'steve';
 const jobNameEnabled = process.env.BULL_JOB_NAME_ENABLED === 'true';
 const concurrencyEnabled = process.env.BULL_CONCURRENCY_ENABLED === 'true';
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
 
 if (!validCallbackTypes.includes(receiveType)) {
   log(`Callback types must be one of these: ${validCallbackTypes.join(', ')} but got ${receiveType}`);
@@ -42,13 +43,5 @@ const app = express();
 app.get('/', (_req, res) => {
   res.send('Ok');
 });
-
-function log() {
-  /* eslint-disable no-console */
-  const args = Array.prototype.slice.call(arguments);
-  args[0] = `${logPrefix}${args[0]}`;
-  console.log.apply(console, args);
-  /* eslint-enable no-console */
-}
 
 app.listen(port, () => log(`Bull receiver app listening on port ${port}`));

--- a/packages/collector/test/tracing/messaging/bull/sender.js
+++ b/packages/collector/test/tracing/messaging/bull/sender.js
@@ -35,13 +35,7 @@ function getJobData(testId, bulkIndex, withError) {
   };
 }
 
-function log() {
-  /* eslint-disable no-console */
-  const args = Array.prototype.slice.call(arguments);
-  args[0] = `${logPrefix}${args[0]}`;
-  console.log.apply(console, args);
-  /* eslint-enable no-console */
-}
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
 
 // curl -X POST "http://127.0.0.1:3215/send?jobName=true&bulk=false&repeat=true"
 app.post('/send', (request, response) => {

--- a/packages/core/test/test_util/circular_list.js
+++ b/packages/core/test/test_util/circular_list.js
@@ -1,0 +1,14 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2021
+ */
+
+'use strict';
+
+exports.getCircularList = function getCircularList(arr) {
+  let currentIndex = 0;
+  return function getNextItemFromList() {
+    const len = arr.length;
+    return arr[currentIndex++ % len];
+  };
+};

--- a/packages/core/test/test_util/common_verifications.js
+++ b/packages/core/test/test_util/common_verifications.js
@@ -1,0 +1,141 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2021
+ */
+
+'use strict';
+
+const expectExactlyOneMatching = require('./expectExactlyOneMatching');
+const constants = require('../../src/index').tracing.constants;
+const { expect } = require('chai');
+
+/**
+ * @typedef {import('../../src/tracing/cls').InstanaBaseSpan} InstanaBaseSpan
+ */
+
+/**
+ * @typedef {Object} HttpRootEntryOptions
+ * @property {Array.<InstanaBaseSpan>} spans
+ * @property {string} apiPath
+ * @property {string} pid
+ * @property {Array.<(span: InstanaBaseSpan) => void>} [extraTests]
+ */
+
+/**
+ * @typedef {Object} ExitSpanOptions
+ * @property {string} spanName
+ * @property {Array.<InstanaBaseSpan>} spans
+ * @property {InstanaBaseSpan} parent
+ * @property {boolean} withError
+ * @property {string} pid
+ * @property {Array.<(span: InstanaBaseSpan) => void>} [extraTests]
+
+ */
+
+/**
+ * @typedef {Object} HttpExitOptions
+ * @property {Array.<InstanaBaseSpan>} spans
+ * @property {InstanaBaseSpan} parent
+ * @property {string} pid
+ * @property {Array.<(span: InstanaBaseSpan) => void>} [extraTests]
+ */
+
+/**
+ * @param {HttpRootEntryOptions} options
+ * @returns {InstanaBaseSpan}
+ */
+// eslint-disable-next-line
+exports.verifyHttpRootEntry = function verifyHttpRootEntry({ spans, apiPath, pid, extraTests }) {
+  /** @type {Array.<(span: InstanaBaseSpan) => void>} */
+  const tests = [
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.p).to.not.exist;
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.k).to.equal(constants.ENTRY);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.f.e).to.equal(pid);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.f.h).to.equal('agent-stub-uuid');
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.n).to.equal('node.http.server');
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.data.http.url).to.equal(apiPath);
+    }
+  ].concat(extraTests || []);
+
+  return expectExactlyOneMatching(spans, tests);
+};
+
+/**
+ * @param {ExitSpanOptions} options
+ * @returns {InstanaBaseSpan}
+ */
+// eslint-disable-next-line
+exports.verifyExitSpan = function verifyExitSpan({ spanName, spans, parent, withError, pid, extraTests }) {
+  const tests = [
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.k).to.equal(constants.EXIT);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.n).to.equal(spanName);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.t).to.equal(parent.t);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.p).to.equal(parent.s);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.f.e).to.equal(pid);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.f.h).to.equal('agent-stub-uuid');
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.ec).to.equal(withError ? 1 : 0);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.data).to.exist;
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.data[spanName]).to.be.an('object');
+    }
+  ].concat(extraTests || []);
+
+  return expectExactlyOneMatching(spans, tests);
+};
+
+/**
+ * @param {HttpExitOptions} options
+ * @returns {InstanaBaseSpan}
+ */
+// eslint-disable-next-line
+exports.verifyHttpExit = function verifyHttpExit({ spans, parent, pid, extraTests }) {
+  const tests = [
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.t).to.equal(parent.t);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.p).to.equal(parent.s);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.k).to.equal(constants.EXIT);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.f.e).to.equal(pid);
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.f.h).to.equal('agent-stub-uuid');
+    },
+    (/** @type {InstanaBaseSpan} */ span) => {
+      expect(span.n).to.equal('node.http.client');
+    }
+  ].concat(extraTests || []);
+
+  return expectExactlyOneMatching(spans, tests);
+};

--- a/packages/core/test/test_util/expectExactlyOneMatching.js
+++ b/packages/core/test/test_util/expectExactlyOneMatching.js
@@ -8,6 +8,16 @@
 const { findAllMatchingItems, reportFailure } = require('./matchingItems');
 const stringifyItems = require('./stringifyItems');
 
+/**
+ * @typedef {import('../../src/tracing/cls').InstanaBaseSpan} InstanaBaseSpan
+ */
+
+/**
+ * @type {Function}
+ * @param {Array.<InstanaBaseSpan>} items
+ * @param {(span: InstanaBaseSpan) => void} expectations
+ * @returns {InstanaBaseSpan}
+ */
 module.exports = exports = function expectExactlyOneMatching(items, expectations) {
   const matchResult = findAllMatchingItems(items, expectations);
   const matches = matchResult.getMatches();

--- a/packages/core/test/test_util/matchingItems.js
+++ b/packages/core/test/test_util/matchingItems.js
@@ -9,7 +9,15 @@ const fail = require('chai').assert.fail;
 
 const stringifyItems = require('./stringifyItems');
 
+/**
+ * @typedef {import('../../src/tracing/cls').InstanaBaseSpan} InstanaBaseSpan
+ */
+
 class MatchResult {
+  /**
+   * @param {Array.<InstanaBaseSpan>} items
+   * @param {Array.<(span: InstanaBaseSpan) => void> | ((span: InstanaBaseSpan) => void)} expectations
+   */
   constructor(items, expectations) {
     if (!Array.isArray(items)) {
       throw new Error(`items needs to be an array: ${items}`);
@@ -19,6 +27,7 @@ class MatchResult {
     }
     this.items = items;
     this.expectations = expectations;
+    /** @type {Array.<InstanaBaseSpan>} */
     this.matches = [];
     this.saveBestMatch = Array.isArray(expectations);
     this.bestMatchPassed = 0;
@@ -36,6 +45,9 @@ class MatchResult {
     return this.matches;
   }
 
+  /**
+   * @param {InstanaBaseSpan} item
+   */
   addMatch(item) {
     this.matches.push(item);
   }
@@ -44,6 +56,9 @@ class MatchResult {
     return this.error;
   }
 
+  /**
+   * @param {*} error
+   */
   setError(error) {
     this.error = error;
   }
@@ -56,6 +71,9 @@ class MatchResult {
     return this.bestMatch;
   }
 
+  /**
+   * @param {InstanaBaseSpan} bestMatch
+   */
   setBestMatch(bestMatch) {
     this.bestMatch = bestMatch;
   }
@@ -64,6 +82,9 @@ class MatchResult {
     return this.bestMatchPassed;
   }
 
+  /**
+   * @param {number} bestMatchPassed
+   */
   setBestMatchPassed(bestMatchPassed) {
     this.bestMatchPassed = bestMatchPassed;
   }
@@ -72,6 +93,9 @@ class MatchResult {
     return this.failedExpectation;
   }
 
+  /**
+   * @param {(span: InstanaBaseSpan) => void} failedExpectation
+   */
   setFailedExpectation(failedExpectation) {
     this.failedExpectation = failedExpectation;
   }
@@ -79,6 +103,12 @@ class MatchResult {
 
 exports.MatchResult = MatchResult;
 
+/**
+ *
+ * @param {Array.<import('../../src/tracing/cls').InstanaBaseSpan>} items
+ * @param {Array.<(span: InstanaBaseSpan) => void> | ((span: InstanaBaseSpan) => void)} expectations
+ * @returns {MatchResult}
+ */
 exports.findAllMatchingItems = function findAllMatchingItems(items, expectations) {
   if (!items || items.length === 0) {
     fail('Could not find any matching items which match all the criteria. In fact, there were zero items.');
@@ -121,6 +151,10 @@ exports.findAllMatchingItems = function findAllMatchingItems(items, expectations
   return result;
 };
 
+/**
+ * @param {MatchResult} result
+ * @param {*} lookingFor
+ */
 exports.reportFailure = function reportFailure(result, lookingFor) {
   // Clone the stack before creating a new error object, otherwise the stack of the new error object (including the
   // stringified spans) will be added again, basically duplicating the list of spans we add to the error message.

--- a/packages/core/test/test_util/stringifyItems.js
+++ b/packages/core/test/test_util/stringifyItems.js
@@ -7,6 +7,12 @@
 
 const MAX_SPANS_IN_ERROR = 30;
 
+/** @typedef {import('../../src/tracing/cls').InstanaBaseSpan} InstanaBaseSpan */
+
+/**
+ * @type {Function}
+ * @param {null | undefined | Array.<InstanaBaseSpan>} items
+ */
 module.exports = exports = function stringifyItems(items) {
   if (items === null) {
     return 'null';
@@ -29,6 +35,10 @@ module.exports = exports = function stringifyItems(items) {
   }
 };
 
+/**
+ * @param {InstanaBaseSpan} item
+ * @returns {InstanaBaseSpan}
+ */
 function shortenStackTrace(item) {
   if (!item.stack) {
     return item;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
   "include": [
     "packages/core/src/util",
     "packages/core/src/tracing/*.js",
+    "packages/core/test/test_util/common_verifications.js"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Essentially, this change does the following:

 * Refactor AWS tests
 * Makes `verify*` functions reusable, where most common cases are covered
 * Reduces the number of creation/deletion of AWS entities (streams, tables, buckets) to one time
 * Runs AWS tests in parallel with Promise.all, when these tests don't depend on a sequence of operations to run